### PR TITLE
fix(gcr): fix syntax error in isFirstConnection function

### DIFF
--- a/src/libs/blockchain/gcr/gcr_routines/GCRIdentityRoutines.ts
+++ b/src/libs/blockchain/gcr/gcr_routines/GCRIdentityRoutines.ts
@@ -890,7 +890,8 @@ export default class GCRIdentityRoutines {
         gcrMainRepository: Repository<GCRMain>,
         currentAccount?: string,
     ): Promise<boolean> {
-        if (type !== "web3") {
+        if (type !== "web3" && type !== "ud") {
+            // Handle web2 identity types: twitter, github, telegram, discord
             const queryTemplate = `
             EXISTS (SELECT 1 FROM jsonb_array_elements(COALESCE(gcr.identities->'web2'->'${type}', '[]'::jsonb)) as ${type}_id WHERE ${type}_id->>'userId' = :userId)
         `
@@ -900,9 +901,6 @@ export default class GCRIdentityRoutines {
                 .where(queryTemplate, { userId: data.userId })
                 .andWhere("gcr.pubkey != :currentAccount", { currentAccount })
                 .getOne()
-
-            return !result
-        }
 
             /**
              * Return true if no account has this userId
@@ -932,23 +930,23 @@ export default class GCRIdentityRoutines {
             const addressToCheck =
                 data.chain === "evm" ? data.address.toLowerCase() : data.address
 
-        const result = await gcrMainRepository
-            .createQueryBuilder("gcr")
-            .where(
-                "EXISTS (SELECT 1 FROM jsonb_array_elements(gcr.identities->'xm'->:chain->:subchain) as xm_id WHERE xm_id->>'address' = :address)",
-                {
-                    chain: data.chain,
-                    subchain: data.subchain,
-                    address: addressToCheck,
-                },
-            )
-            .andWhere("gcr.pubkey != :currentAccount", { currentAccount })
-            .getOne()
+            const result = await gcrMainRepository
+                .createQueryBuilder("gcr")
+                .where(
+                    "EXISTS (SELECT 1 FROM jsonb_array_elements(gcr.identities->'xm'->:chain->:subchain) as xm_id WHERE xm_id->>'address' = :address)",
+                    {
+                        chain: data.chain,
+                        subchain: data.subchain,
+                        address: addressToCheck,
+                    },
+                )
+                .andWhere("gcr.pubkey != :currentAccount", { currentAccount })
+                .getOne()
 
-        /**
-         * Return true if this is the first connection
-         */
-        return !result
-        // }
+            /**
+             * Return true if this is the first connection
+             */
+            return !result
+        }
     }
 }


### PR DESCRIPTION
Fixed critical syntax error in the isFirstConnection method that was preventing TypeScript compilation. The if-else chain was malformed with orphaned braces and unreachable code.

Changes:
- Restructured the if-else chain to properly handle web2, ud, and web3 types
- Changed condition from `if (type !== "web3")` to `if (type !== "web3" && type !== "ud")`
- Removed orphaned closing braces and unreachable return statement
- Fixed indentation for the web3 (else) block

This resolves the following TypeScript errors:
- TS1068: Unexpected token
- TS1005: ',' expected
- TS1128: Declaration or statement expected

The UD identity integration will now function correctly with proper first-time connection detection for incentive points.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Unstoppable Domain identity handling by routing these identities through a dedicated processing path, separate from web2 and web3 identity flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->