### PR TITLE
Refactor Telegram attestation verification to support 'validate' mode…

### DIFF
--- a/src/libs/abstraction/index.ts
+++ b/src/libs/abstraction/index.ts
@@ -5,6 +5,7 @@ import { type Web2ProofParser } from "./web2/parsers"
 import { Web2CoreTargetIdentityPayload } from "@kynesyslabs/demosdk/abstraction"
 import { hexToUint8Array, ucrypto } from "@kynesyslabs/demosdk/encryption"
 import { Twitter } from "../identity/tools/twitter"
+import { Transaction } from "@kynesyslabs/demosdk/types"
 
 /**
  * Fetches the proof data using the appropriate parser and verifies the signature
@@ -27,6 +28,7 @@ import { Twitter } from "../identity/tools/twitter"
 export async function verifyWeb2Proof(
     payload: Web2CoreTargetIdentityPayload,
     sender: string,
+    transaction?: Transaction,
 ) {
     let parser: typeof TwitterProofParser | typeof GithubProofParser | typeof TelegramProofParser
 
@@ -75,6 +77,7 @@ export async function verifyWeb2Proof(
     try {
         const { message, type, signature } = await instance.readData(
             payload.proof,
+            payload.context === "telegram" ? transaction : undefined,
         )
         try {
             const verified = await ucrypto.verify({

--- a/src/libs/abstraction/web2/telegram.ts
+++ b/src/libs/abstraction/web2/telegram.ts
@@ -1,6 +1,6 @@
 import { Web2ProofParser } from "./parsers"
 import Telegram from "@/libs/identity/tools/telegram"
-import { SigningAlgorithm } from "@kynesyslabs/demosdk/types"
+import { SigningAlgorithm, Transaction } from "@kynesyslabs/demosdk/types"
 
 /**
  * TelegramProofParser - Parses and validates Telegram identity proofs
@@ -34,9 +34,10 @@ export class TelegramProofParser extends Web2ProofParser {
      * - Bot's signature of the attestation
      * 
      * @param proofData - JSON string containing bot attestation data
+     * @param transaction - The transaction containing this proof (for challenge hash extraction)
      * @returns Parsed signature data for verification
      */
-    async readData(proofData: string): Promise<{
+    async readData(proofData: string, transaction?: Transaction): Promise<{
         message: string
         signature: string
         type: SigningAlgorithm
@@ -54,10 +55,19 @@ export class TelegramProofParser extends Web2ProofParser {
                 }
             }
 
+            // Extract challenge hash from transaction for replay protection validation
+            const transactionChallengeHash = transaction 
+                ? Telegram.extractChallengeHashFromTransaction(transaction)
+                : null
+
             // Verify the bot attestation first (this validates both signatures)
-            // IMPORTANT: use mode 'validate' here because interactive phase already marked challenge as used.
-            // We only need cryptographic verification now; reused/missing challenge should not fail.
-            const verificationResult = await this.telegram.verifyAttestation(attestationData, 'validate')
+            // IMPORTANT: Use 'validate' mode for on-chain validation
+            // This mode performs cryptographic verification and replay protection when transaction hash is available
+            const verificationResult = await this.telegram.verifyAttestation(
+                attestationData, 
+                'validate',
+                transactionChallengeHash
+            )
             
             if (!verificationResult.success) {
                 throw new Error(`Telegram verification failed: ${verificationResult.message}`)

--- a/src/libs/identity/tools/telegram.ts
+++ b/src/libs/identity/tools/telegram.ts
@@ -14,6 +14,7 @@ interface TelegramWeb2Payload {
     proof: string // bot attestation JSON string
     username: string
     userId: string
+    attestation_id?: string // Challenge hash for replay attack prevention
 }
 
 import { ucrypto, hexToUint8Array } from "@kynesyslabs/demosdk/encryption"
@@ -174,12 +175,13 @@ export default class Telegram {
     /**
      * Verify a Telegram attestation.
      * mode = 'attest'  : interactive phase (bot hits /api/tg-verify). Challenge must exist & be unused; we then mark it used.
-     * mode = 'validate': on-chain validation phase (parser replays verification). We ALLOW reused / missing (expired GC) challenge
-     *                   while still verifying both signatures cryptographically. This prevents false negatives when broadcasting.
+     * mode = 'validate': on-chain validation phase (parser replays verification). We verify challenge reuse protection
+     *                   by checking the challenge hash embedded in the transaction payload.
      */
     async verifyAttestation(
         request: TelegramVerificationRequest,
         mode: 'attest' | 'validate' = 'attest',
+        transactionChallengeHash?: string, // For validate mode: hash from transaction payload
     ): Promise<TelegramVerificationResponse> {
         try {
             // 1. Check if bot address is authorized (from genesis)
@@ -192,7 +194,9 @@ export default class Telegram {
             }
 
             // 2. Parse the challenge from user's signed message
-            const challengeData = this.parseChallenge(request.signed_challenge.split(":")[0] || request.signed_challenge)
+            const challengeInput = request.signed_challenge.split(":")[0] || request.signed_challenge
+
+            const challengeData = this.parseChallenge(challengeInput)
             if (!challengeData) {
                 return { 
                     success: false, 
@@ -200,24 +204,46 @@ export default class Telegram {
                 }
             }
 
-            // 3. Fetch stored challenge (in-memory). For 'validate' we tolerate absence or reuse.
-            const storedChallenge = this.challenges.get(
-                `DEMOS_TG_BIND_${challengeData.demosAddress}_${challengeData.timestamp}_${challengeData.nonce}`,
-            )
-            if (!storedChallenge && mode === 'attest') {
-                return {
-                    success: false,
-                    message: 'Challenge not found or expired',
+            // 3. Calculate challenge hash for replay protection
+            const originalChallenge = `DEMOS_TG_BIND_${challengeData.demosAddress}_${challengeData.timestamp}_${challengeData.nonce}`
+            const challengeHash = crypto.createHash('sha256').update(originalChallenge).digest('hex')
+
+            // 4. Validate challenge reuse protection based on mode
+            const storedChallenge = this.challenges.get(originalChallenge)
+            
+            if (mode === 'attest') {
+                // Interactive mode: strict challenge validation
+                if (!storedChallenge) {
+                    return {
+                        success: false,
+                        message: 'Challenge not found or expired',
+                    }
                 }
-            }
-            if (storedChallenge?.used && mode === 'attest') {
-                return {
-                    success: false,
-                    message: 'Challenge already used',
+                if (storedChallenge.used) {
+                    return {
+                        success: false,
+                        message: 'Challenge already used',
+                    }
+                }
+            } else if (mode === 'validate') {        
+                // If no transaction challenge hash is provided, reject the validation (no legacy txs expected)
+                if (!transactionChallengeHash) {
+                    return {
+                        success: false,
+                        message: 'Transaction challenge hash missing - replay protection failed',
+                    }
+                } else {
+                    // Perform full replay protection validation
+                    if (challengeHash !== transactionChallengeHash) {
+                        return {
+                            success: false,
+                            message: 'Challenge hash mismatch - potential replay attack detected',
+                        }
+                    }
                 }
             }
 
-            // 4. Verify bot signature
+            // 5. Verify bot signature
             const attestationData = {
                 telegram_id: request.telegram_id,
                 username: request.username,
@@ -242,8 +268,7 @@ export default class Telegram {
                 }
             }
 
-            // 5. Verify user signature against the original challenge
-            const originalChallenge = `DEMOS_TG_BIND_${challengeData.demosAddress}_${challengeData.timestamp}_${challengeData.nonce}`
+            // 6. Verify user signature against the original challenge
             const challengeMessage = new TextEncoder().encode(originalChallenge)
             
             // Extract signature from signed challenge (assuming format: "challenge:signature" or just signature)
@@ -266,12 +291,12 @@ export default class Telegram {
                 }
             }
 
-            // 6. Mark challenge as used only during interactive attestation
+            // 7. Mark challenge as used only during interactive attestation
             if (storedChallenge && mode === 'attest') {
                 storedChallenge.used = true
             }
 
-            // 7. Create unsigned identity transaction following Twitter pattern
+            // 8. Create unsigned identity transaction with challenge hash for replay protection
             const unsignedTransaction = this.createIdentityTransaction(
                 challengeData.demosAddress,
                 request.telegram_id,
@@ -284,6 +309,7 @@ export default class Telegram {
                     bot_address: request.bot_address,
                     bot_signature: request.bot_signature,
                 }),
+                challengeHash, // Add challenge hash to prevent replay attacks
             )
 
             // 8. Return success with unsigned transaction for user to sign
@@ -318,11 +344,13 @@ export default class Telegram {
      * - Context: "web2" 
      * - Method: "web2_identity_assign"
      * - Payload contains Telegram identity data and bot attestation proof
+     * - Challenge hash embedded for replay attack prevention
      * 
      * @param demosAddress - User's Demos address
      * @param telegramId - Telegram user ID
      * @param username - Telegram username  
      * @param proofData - JSON string containing bot attestation
+     * @param challengeHash - SHA256 hash of the original challenge for replay protection
      * @returns Unsigned transaction ready for user signature
      */
     private createIdentityTransaction(
@@ -330,15 +358,14 @@ export default class Telegram {
         telegramId: string,
         username: string,
         proofData: string,
+        challengeHash: string,
     ): Transaction {
-        // REVIEW: Create transaction following the exact Twitter pattern
-        // See DemosTransactions.empty() and Identities.inferWeb2Identity()
-        
         const telegramPayload: TelegramWeb2Payload = {
             context: "telegram",
             proof: proofData,  // Bot attestation containing all verification data
             username: username,
             userId: telegramId,
+            attestation_id: challengeHash, // Challenge hash for replay attack prevention
         }
 
         // Create transaction skeleton (same structure as Twitter identity transactions)
@@ -371,6 +398,27 @@ export default class Telegram {
 
         log.info(`Created unsigned Telegram identity transaction for ${demosAddress} ↔ ${telegramId}`)
         return transaction
+    }
+
+    /**
+     * Extract challenge hash from a transaction payload
+     * Used during validation mode to verify replay protection
+     */
+    static extractChallengeHashFromTransaction(transaction: Transaction): string | null {
+        try {
+            if (
+                transaction &&
+                transaction.content &&
+                Array.isArray(transaction.content.data) &&
+                transaction.content.data[0] === "identity" &&
+                (transaction.content.data[1] as { payload?: TelegramWeb2Payload })?.payload?.attestation_id
+            ) {
+                return (transaction.content.data[1] as { payload: TelegramWeb2Payload }).payload.attestation_id || null;
+            }
+            return null;
+        } catch {
+            return null;
+        }
     }
 
     /**

--- a/src/libs/network/routines/transactions/handleIdentityRequest.ts
+++ b/src/libs/network/routines/transactions/handleIdentityRequest.ts
@@ -81,6 +81,7 @@ export default async function handleIdentityRequest(
             return await verifyWeb2Proof(
                 payload.payload as Web2CoreTargetIdentityPayload,
                 sender,
+                tx, // Pass the transaction for Telegram challenge hash validation
             )
         case "xm_identity_remove":
         case "pqc_identity_remove":


### PR DESCRIPTION
### **User description**
Description:
- Added handling for logic to fetch genesis blocks
- Added modes  'attest' | 'validate' for verifyAttestation avoid of errors when after validation we mark Challenge as used and get error during broadcast validation.


___

### **PR Type**
Enhancement


___

### **Description**
- Added 'validate' mode to Telegram attestation verification

- Fixed genesis block parsing for bot authorization

- Improved challenge format parsing and error handling

- Enhanced transaction structure with required fields


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["TelegramProofParser"] -- "calls with 'validate' mode" --> B["verifyAttestation"]
  B -- "parses genesis block" --> C["Bot Authorization"]
  B -- "validates challenge format" --> D["Challenge Verification"]
  D -- "allows reused challenges in validate mode" --> E["Signature Verification"]
  E -- "creates identity transaction" --> F["Transaction Output"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>telegram.ts</strong><dd><code>Switch to validate mode for attestation verification</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/libs/abstraction/web2/telegram.ts

<ul><li>Modified <code>verifyAttestation</code> call to use 'validate' mode<br> <li> Added comment explaining why validate mode is needed</ul>


</details>


  </td>
  <td><a href="https://github.com/kynesyslabs/node/pull/432/files#diff-0910392ed45639d10e7e68dca18d16e470b5f4db3a4dd27dbec3dd9f8115d559">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>telegram.ts</strong><dd><code>Major refactor of Telegram verification logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/libs/identity/tools/telegram.ts

<ul><li>Added 'validate' mode parameter to <code>verifyAttestation</code> method<br> <li> Fixed genesis block content parsing with proper JSON handling<br> <li> Corrected challenge parsing format (6 parts instead of 5)<br> <li> Enhanced transaction structure with required fields<br> <li> Replaced SDK import with local interface definition</ul>


</details>


  </td>
  <td><a href="https://github.com/kynesyslabs/node/pull/432/files#diff-2b4faef33bb1f4565494d28e39d20148d90cfbc73e578b8a8d2482bd6dc787d6">+68/-22</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Identity transactions now include sender info, transaction fees and pending/broadcast metadata.
  * Telegram proofs can optionally use transaction context for on‑chain validation and replay protection.

* **Bug Fixes**
  * More robust handling of varying genesis data formats to preserve balances.
  * Fixed Telegram challenge parsing to prevent mismatches.

* **Improvements**
  * Verification flow refined so challenges are only marked used during interactive attestations; non‑interactive validation proceeds without consuming challenges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->