### PR TITLE
node: storage program read RPCs, /health, rate-limit headers, ACL hardening

### DIFF
--- a/history/planning/sdk-capability-detection.md
+++ b/history/planning/sdk-capability-detection.md
@@ -1,0 +1,598 @@
+# SDK Capability Detection — Implementation Plan
+
+> ## ⚠️ Repo scope
+>
+> **This document plans work in `kynesyslabs/sdks`.** It lives in `kynesyslabs/node` only as a planning artifact (we use `node/docs/planning/` as the durable home for cross-cutting plans).
+>
+> - **Implementation target:** `kynesyslabs/sdks` — branch `claude/checkout-branches-WQCIg`.
+> - **Node-side prerequisites:** already shipped on `kynesyslabs/node` `claude/checkout-branches-WQCIg`. **Do NOT modify `kynesyslabs/node` while implementing item 9.**
+> - **Throughout this doc, every code path is prefixed `sdks/...` or `node/...`** so there is zero ambiguity about which repo to open.
+
+---
+
+## 1. Goal
+
+When a Demos SDK method calls a node RPC that the connected node doesn't support, the SDK currently returns `null` or garbage. The caller cannot distinguish "method not supported" from "called and got empty result". This work surfaces the distinction with a typed error, gated behind an opt-in flag with a deprecation path for the legacy `null` behavior.
+
+## 2. Context — what's already shipped (do NOT redo)
+
+### 2.1 Already on `kynesyslabs/node` (do NOT modify these — read-only context)
+
+| Phase / Item | Commit (relative to base) | What it gives us |
+|---|---|---|
+| Phase 1, item 1 | `node:e57be21` | Unknown RPC messages → `result: 404` + JSON `{error: "Unknown message", message: "<wireName>"}`. **This is what the SDK reactively detects.** |
+| Phase 1, item 5 | `node:564f0af` | `GET /health` → `{version, version_name, accepting, mempool_size, uptime_s}`. **Used for proactive version gating.** |
+| Phase 2, item 7 | `node:2b97270` | 9 storage-program read RPCs implemented. These are the methods that need a min-version on the SDK side. |
+
+### 2.2 Already on `kynesyslabs/sdks` (read-only context — you'll *extend* these, not replace them)
+
+| Phase / Item | What it gives us |
+|---|---|
+| Phase 1, item 6 | Unified `_doPost(url, body, headers, opts)` private method on `Demos` (`sdks/src/websdk/demosclass.ts:676`) with retry-on-5xx and `Retry-After` support. `TransportError` exported. **This is the choke point where reactive 404 detection plugs in.** |
+| Phase 1, item 8 | `DemosTransactions.broadcastAndWait` + `BroadcastTimeoutError`. |
+
+You should **not** re-investigate these. Read them if useful, but they're done.
+
+## 3. Architectural decisions (already made — do not relitigate)
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Detection style | **Both reactive (transport-level) AND proactive (per-method)** | Reactive catches everything via `Demos.call`; proactive (decorator) gives early failure without a roundtrip. |
+| Local gating mechanism | **TS legacy decorators** (`experimentalDecorators: true`) | Mature, well-supported on TS 5.9. Stage-3 is settling but ecosystem still patchy. Static methods need decorator support which legacy has. |
+| Non-class-method gating | **Manual `assertNodeVersion(demos, "X.Y.Z", "wireName")` helper** | `DemosTransactions` is an object literal — decorators don't apply. Same for arrow-fn class fields. |
+| Default behavior | **Opt-in `strictCapabilities` flag** (default `false`) | Preserves back-compat. |
+| Legacy path behavior | **`console.warn` deprecation notice + return null** (current behavior) | Tells users the migration is coming; doesn't break them today. |
+| Strict path behavior | **Throw `MethodNotSupportedError`** | Typed, explicit. |
+| Error class hierarchy | **No hierarchy** — `MethodNotSupportedError` is standalone, sibling to `TransportError` and `BroadcastTimeoutError` | Consistent with prior phases. |
+| Deprecation warning dedup | **One warn per `(rpcUrl, wireName)` tuple** | Avoid spamming in polling loops. |
+| Decorator metadata | **`emitDecoratorMetadata: false`** initially (try without first) | Only enable if a decorator actually needs it. We probably won't. |
+
+## 4. SDK audit (verbatim findings — `sdks/...` paths authoritative)
+
+The audit ran `grep`/Explore over `sdks/src/`. ~30 public methods hit the node across 7 files. **Source of truth for wire names is the SDK itself** (not the node, not docs).
+
+### 4.1 Decoratable methods (class methods, native `this.rpc_url` or constructor-injected)
+
+#### `sdks/src/websdk/demosclass.ts` — `Demos` class
+
+| Method | Line | Wire | Returns |
+|---|---|---|---|
+| `getLastBlockNumber()` | 931 | `getLastBlockNumber` | `Promise<number>` |
+| `getLastBlockHash()` | 938 | `getLastBlockHash` | `Promise<string \| null>` |
+| `getBlocks(start, limit)` | 946 | `getBlocks` | `Promise<Block[]>` |
+| `getBlockByNumber(n)` | 958 | `getBlockByNumber` | `Promise<Block>` |
+| `getBlockByHash(h)` | 969 | `getBlockByHash` | `Promise<Block>` |
+| `getTxByHash(h)` | 980 | `getTxByHash` | `Promise<Transaction>` |
+| `getAllTxs()` | 995 | (delegates to `getTransactions`) | — |
+| `getTransactionHistory(addr, type, opts)` | 1009 | `getTransactionHistory` | `Promise<Transaction[]>` |
+| `getTransactions(start, limit)` | 1024 | `getTransactions` | `Promise<RawTransaction[]>` |
+| `getPeerlist()` | 1034 | `getPeerlist` | `Promise<IPeer[]>` |
+| `getMempool()` | 1042 | `getMempool` | `Promise<Transaction[]>` |
+| `getPeerIdentity()` | 1049 | `getPeerIdentity` | `Promise<string>` |
+| `getAddressInfo(addr)` | 1058 | `getAddressInfo` | `Promise<AddressInfo \| null>` |
+| `getAddressNonce(addr)` | 1082 | `getAddressNonce` | `Promise<number>` |
+
+#### `sdks/src/storage/StorageProgram.ts` — `StorageProgram` static methods
+
+| Method | Line | Wire | Returns |
+|---|---|---|---|
+| `getByAddress(rpc, addr, identity?)` | 809 | `getStorageProgram` | `StorageProgramData \| null` |
+| `getByOwner(rpc, owner, identity?)` | 851 | `getStorageProgramsByOwner` | `StorageProgramListItem[]` |
+| `searchByName(rpc, q, opts?)` | 904 | `searchStoragePrograms` | `StorageProgramListItem[]` |
+| `getFields(rpc, addr, identity?)` | 961 | `getStorageProgramFields` | `… \| null` |
+| `getValue(rpc, addr, field, identity?)` | 1004 | `getStorageProgramValue` | `… \| null` |
+| `getItem(rpc, addr, field, idx, identity?)` | 1056 | `getStorageProgramItem` | `… \| null` |
+| `hasField(rpc, addr, field, identity?)` | 1101 | `hasStorageProgramField` | `… \| null` |
+| `getFieldType(rpc, addr, field, identity?)` | 1145 | `getStorageProgramFieldType` | `… \| null` |
+| `getAll(rpc, addr, identity?)` | 1187 | `getStorageProgram` (alias) | `StorageProgramData \| null` |
+
+> **Caveat:** `StorageProgram` methods are **static** and take `rpcUrl` as first arg. Each call may target a different node. The version cache must be a static `Map<rpcUrl, {version, fetchedAt}>`, not per-instance.
+
+#### `sdks/src/contracts/ContractInteractor.ts`
+
+| Method | Line | Wire | Returns |
+|---|---|---|---|
+| `viewCall<T>()` | 78 | `contractCall` | `ContractCallResult<T>` |
+| `transactionCall<T>()` | 110 | `sendTransaction` | `ContractCallResult<T>` |
+| `waitForTransaction()` | 232 | `getTransactionReceipt` | (polled) |
+
+#### `sdks/src/websdk/Web2Calls.ts`
+
+| Method | Line | Wire | Returns |
+|---|---|---|---|
+| `Web2Proxy.send(opts)` | 155 | `web2ProxyRequest` | `IWeb2Result` |
+
+#### `sdks/src/abstraction/Identities.ts`
+
+| Method | Line | Wire | Returns |
+|---|---|---|---|
+| `Identities.resolveUdDomain(demos, domain)` | 1070 | `resolveUdDomain` | (resolved domain info) |
+
+### 4.2 NOT decoratable — needs `assertNodeVersion(...)` inline
+
+| File | Symbol | Why |
+|---|---|---|
+| `sdks/src/websdk/DemosTransactions.ts` | `confirm` :186, `broadcast` :207, `broadcastAndWait` :264, plus `pay`, `transfer` | Whole module is an object literal, not a class |
+| `sdks/src/websdk/demosclass.ts` `Demos.web2.getTweet` :1210 | arrow fn on object-literal property | Decorator targets methods, not arrow-fn properties |
+| `sdks/src/websdk/demosclass.ts` `Demos.web2.getDiscordMessage` :1221 | same | same |
+| `sdks/src/websdk/demosclass.ts` `Demos.ipfs.quote` :1261 | same | same |
+| `sdks/src/websdk/Web2Calls.ts` `web2Calls.createDahr(demos)` :216 | exported arrow fn | free function, not a method |
+
+### 4.3 TSConfig & build state (`kynesyslabs/sdks` only)
+
+- `sdks/tsconfig.json`: `experimentalDecorators` **NOT set** (defaults `false`). Must flip to `true`.
+- `emitDecoratorMetadata`: **NOT set**. Leave off unless needed. Verify after.
+- `target`: `"es2020"` — fine.
+- TypeScript: `5.9.2` — supports both legacy and stage-3.
+- Build: `tsc --skipLibCheck && resolve-tspaths && mv build/src/* build/`. `resolve-tspaths` doesn't interact with decorators; should be fine.
+
+## 5. Components to build (all in `kynesyslabs/sdks`)
+
+### 5.1 `MethodNotSupportedError` — new file
+
+**Path:** `sdks/src/websdk/MethodNotSupportedError.ts`
+
+Match the style of `sdks/src/websdk/TransportError.ts` and `sdks/src/websdk/BroadcastTimeoutError.ts` (already in repo — read them first). No hierarchy, no `cause` chaining gymnastics.
+
+```ts
+export class MethodNotSupportedError extends Error {
+    public readonly wireName: string
+    public readonly requiredVersion: string
+    public readonly actualVersion?: string
+    public readonly rpcUrl?: string
+
+    constructor(opts: {
+        wireName: string
+        requiredVersion: string
+        actualVersion?: string
+        rpcUrl?: string
+    }) {
+        const v = opts.actualVersion
+            ? `node version ${opts.actualVersion}`
+            : "the connected node"
+        super(
+            `Method "${opts.wireName}" is not supported by ${v} ` +
+            `(requires >= ${opts.requiredVersion})`
+        )
+        this.name = "MethodNotSupportedError"
+        this.wireName = opts.wireName
+        this.requiredVersion = opts.requiredVersion
+        this.actualVersion = opts.actualVersion
+        this.rpcUrl = opts.rpcUrl
+    }
+}
+```
+
+Export from `sdks/src/websdk/index.ts`.
+
+### 5.2 `capabilities.ts` — new file
+
+**Path:** `sdks/src/websdk/capabilities.ts`
+
+Holds: the decorator, the helper, the version cache, the deprecation warn dedup.
+
+```ts
+import { MethodNotSupportedError } from "./MethodNotSupportedError"
+
+interface CachedHealth {
+    version: string
+    fetchedAt: number
+}
+
+const CACHE_TTL_MS = 5 * 60_000        // 5 min
+const HEALTH_FETCH_TIMEOUT_MS = 5_000
+
+// Per-rpc-url version cache (used by static methods like StorageProgram).
+const urlCache = new Map<string, CachedHealth>()
+// Singleflight in-flight fetch per rpc url.
+const inflight = new Map<string, Promise<string | null>>()
+// Deprecation warn dedup: Set<`${rpcUrl}::${wireName}`>.
+const warnedKeys = new Set<string>()
+
+/**
+ * Fetch /health and return the node version, or null if the node doesn't
+ * support /health (pre-Phase-1) or fails. Cached per rpcUrl with TTL.
+ */
+export async function getNodeVersion(rpcUrl: string): Promise<string | null> {
+    const cached = urlCache.get(rpcUrl)
+    if (cached && Date.now() - cached.fetchedAt < CACHE_TTL_MS) {
+        return cached.version
+    }
+    if (inflight.has(rpcUrl)) return inflight.get(rpcUrl)!
+
+    const p = (async () => {
+        try {
+            const axios = (await import("axios")).default
+            const res = await axios.get(`${rpcUrl.replace(/\/$/, "")}/health`, {
+                timeout: HEALTH_FETCH_TIMEOUT_MS,
+            })
+            const version: string | undefined = res.data?.version
+            if (typeof version === "string") {
+                urlCache.set(rpcUrl, { version, fetchedAt: Date.now() })
+                return version
+            }
+            return null
+        } catch {
+            return null
+        } finally {
+            inflight.delete(rpcUrl)
+        }
+    })()
+
+    inflight.set(rpcUrl, p)
+    return p
+}
+
+/** Compare semver strings (very small parser; "0.9.8" vs "0.9.9" etc.). */
+export function semverGte(actual: string, required: string): boolean {
+    const a = actual.split(/[.\-+]/).map(s => Number(s) || 0).slice(0, 3)
+    const r = required.split(/[.\-+]/).map(s => Number(s) || 0).slice(0, 3)
+    for (let i = 0; i < 3; i++) {
+        const av = a[i] ?? 0
+        const rv = r[i] ?? 0
+        if (av > rv) return true
+        if (av < rv) return false
+    }
+    return true
+}
+
+/**
+ * Inline gate — call as the first await in any method that can't be decorated.
+ * Pass the Demos instance so we can find rpcUrl + the strictCapabilities flag.
+ */
+export async function assertNodeVersion(
+    demos: { rpc_url: string; strictCapabilities?: boolean },
+    requiredVersion: string,
+    wireName: string,
+): Promise<void> {
+    const actual = await getNodeVersion(demos.rpc_url)
+    if (actual === null) {
+        return softFailOrThrow(demos, requiredVersion, wireName, undefined)
+    }
+    if (semverGte(actual, requiredVersion)) return
+    return softFailOrThrow(demos, requiredVersion, wireName, actual)
+}
+
+function softFailOrThrow(
+    demos: { rpc_url: string; strictCapabilities?: boolean },
+    requiredVersion: string,
+    wireName: string,
+    actualVersion: string | undefined,
+): void {
+    if (demos.strictCapabilities) {
+        throw new MethodNotSupportedError({
+            wireName,
+            requiredVersion,
+            actualVersion,
+            rpcUrl: demos.rpc_url,
+        })
+    }
+    const key = `${demos.rpc_url}::${wireName}`
+    if (!warnedKeys.has(key)) {
+        warnedKeys.add(key)
+        const v = actualVersion ? ` (got ${actualVersion})` : " (version unknown)"
+        // eslint-disable-next-line no-console
+        console.warn(
+            `[DEPRECATION] "${wireName}" requires node >= ${requiredVersion}${v}. ` +
+            `In a future major release, calling this against an older node will ` +
+            `throw MethodNotSupportedError. To opt in now, construct ` +
+            `Demos({ strictCapabilities: true }).`,
+        )
+    }
+}
+
+/**
+ * Legacy decorator. Apply to instance methods on classes whose `this` carries
+ * an `rpc_url` (Demos, ContractInteractor wrapping a Demos, Web2Proxy with
+ * `_demos`) — adapt the resolver if `rpc_url` lives elsewhere.
+ *
+ * For static methods (StorageProgram), see `minNodeVersionStatic` below.
+ */
+export function minNodeVersion(requiredVersion: string, wireName?: string) {
+    return function <T extends { rpc_url?: string; strictCapabilities?: boolean; _demos?: any }>(
+        target: any,
+        propertyKey: string,
+        descriptor: PropertyDescriptor,
+    ) {
+        const original = descriptor.value
+        const wn = wireName ?? propertyKey
+        descriptor.value = async function (this: T, ...args: any[]) {
+            const demos = (this as any)._demos ?? this
+            await assertNodeVersion(demos, requiredVersion, wn)
+            return original.apply(this, args)
+        }
+        return descriptor
+    }
+}
+
+/**
+ * Static-method variant. The first arg of the decorated method must be the
+ * rpcUrl (matches StorageProgram convention).
+ *
+ * Strict mode: read off a module-level config (`setStaticStrictCapabilities`)
+ * since static methods don't carry instance state. Defaults to false.
+ */
+let staticStrict = false
+export function setStaticStrictCapabilities(v: boolean) { staticStrict = v }
+
+export function minNodeVersionStatic(requiredVersion: string, wireName?: string) {
+    return function (
+        target: any,
+        propertyKey: string,
+        descriptor: PropertyDescriptor,
+    ) {
+        const original = descriptor.value
+        const wn = wireName ?? propertyKey
+        descriptor.value = async function (rpcUrl: string, ...rest: any[]) {
+            await assertNodeVersion(
+                { rpc_url: rpcUrl, strictCapabilities: staticStrict },
+                requiredVersion,
+                wn,
+            )
+            return original.call(this, rpcUrl, ...rest)
+        }
+        return descriptor
+    }
+}
+
+/** Test/integration helper. */
+export function _resetCapabilitiesCacheForTests() {
+    urlCache.clear()
+    inflight.clear()
+    warnedKeys.clear()
+    staticStrict = false
+}
+```
+
+> **Sanity check while implementing:** `import("axios")` lazy import vs. top-level — pick whichever the rest of the SDK already does. Top-level is fine; the lazy import in the snippet is just to keep the file self-contained.
+
+### 5.3 `Demos` constructor — accept `strictCapabilities`
+
+**Path:** `sdks/src/websdk/demosclass.ts`
+
+Find the `Demos` constructor (read it first; ~line 100-ish) and add an optional options object. Today's no-arg construction must still work.
+
+```ts
+constructor(opts?: { strictCapabilities?: boolean }) {
+    // ... existing init ...
+    this.strictCapabilities = opts?.strictCapabilities ?? false
+}
+
+public strictCapabilities: boolean = false
+```
+
+### 5.4 Reactive 404 detection in `Demos.call`
+
+When the node returns `result: 404` with body shape `{error: "Unknown message", message: "<wireName>"}`, that's the Phase-1-item-1 shape (originating in `kynesyslabs/node`). Treat it as `MethodNotSupportedError` material on the SDK side.
+
+**Recommended location:** `Demos.call` (`sdks/src/websdk/demosclass.ts:828`). Do NOT modify `_doPost` directly — `_doPost` is HTTP-level, not RPC-aware. `call` is where the RPC envelope is unpacked.
+
+Sketch:
+
+```ts
+// Inside Demos.call, after getting the response envelope:
+if (
+    response.result === 404 &&
+    response.response &&
+    typeof response.response === "object" &&
+    (response.response as any).error === "Unknown message"
+) {
+    const wireName = (response.response as any).message ?? "<unknown>"
+    if (this.strictCapabilities) {
+        throw new MethodNotSupportedError({
+            wireName,
+            requiredVersion: "(unknown — node returned Unknown message)",
+            rpcUrl: this.rpc_url,
+        })
+    }
+    const key = `${this.rpc_url}::${wireName}`
+    if (!warnedKeys.has(key)) {  // import dedup helper from capabilities.ts
+        warnedKeys.add(key)
+        console.warn(
+            `[DEPRECATION] Node at ${this.rpc_url} does not support "${wireName}". ` +
+            `Future SDK versions will throw MethodNotSupportedError. ` +
+            `Opt in now via new Demos({ strictCapabilities: true }).`,
+        )
+    }
+}
+```
+
+> **Important:** the reactive path **must not change the return shape** in default mode. Existing call sites rely on `response.result !== 200 → null` patterns. Throw only when `strictCapabilities` is on.
+
+### 5.5 Apply decorators / helpers
+
+**Static decorator on `sdks/src/storage/StorageProgram.ts`** (illustrative):
+
+```ts
+import { minNodeVersionStatic } from "../websdk/capabilities"
+
+export class StorageProgram {
+    @minNodeVersionStatic("0.9.9", "getStorageProgram")
+    static async getByAddress(rpcUrl: string, storageAddress: string, identity?: string) {
+        // ... unchanged body ...
+    }
+    // ...repeat for other 8 methods, each with the right wireName...
+}
+```
+
+> Repeat for all 9 storage methods. The `wireName` argument is **mandatory** for `getByAddress`/`getAll` (because they map to different/aliased wire names than the property name). Pass it explicitly to avoid mistakes.
+
+**Inline helper on `sdks/src/websdk/DemosTransactions.ts`** (illustrative):
+
+```ts
+import { assertNodeVersion } from "./capabilities"
+
+broadcastAndWait: async function (validationData, demos, opts) {
+    await assertNodeVersion(demos, "0.9.9", "getTransactionStatus")
+    // ... unchanged body, which polls getTransactionStatus ...
+}
+```
+
+### 5.6 Hook `Demos.connect()` to warm the cache (optional but recommended)
+
+**Path:** `sdks/src/websdk/demosclass.ts:140`
+
+`connect()` already does a GET to verify reachability. Extend to fetch `/health` once and prime the cache. Failure is non-fatal — just don't cache.
+
+```ts
+async connect(rpc_url: string) {
+    // ... existing reachability check ...
+    this.rpc_url = rpc_url
+    this.connected = true
+    // Warm the version cache; ignore failure.
+    void getNodeVersion(rpc_url)
+    return this.connected
+}
+```
+
+## 6. Min-version table (initial)
+
+Apply decorators/helpers ONLY to these 10 methods in this PR. **Do NOT decorate pre-existing methods.** Pre-existing methods are assumed to work on all supported node versions; gating them retroactively risks breaking working clients.
+
+| Wire | Min node version | SDK call site (`kynesyslabs/sdks`) |
+|---|---|---|
+| `getTransactionStatus` | `0.9.9` | `sdks/src/websdk/DemosTransactions.ts` `broadcastAndWait` (inline helper — not a class method) |
+| `getStorageProgram` | `0.9.9` | `sdks/src/storage/StorageProgram.ts` `getByAddress` (decorator) + `getAll` (decorator, same wire) |
+| `getStorageProgramsByOwner` | `0.9.9` | `sdks/src/storage/StorageProgram.ts` `getByOwner` |
+| `searchStoragePrograms` | `0.9.9` | `sdks/src/storage/StorageProgram.ts` `searchByName` |
+| `getStorageProgramFields` | `0.9.9` | `sdks/src/storage/StorageProgram.ts` `getFields` |
+| `getStorageProgramValue` | `0.9.9` | `sdks/src/storage/StorageProgram.ts` `getValue` |
+| `getStorageProgramItem` | `0.9.9` | `sdks/src/storage/StorageProgram.ts` `getItem` |
+| `hasStorageProgramField` | `0.9.9` | `sdks/src/storage/StorageProgram.ts` `hasField` |
+| `getStorageProgramFieldType` | `0.9.9` | `sdks/src/storage/StorageProgram.ts` `getFieldType` |
+
+> **Confirm the `0.9.9` figure with the team.** `APP_VERSION` in `node/src/utilities/constants.ts:9` was `0.9.8` at the start of this work. It should be bumped on the node side when Phase 1 + 2 lands. If the team picks a different version, edit this table accordingly before applying.
+
+## 7. PR breakdown (recommended)
+
+The user has not committed to one-PR-vs-three. Default plan: **3 PRs** for reviewability. If the user prefers one PR, flatten.
+
+### PR 9.1 — infrastructure only (`kynesyslabs/sdks`)
+
+Files (all in `kynesyslabs/sdks`):
+- New: `sdks/src/websdk/MethodNotSupportedError.ts`
+- New: `sdks/src/websdk/capabilities.ts`
+- Modified: `sdks/src/websdk/index.ts` (export new error)
+- Modified: `sdks/src/websdk/demosclass.ts` (constructor opts + reactive 404 handler in `Demos.call` + `connect()` warming)
+- Modified: `sdks/tsconfig.json` (`experimentalDecorators: true`)
+
+**No method decorations yet.** This PR only ships the mechanism. Self-test by writing a tiny standalone TS file under `/tmp/` (do not commit) that:
+1. Mocks an `rpc_url` to a server returning `result: 404` with the unknown-message body.
+2. Calls `Demos.call(...)` with `strictCapabilities: false` → expects warn + envelope returned.
+3. Calls with `strictCapabilities: true` → expects `MethodNotSupportedError` thrown.
+
+Commit message:
+```
+sdk: add capability detection infrastructure (item 9 part 1)
+
+Adds the mechanism for detecting and gating unsupported node RPC methods,
+without yet applying it to any specific method.
+
+  - MethodNotSupportedError: typed error class
+  - capabilities.ts: @minNodeVersion / @minNodeVersionStatic decorators,
+    assertNodeVersion() helper, per-rpcUrl version cache (5 min TTL,
+    singleflight), deprecation warn dedup
+  - Demos constructor accepts { strictCapabilities?: boolean } (default false)
+  - Demos.call detects Phase-1-item-1 "Unknown message" 404s; warns or
+    throws based on the flag
+  - Demos.connect() warms the version cache via /health (best effort)
+  - tsconfig: experimentalDecorators=true (legacy decorators)
+
+Default behavior preserved: methods returning null on 404 continue to do
+so, but emit a deprecation console.warn (deduplicated per rpcUrl/wireName)
+the first time the path is hit. To get throws today, opt in via
+new Demos({ strictCapabilities: true }).
+```
+
+### PR 9.2 — apply gating to the 10 new methods (`kynesyslabs/sdks`)
+
+Files (all in `kynesyslabs/sdks`):
+- Modified: `sdks/src/storage/StorageProgram.ts` (`@minNodeVersionStatic("0.9.9", "<wireName>")` on 9 static methods)
+- Modified: `sdks/src/websdk/DemosTransactions.ts` (`assertNodeVersion(demos, "0.9.9", "getTransactionStatus")` at top of `broadcastAndWait`)
+- Test scaffolding if a test harness exists (audit found `sdks/src/tests/storagePrograms.spec.ts` is `test.skip` — skip is fine; not adding tests in this PR unless trivial)
+
+Commit message:
+```
+sdk: apply @minNodeVersion to Phase 1+2 RPC additions (item 9 part 2)
+
+Gates the 10 SDK methods that require node >= 0.9.9 (Phase 1 item 4 +
+Phase 2 item 7 additions):
+
+  - DemosTransactions.broadcastAndWait (uses getTransactionStatus)
+  - StorageProgram.{getByAddress, getByOwner, searchByName, getFields,
+    getValue, getItem, hasField, getFieldType, getAll}
+
+Default mode logs a deprecation warning when the connected node lacks
+support; strict mode throws MethodNotSupportedError. No pre-existing
+method is decorated — gating older methods retroactively risks breaking
+working clients.
+```
+
+### PR 9.3 — docs & changelog
+
+- New: `sdks/docs/sdk-version-compat.md` (or wherever the SDK keeps its docs) — table of SDK version → required node version per method.
+- Hand-off brief for Mintlify docs (the docs repo is `kynesyslabs/documentation-mintlify`, **outside the implementer's GitHub MCP scope** — produce a brief Markdown that lists each docs page that needs an entry, the same way `node/docs/planning/` is used here).
+- README/CHANGELOG entries in `kynesyslabs/sdks`.
+
+## 8. Verification checklist (before pushing PR 9.1)
+
+1. Branch is `claude/checkout-branches-WQCIg` in `kynesyslabs/sdks`. **Do NOT commit on `main`.** Run `cd /home/user/sdks && git rev-parse --abbrev-ref HEAD` first.
+2. `cd /home/user/sdks && cat package.json | grep version` — note the SDK version. Bump if the team has a convention; otherwise leave for release engineering.
+3. `cd /home/user/sdks && bun run build` — must succeed. Pre-existing baseline is 1 error in `sdks/src/tests/multichain/ten.spec.ts:115`. Anything new is your problem.
+4. `cd /home/user/node && git status` — must be clean. **No node changes — `kynesyslabs/node` is read-only for this work.**
+5. Smoke: write a 30-line script under `/tmp/` (do not commit) that constructs a `Demos`, points it at a mock URL, and exercises the strict/non-strict paths. Confirm warns are deduplicated and throws fire when expected.
+
+## 9. Risks & mitigations
+
+| # | Risk | Mitigation |
+|---|---|---|
+| 1 | `experimentalDecorators` flips output behavior | Test build before applying decorators. Most likely flag is harmless; if surprises, fall back to wrapper functions instead of decorators. |
+| 2 | `emitDecoratorMetadata: false` works only if no decorator imports `reflect-metadata` | The provided `capabilities.ts` does NOT use `reflect-metadata`. Keep it that way. |
+| 3 | Static decorator + URL-keyed cache race | `inflight` map in `getNodeVersion` provides singleflight. |
+| 4 | Node lacks `/health` (pre-Phase-1) | `getNodeVersion` returns `null` on failure; `assertNodeVersion` treats null as "unsupported". User sees deprecation warn or `MethodNotSupportedError` with `actualVersion: undefined`. |
+| 5 | Custom node builds don't bump `APP_VERSION` | Strict mode is opt-in for exactly this reason. Document. |
+| 6 | Deprecation noise spams long-running apps | Per-`(rpcUrl, wireName)` Set-based dedup. |
+| 7 | Test coverage breaks | Audit found relevant tests are `.skip`'d. Spot-check before committing. |
+| 8 | `StorageProgram.getAll` and `StorageProgram.getByAddress` share wire name `getStorageProgram` | Both get `@minNodeVersionStatic("0.9.9", "getStorageProgram")` — the wireName arg is explicit; no collision. |
+| 9 | Multi-instance `Demos` with different URLs | Per-rpcUrl cache handles this naturally. |
+| 10 | `Demos.connect` fetching `/health` adds latency | `void getNodeVersion(...)` (fire-and-forget). The decorator's `assertNodeVersion` will await it on first method call anyway. |
+
+## 10. Open decisions for the implementer
+
+If the user has not made the call before you start, **flag and ask**:
+
+1. **Min node version for the gated methods** — currently `0.9.9` placeholder. Should match the actual `APP_VERSION` Phase 1+2 ships as.
+2. **`strictCapabilities` shape**: simple `boolean` (recommended, matches this doc) vs. granular object (`{strict, warnOnce, ...}`). Default to boolean.
+3. **One PR vs. three**: this doc proposes three for review. If the user wants one, collapse `9.1`+`9.2` into a single commit.
+4. **Where docs go** in `sdks/docs/`. Only relevant for PR 9.3.
+
+## 11. Repo boundary — explicit do-not-touch list
+
+| Repo | Allowed? | What |
+|---|---|---|
+| `kynesyslabs/sdks` | ✅ YES | All implementation work happens here. Branch `claude/checkout-branches-WQCIg`. |
+| `kynesyslabs/node` | ❌ **NO** | Read-only. The `/health` endpoint, `result: 404` for unknown messages, and the 9 storage-program read RPCs are all already shipped and pushed. |
+| `kynesyslabs/documentation-mintlify` | ❌ **NO** (out of scope) | Docs hand-off in PR 9.3 produces a Markdown brief; another agent with that repo in scope ships it. |
+
+## 12. What is explicitly out of scope
+
+- **Node changes.** Already covered above — `kynesyslabs/node` is frozen for this work.
+- **Test framework upgrades.** If existing tests don't run, that's a pre-existing issue (Phase 1 item 6 audit found 800+ pre-existing TS errors in tests).
+- **Decorating pre-existing methods.** Only the 10 methods in §6.
+- **Migrating callers off the legacy null-return pattern.** That's a major-version effort, separate.
+- **`reflect-metadata` integration.** Don't introduce it.
+
+## 13. Cross-references
+
+- **Phase 1 item 4 commit** (introduces `getTransactionStatus`): `node:0def623` on `kynesyslabs/node` `claude/checkout-branches-WQCIg`.
+- **Phase 1 item 5 commit** (introduces `/health`): `node:564f0af` on `kynesyslabs/node` `claude/checkout-branches-WQCIg`.
+- **Phase 1 item 1 commit** (404 for unknown messages): `node:e57be21` on `kynesyslabs/node` `claude/checkout-branches-WQCIg`.
+- **Phase 2 item 7 commit** (storage-program reads): `node:2b97270` on `kynesyslabs/node` `claude/checkout-branches-WQCIg`.
+- **Phase 1 item 6 commit** (`_doPost` + `TransportError`): `sdks:5f0076d` on `kynesyslabs/sdks` `claude/checkout-branches-WQCIg`.
+- **Phase 1 item 8 commit** (`broadcastAndWait`): `sdks:c6a6d26` on `kynesyslabs/sdks` `claude/checkout-branches-WQCIg`.
+
+## 14. When done
+
+1. Push the branch to `kynesyslabs/sdks`.
+2. Report back with: PR(s) opened, decorated methods list, test-run summary, anything that surprised you.
+3. **Stop.** Do NOT touch `kynesyslabs/node`. Do NOT proactively chase the docs PR — that's a separate hand-off.

--- a/src/features/storageprogram/routes.ts
+++ b/src/features/storageprogram/routes.ts
@@ -629,37 +629,32 @@ async function listByOwnerHandler(req: Request): Promise<Response> {
             return jsonResponse(response, 400)
         }
 
-        // Get requester identity from header
+        // Get requester identity from header. Empty string and missing
+        // identity both map to undefined so the SQL ACL filter sees a true
+        // anonymous caller (not a falsy owner-bypass).
         const identity = req.headers.get("identity")
         let requesterAddress: string | undefined
 
-        if (identity) {
+        if (identity && identity.length > 0) {
             const splits = identity.split(":")
-            requesterAddress = splits.length > 1 ? splits[1] : identity
+            const candidate = splits.length > 1 ? splits[1] : identity
+            requesterAddress =
+                candidate && candidate.length > 0 ? candidate : undefined
         }
 
         // Get repository
         const db = await Datasource.getInstance()
         const repository = db.getDataSource().getRepository(GCRStorageProgram)
 
-        // Fetch all programs by owner
-        const programs =
+        // ACL filtering happens in SQL. The owner-fast-path is internal:
+        // when requesterAddress === owner, the routine skips the jsonb
+        // predicate and uses the owner index directly.
+        const accessiblePrograms =
             await GCRStorageProgramRoutines.getStorageProgramsByOwner(
                 owner,
                 repository,
+                requesterAddress,
             )
-
-        // Owner always sees all their own programs.
-        // For other requesters, filter by read permission.
-        const isOwnerRequest = !requesterAddress || requesterAddress === owner
-        const accessiblePrograms = isOwnerRequest
-            ? programs
-            : programs.filter(program =>
-                  GCRStorageProgramRoutines.checkReadPermission(
-                      program,
-                      requesterAddress,
-                  ),
-              )
 
         // Map to response format
         const response: StorageProgramsListResponse = {
@@ -736,21 +731,14 @@ async function searchByNameHandler(req: Request): Promise<Response> {
         const db = await Datasource.getInstance()
         const repository = db.getDataSource().getRepository(GCRStorageProgram)
 
-        // Search programs by name
-        const programs =
+        // ACL filtering happens in SQL so LIMIT/OFFSET produce full pages
+        // (no post-fetch JS filter that would silently shorten them).
+        const accessiblePrograms =
             await GCRStorageProgramRoutines.searchStorageProgramsByName(
                 query.trim(),
                 repository,
-                { limit, offset, exactMatch },
+                { limit, offset, exactMatch, requesterAddress },
             )
-
-        // Filter to only programs the requester can read
-        const accessiblePrograms = programs.filter(program =>
-            GCRStorageProgramRoutines.checkReadPermission(
-                program,
-                requesterAddress,
-            ),
-        )
 
         // Map to response format
         const response: StorageProgramsListResponse = {

--- a/src/features/storageprogram/routes.ts
+++ b/src/features/storageprogram/routes.ts
@@ -629,6 +629,18 @@ async function listByOwnerHandler(req: Request): Promise<Response> {
             return jsonResponse(response, 400)
         }
 
+        // Pagination via ?limit=&offset= — defaults match the GCR routine
+        // (200 limit today, will drop to 100 in a future release).
+        const rawLimit = parseInt(
+            url.searchParams.get("limit") || "200",
+            10,
+        )
+        const limit = Math.min(Math.max(1, rawLimit), 200)
+        const offset = Math.max(
+            0,
+            parseInt(url.searchParams.get("offset") || "0", 10),
+        )
+
         // Get requester identity from header. Empty string and missing
         // identity both map to undefined so the SQL ACL filter sees a true
         // anonymous caller (not a falsy owner-bypass).
@@ -646,14 +658,16 @@ async function listByOwnerHandler(req: Request): Promise<Response> {
         const db = await Datasource.getInstance()
         const repository = db.getDataSource().getRepository(GCRStorageProgram)
 
-        // ACL filtering happens in SQL. The owner-fast-path is internal:
-        // when requesterAddress === owner, the routine skips the jsonb
-        // predicate and uses the owner index directly.
+        // ACL filtering and pagination both happen in SQL. The
+        // owner-fast-path is internal: when requesterAddress === owner, the
+        // routine skips the jsonb predicate and uses the owner index
+        // directly.
         const accessiblePrograms =
             await GCRStorageProgramRoutines.getStorageProgramsByOwner(
                 owner,
                 repository,
                 requesterAddress,
+                { limit, offset },
             )
 
         // Map to response format

--- a/src/features/storageprogram/routes.ts
+++ b/src/features/storageprogram/routes.ts
@@ -99,13 +99,29 @@ interface StorageProgramGranularResponse {
         | "INVALID_FIELD_TYPE"
 }
 
+/**
+ * Extract the requester's address from the `identity` header.
+ *
+ * Identity can be either a bare address or a `prefix:address` form
+ * (e.g. `ed25519:<addr>`). Returns `undefined` when:
+ *   - the header is missing or empty
+ *   - the post-colon segment is empty (e.g. `"ed25519:"`)
+ *
+ * Returning `undefined` for an empty post-colon segment is semantically
+ * equivalent to anonymous in `checkReadPermission` — every branch either
+ * already guards on falsy requesterAddress or compares it against a real
+ * value that an empty string can't match. The change ensures consistent
+ * behaviour with the SQL ACL filter and other call sites that distinguish
+ * `""` from `undefined`.
+ */
 function getRequesterAddress(req: Request): string | undefined {
     const identity = req.headers.get("identity")
-    if (!identity) {
+    if (!identity || identity.length === 0) {
         return undefined
     }
     const splits = identity.split(":")
-    return splits.length > 1 ? splits[1] : identity
+    const candidate = splits.length > 1 ? splits[1] : identity
+    return candidate && candidate.length > 0 ? candidate : undefined
 }
 
 function getValueType(
@@ -641,18 +657,10 @@ async function listByOwnerHandler(req: Request): Promise<Response> {
             parseInt(url.searchParams.get("offset") || "0", 10),
         )
 
-        // Get requester identity from header. Empty string and missing
-        // identity both map to undefined so the SQL ACL filter sees a true
-        // anonymous caller (not a falsy owner-bypass).
-        const identity = req.headers.get("identity")
-        let requesterAddress: string | undefined
-
-        if (identity && identity.length > 0) {
-            const splits = identity.split(":")
-            const candidate = splits.length > 1 ? splits[1] : identity
-            requesterAddress =
-                candidate && candidate.length > 0 ? candidate : undefined
-        }
+        // Empty string and missing identity both map to undefined so the
+        // SQL ACL filter sees a true anonymous caller (not a falsy
+        // owner-bypass).
+        const requesterAddress = getRequesterAddress(req)
 
         // Get repository
         const db = await Datasource.getInstance()
@@ -732,14 +740,7 @@ async function searchByNameHandler(req: Request): Promise<Response> {
             return jsonResponse(response, 400)
         }
 
-        // Get requester identity from header
-        const identity = req.headers.get("identity")
-        let requesterAddress: string | undefined
-
-        if (identity) {
-            const splits = identity.split(":")
-            requesterAddress = splits.length > 1 ? splits[1] : identity
-        }
+        const requesterAddress = getRequesterAddress(req)
 
         // Get repository
         const db = await Datasource.getInstance()

--- a/src/libs/blockchain/chain.ts
+++ b/src/libs/blockchain/chain.ts
@@ -26,6 +26,9 @@ import * as blockOps from "./chainBlocks"
 import * as txOps from "./chainTransactions"
 import * as genesisOps from "./chainGenesis"
 import * as statusOps from "./chainStatus"
+import type { TxStatus } from "./chainTypes"
+
+export type { TxStatus } from "./chainTypes"
 
 /**
  * Chain facade — delegates to focused sub-modules:
@@ -102,6 +105,10 @@ export default class Chain {
     // ── Transaction queries ───────────────────────────────────
     static async getTxByHash(hash: string): Promise<Transaction | null> {
         return txOps.getTxByHash(hash)
+    }
+
+    static async getTransactionStatus(hash: string): Promise<TxStatus> {
+        return txOps.getTransactionStatus(hash)
     }
 
     static async getTransactionHistory(

--- a/src/libs/blockchain/chainTransactions.ts
+++ b/src/libs/blockchain/chainTransactions.ts
@@ -5,8 +5,9 @@ import { Transactions } from "src/model/entities/Transactions"
 import { L2PSHash } from "src/model/entities/L2PSHashes"
 import { handleError } from "src/errors"
 import { getTransactionsRepo } from "./chainDb"
+import Mempool from "./mempool"
 import type { TransactionContent } from "@kynesyslabs/demosdk/types"
-import type { L2PSHashUpdatePayload } from "./chainTypes"
+import type { L2PSHashUpdatePayload, TxStatus } from "./chainTypes"
 
 export function getL2PSHashUpdatePayload(
     tx: Transaction,
@@ -67,6 +68,29 @@ export async function getTxByHash(hash: string): Promise<Transaction | null> {
         log.error(`[ChainDB] [ ERROR ]: ${JSON.stringify(error)}`)
         throw error
     }
+}
+
+/**
+ * Lifecycle status of a transaction by hash.
+ *
+ * Cheap: 1 mempool lookup, then 1 transactions lookup if not in mempool.
+ *
+ * "failed" is reserved — currently the node does not record execution
+ * failures, so failed txs surface as "unknown".
+ */
+export async function getTransactionStatus(hash: string): Promise<TxStatus> {
+    const inMempool = await Mempool.findByHash(hash)
+    if (inMempool) return { state: "pending" }
+
+    const tx = await getTxByHash(hash)
+    if (tx) {
+        return {
+            state: "included",
+            blockNumber: tx.blockNumber ?? undefined,
+        }
+    }
+
+    return { state: "unknown" }
 }
 
 export async function getTransactionHistory(

--- a/src/libs/blockchain/chainTypes.ts
+++ b/src/libs/blockchain/chainTypes.ts
@@ -3,3 +3,17 @@ export interface L2PSHashUpdatePayload {
     consolidated_hash: string
     transaction_count: number
 }
+
+/**
+ * Transaction lifecycle state returned by Chain.getTransactionStatus.
+ *
+ *   - "pending"  — present in mempool, not yet included in a block
+ *   - "included" — present in the transactions table, has a block number
+ *   - "failed"   — reserved (the node does not currently record execution
+ *                  failures, so failed txs surface as "unknown")
+ *   - "unknown"  — not found anywhere
+ */
+export type TxStatus = {
+    state: "pending" | "included" | "failed" | "unknown"
+    blockNumber?: number
+}

--- a/src/libs/blockchain/gcr/gcr_routines/GCRStorageProgramRoutines.ts
+++ b/src/libs/blockchain/gcr/gcr_routines/GCRStorageProgramRoutines.ts
@@ -913,24 +913,118 @@ export class GCRStorageProgramRoutines {
     }
 
     /**
-     * Get all storage programs owned by an address
+     * SQL predicate that mirrors {@link checkReadPermission} at the database
+     * layer. Evaluated against the alias `sp` (storage program) row.
+     *
+     * Produces an `(SQL, parameters)` pair the caller `.andWhere()`s into a
+     * QueryBuilder, so ACL filtering happens before LIMIT/OFFSET and pages
+     * stay full. Without this, post-fetch JS filtering produced short pages
+     * and silently hid accessible rows past the SQL window.
+     *
+     * Branches (all expressed as jsonb containment so they map to the natural
+     * Postgres operators and don't require value normalisation):
+     *   - public mode and not blacklisted (anonymous always sees public —
+     *     blacklist needs an identity to test)
+     *   - owner mode and requester is the owner
+     *   - restricted mode and requester is the owner (owner overrides
+     *     blacklist; matches checkReadPermission line 1006-1009)
+     *   - restricted mode and requester is in `acl.allowed` and not in
+     *     `acl.blacklisted`
+     *   - restricted mode and requester is a member of a group whose
+     *     `permissions` array contains "read", and not blacklisted
+     *
+     * Uses jsonb `@>` containment so Postgres can short-circuit on absent
+     * keys; no GIN index is required because the query is already gated by
+     * `programName ILIKE` / `owner` / `isDeleted` predicates that prune the
+     * candidate set heavily before this predicate runs.
+     */
+    private static readReachablePredicate(
+        requesterAddress: string | undefined,
+        alias = "sp",
+    ): { sql: string; params: Record<string, unknown> } {
+        const a = alias
+        if (requesterAddress === undefined) {
+            // Anonymous: only public programs are visible. Blacklist applies
+            // only to identified callers (we have no identity to test
+            // against), matching checkReadPermission.
+            return {
+                sql: `(${a}.acl->>'mode' = 'public')`,
+                params: {},
+            }
+        }
+        return {
+            sql: `(
+                -- public mode, requester not in blacklist
+                (${a}.acl->>'mode' = 'public'
+                  AND NOT COALESCE(${a}.acl->'blacklisted' @> to_jsonb(:requesterAddress::text), false))
+                -- owner mode, requester is the owner
+                OR (${a}.acl->>'mode' = 'owner' AND ${a}.owner = :requesterAddress)
+                -- restricted mode, requester is the owner (owner overrides blacklist)
+                OR (${a}.acl->>'mode' = 'restricted' AND ${a}.owner = :requesterAddress)
+                -- restricted mode, requester is in allowed list and not blacklisted
+                OR (${a}.acl->>'mode' = 'restricted'
+                    AND ${a}.acl->'allowed' @> to_jsonb(:requesterAddress::text)
+                    AND NOT COALESCE(${a}.acl->'blacklisted' @> to_jsonb(:requesterAddress::text), false))
+                -- restricted mode, requester is a member of a group with read permission
+                OR (${a}.acl->>'mode' = 'restricted'
+                    AND NOT COALESCE(${a}.acl->'blacklisted' @> to_jsonb(:requesterAddress::text), false)
+                    AND EXISTS (
+                        SELECT 1 FROM jsonb_each(${a}.acl->'groups') AS grp(name, def)
+                        WHERE def->'members' @> to_jsonb(:requesterAddress::text)
+                          AND def->'permissions' @> '"read"'::jsonb
+                    ))
+            )`,
+            params: { requesterAddress },
+        }
+    }
+
+    /**
+     * Get all storage programs owned by an address, optionally ACL-filtered
+     * for a requester.
+     *
+     * When `requesterAddress` matches `owner`, ACL filtering is skipped (the
+     * owner sees everything, hits only the existing owner index). For any
+     * other requester, the SQL ACL predicate runs at the database layer so
+     * pagination — when the caller adds it — stays correct.
      */
     static async getStorageProgramsByOwner(
         owner: string,
         repository: Repository<GCRStorageProgram>,
+        requesterAddress?: string,
     ): Promise<GCRStorageProgram[]> {
-        return repository.find({
-            where: { owner, isDeleted: false },
-            order: { createdAt: "DESC" },
-        })
+        // Owner fast-path: same owner index as before, no jsonb evaluation.
+        if (requesterAddress === owner) {
+            return repository.find({
+                where: { owner, isDeleted: false },
+                order: { createdAt: "DESC" },
+            })
+        }
+
+        const qb = repository
+            .createQueryBuilder("sp")
+            .where("sp.owner = :owner", { owner })
+            .andWhere("sp.isDeleted = false")
+
+        const acl = this.readReachablePredicate(requesterAddress)
+        qb.andWhere(acl.sql, acl.params)
+
+        return qb.orderBy("sp.createdAt", "DESC").getMany()
     }
 
     /**
-     * Search storage programs by name (supports partial matching)
+     * Search storage programs by name (partial or exact match), ACL-filtered
+     * for the requester at the SQL layer so LIMIT/OFFSET produce full pages.
+     *
+     * The previous implementation paginated first and ACL-filtered the
+     * already-truncated result, which produced short pages and hid accessible
+     * rows past the SQL window. Now the predicate is part of the WHERE clause
+     * so the database returns exactly the requested page of *accessible*
+     * rows.
+     *
      * @param namePattern - The name or partial name to search for
      * @param repository - TypeORM repository for GCRStorageProgram
-     * @param options - Search options (limit, offset, exactMatch)
-     * @returns Array of matching storage programs
+     * @param options - Search options (limit, offset, exactMatch, requesterAddress)
+     * @returns Array of matching storage programs the requester can read
      */
     static async searchStorageProgramsByName(
         namePattern: string,
@@ -939,28 +1033,28 @@ export class GCRStorageProgramRoutines {
             limit?: number
             offset?: number
             exactMatch?: boolean
+            requesterAddress?: string
         },
     ): Promise<GCRStorageProgram[]> {
         const limit = options?.limit ?? 50
         const offset = options?.offset ?? 0
         const exactMatch = options?.exactMatch ?? false
 
-        if (exactMatch) {
-            return repository.find({
-                where: { programName: namePattern, isDeleted: false },
-                order: { createdAt: "DESC" },
-                take: limit,
-                skip: offset,
-            })
-        }
+        const qb = repository.createQueryBuilder("sp")
 
-        // Partial match using ILIKE (case-insensitive)
-        return repository
-            .createQueryBuilder("sp")
-            .where("sp.programName ILIKE :pattern", {
+        if (exactMatch) {
+            qb.where("sp.programName = :name", { name: namePattern })
+        } else {
+            qb.where("sp.programName ILIKE :pattern", {
                 pattern: `%${namePattern}%`,
             })
-            .andWhere("sp.isDeleted = false")
+        }
+        qb.andWhere("sp.isDeleted = false")
+
+        const acl = this.readReachablePredicate(options?.requesterAddress)
+        qb.andWhere(acl.sql, acl.params)
+
+        return qb
             .orderBy("sp.createdAt", "DESC")
             .take(limit)
             .skip(offset)

--- a/src/libs/blockchain/gcr/gcr_routines/GCRStorageProgramRoutines.ts
+++ b/src/libs/blockchain/gcr/gcr_routines/GCRStorageProgramRoutines.ts
@@ -992,24 +992,40 @@ export class GCRStorageProgramRoutines {
     }
 
     /**
-     * Get all storage programs owned by an address, optionally ACL-filtered
-     * for a requester.
+     * Get storage programs owned by an address, ACL-filtered for the
+     * requester and paginated at the SQL layer.
      *
      * When `requesterAddress` matches `owner`, ACL filtering is skipped (the
      * owner sees everything, hits only the existing owner index). For any
-     * other requester, the SQL ACL predicate runs at the database layer so
-     * pagination — when the caller adds it — stays correct.
+     * other requester, the SQL ACL predicate runs at the database layer.
+     *
+     * **Pagination:** SQL LIMIT/OFFSET are always applied to avoid
+     * materialising the full result set in memory for owners with many
+     * programs. `options.limit` defaults to **200** today and is clamped
+     * to [1, 200].
+     *
+     * **Default limit will drop to 100 in a future release** — callers that
+     * rely on the implicit cap should pass an explicit `options.limit`
+     * matching their expectation, or paginate via `options.offset`.
      */
     static async getStorageProgramsByOwner(
         owner: string,
         repository: Repository<GCRStorageProgram>,
         requesterAddress?: string,
+        options?: { limit?: number; offset?: number },
     ): Promise<GCRStorageProgram[]> {
+        const rawLimit = options?.limit ?? 200
+        const limit = Math.min(Math.max(1, Math.floor(rawLimit)), 200)
+        const rawOffset = options?.offset ?? 0
+        const offset = Math.max(0, Math.floor(rawOffset))
+
         // Owner fast-path: same owner index as before, no jsonb evaluation.
         if (requesterAddress === owner) {
             return repository.find({
                 where: { owner, isDeleted: false },
                 order: { createdAt: "DESC" },
+                take: limit,
+                skip: offset,
             })
         }
 
@@ -1021,7 +1037,11 @@ export class GCRStorageProgramRoutines {
         const acl = this.readReachablePredicate(requesterAddress)
         qb.andWhere(acl.sql, acl.params)
 
-        return qb.orderBy("sp.createdAt", "DESC").getMany()
+        return qb
+            .orderBy("sp.createdAt", "DESC")
+            .take(limit)
+            .skip(offset)
+            .getMany()
     }
 
     /**

--- a/src/libs/blockchain/gcr/gcr_routines/GCRStorageProgramRoutines.ts
+++ b/src/libs/blockchain/gcr/gcr_routines/GCRStorageProgramRoutines.ts
@@ -942,6 +942,15 @@ export class GCRStorageProgramRoutines {
         requesterAddress: string | undefined,
         alias = "sp",
     ): { sql: string; params: Record<string, unknown> } {
+        // Defense-in-depth: alias is interpolated directly into SQL, so
+        // reject anything outside a normal SQL identifier shape. Today the
+        // only caller uses the default "sp", but a future caller passing
+        // user-derived input would otherwise be a SQL-injection vector.
+        if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(alias)) {
+            throw new Error(
+                `Invalid SQL alias for readReachablePredicate: ${alias}`,
+            )
+        }
         const a = alias
         if (requesterAddress === undefined) {
             // Anonymous: only public programs are visible. Blacklist applies

--- a/src/libs/blockchain/gcr/gcr_routines/GCRStorageProgramRoutines.ts
+++ b/src/libs/blockchain/gcr/gcr_routines/GCRStorageProgramRoutines.ts
@@ -942,6 +942,18 @@ export class GCRStorageProgramRoutines {
         requesterAddress: string | undefined,
         alias = "sp",
     ): { sql: string; params: Record<string, unknown> } {
+        // Normalize empty-string requester to undefined so this primitive
+        // matches checkReadPermission's anonymous semantics (every branch
+        // there treats falsy requesterAddress as anonymous via falsy
+        // checks). All current callers already gate on .length > 0, so
+        // this is defense-in-depth — but the function should be
+        // self-protecting against future callers.
+        const r =
+            typeof requesterAddress === "string" &&
+            requesterAddress.length > 0
+                ? requesterAddress
+                : undefined
+
         // Defense-in-depth: alias is interpolated directly into SQL, so
         // reject anything outside a normal SQL identifier shape. Today the
         // only caller uses the default "sp", but a future caller passing
@@ -952,7 +964,7 @@ export class GCRStorageProgramRoutines {
             )
         }
         const a = alias
-        if (requesterAddress === undefined) {
+        if (r === undefined) {
             // Anonymous: only public programs are visible. Blacklist applies
             // only to identified callers (we have no identity to test
             // against), matching checkReadPermission.
@@ -987,7 +999,7 @@ export class GCRStorageProgramRoutines {
                           AND def->'permissions' @> '"read"'::jsonb
                     ))
             )`,
-            params: { requesterAddress },
+            params: { requesterAddress: r },
         }
     }
 

--- a/src/libs/blockchain/gcr/gcr_routines/GCRStorageProgramRoutines.ts
+++ b/src/libs/blockchain/gcr/gcr_routines/GCRStorageProgramRoutines.ts
@@ -966,8 +966,12 @@ export class GCRStorageProgramRoutines {
                     AND ${a}.acl->'allowed' @> to_jsonb(:requesterAddress::text)
                     AND NOT COALESCE(${a}.acl->'blacklisted' @> to_jsonb(:requesterAddress::text), false))
                 -- restricted mode, requester is a member of a group with read permission
+                -- jsonb_typeof guard avoids "cannot call jsonb_each on a non-object"
+                -- when acl.groups is missing/null/non-object (allowed by the schema —
+                -- StorageProgramACL.groups is optional)
                 OR (${a}.acl->>'mode' = 'restricted'
                     AND NOT COALESCE(${a}.acl->'blacklisted' @> to_jsonb(:requesterAddress::text), false)
+                    AND jsonb_typeof(${a}.acl->'groups') = 'object'
                     AND EXISTS (
                         SELECT 1 FROM jsonb_each(${a}.acl->'groups') AS grp(name, def)
                         WHERE def->'members' @> to_jsonb(:requesterAddress::text)

--- a/src/libs/blockchain/mempool.ts
+++ b/src/libs/blockchain/mempool.ts
@@ -1,6 +1,7 @@
 import {
     EntityManager,
     FindManyOptions,
+    ILike,
     In,
     LessThanOrEqual,
     QueryFailedError,
@@ -70,6 +71,21 @@ export default class Mempool {
 
     public static async checkTransactionByHash(hash: string) {
         return await this.repo.exists({ where: { hash: hash } })
+    }
+
+    /**
+     * Cheap mempool size lookup — used by /health.
+     */
+    public static async count(): Promise<number> {
+        return await this.repo.count()
+    }
+
+    /**
+     * Case-insensitive mempool lookup by transaction hash. Returns the
+     * MempoolTx row or null if the hash is not in the mempool.
+     */
+    public static async findByHash(hash: string): Promise<MempoolTx | null> {
+        return await this.repo.findOne({ where: { hash: ILike(hash) } })
     }
 
     public static async addTransaction(

--- a/src/libs/network/bunServer.ts
+++ b/src/libs/network/bunServer.ts
@@ -187,11 +187,19 @@ export const text = (body: string, status = 200): Response => {
     return new Response(body, { status })
 }
 
-export const jsonResponse = (body: any, status = 200): Response => {
+export const jsonResponse = (
+    body: any,
+    status = 200,
+    extraHeaders?: Record<string, string>,
+): Response => {
+    // Spread caller-provided headers first, then force Content-Type so it
+    // can't be accidentally overridden away from application/json.
+    const headers: Record<string, string> = {
+        ...extraHeaders,
+        "Content-Type": "application/json",
+    }
     return new Response(JSON.stringify(body), {
         status,
-        headers: {
-            "Content-Type": "application/json",
-        },
+        headers,
     })
 }

--- a/src/libs/network/handlers/index.ts
+++ b/src/libs/network/handlers/index.ts
@@ -5,6 +5,7 @@ import { identityHandlers } from "./identityHandlers"
 import { tlsnotaryHandlers } from "./tlsnotaryHandlers"
 import { l2psHandlers } from "./l2psHandlers"
 import { miscHandlers } from "./miscHandlers"
+import { storageProgramHandlers } from "./storageProgramHandlers"
 import type { NodeCallHandler } from "./types"
 
 export type { NodeCallHandler } from "./types"
@@ -17,4 +18,5 @@ export const handlerRegistry: Record<string, NodeCallHandler> = {
     ...tlsnotaryHandlers,
     ...l2psHandlers,
     ...miscHandlers,
+    ...storageProgramHandlers,
 }

--- a/src/libs/network/handlers/storageProgramHandlers.ts
+++ b/src/libs/network/handlers/storageProgramHandlers.ts
@@ -1,0 +1,49 @@
+import getStorageProgram from "../routines/nodecalls/getStorageProgram"
+import getStorageProgramAll from "../routines/nodecalls/getStorageProgramAll"
+import getStorageProgramFieldType from "../routines/nodecalls/getStorageProgramFieldType"
+import getStorageProgramFields from "../routines/nodecalls/getStorageProgramFields"
+import getStorageProgramItem from "../routines/nodecalls/getStorageProgramItem"
+import getStorageProgramValue from "../routines/nodecalls/getStorageProgramValue"
+import getStorageProgramsByOwner from "../routines/nodecalls/getStorageProgramsByOwner"
+import hasStorageProgramField from "../routines/nodecalls/hasStorageProgramField"
+import searchStoragePrograms from "../routines/nodecalls/searchStoragePrograms"
+import type { NodeCallHandler } from "./types"
+
+/**
+ * Read-side RPC handlers for the StorageProgram subsystem.
+ *
+ * Each handler returns its own RPCResponse (not the shared mutable
+ * `response` argument) — the dispatcher's adapter just returns whatever
+ * we hand back. ACL enforcement happens inside each handler via
+ * GCRStorageProgramRoutines.checkReadPermission, with anonymous callers
+ * limited to public programs.
+ */
+export const storageProgramHandlers: Record<string, NodeCallHandler> = {
+    getStorageProgram: async data => {
+        return await getStorageProgram(data)
+    },
+    getStorageProgramAll: async data => {
+        return await getStorageProgramAll(data)
+    },
+    getStorageProgramFields: async data => {
+        return await getStorageProgramFields(data)
+    },
+    getStorageProgramFieldType: async data => {
+        return await getStorageProgramFieldType(data)
+    },
+    getStorageProgramItem: async data => {
+        return await getStorageProgramItem(data)
+    },
+    getStorageProgramValue: async data => {
+        return await getStorageProgramValue(data)
+    },
+    getStorageProgramsByOwner: async data => {
+        return await getStorageProgramsByOwner(data)
+    },
+    hasStorageProgramField: async data => {
+        return await hasStorageProgramField(data)
+    },
+    searchStoragePrograms: async data => {
+        return await searchStoragePrograms(data)
+    },
+}

--- a/src/libs/network/handlers/transactionHandlers.ts
+++ b/src/libs/network/handlers/transactionHandlers.ts
@@ -1,5 +1,6 @@
 import Chain from "../../blockchain/chain"
 import getTransactions from "../routines/nodecalls/getTransactions"
+import getTransactionStatus from "../routines/nodecalls/getTransactionStatus"
 import getTxsByHashes from "../routines/nodecalls/getTxsByHashes"
 import Mempool from "../../blockchain/mempool"
 import log from "src/utilities/logger"
@@ -8,6 +9,10 @@ import type { NodeCallHandler } from "./types"
 export const transactionHandlers: Record<string, NodeCallHandler> = {
     getTransactions: async (data, _response) => {
         return await getTransactions(data)
+    },
+
+    getTransactionStatus: async (data, _response) => {
+        return await getTransactionStatus(data)
     },
 
     getTxByHash: async (data, response) => {

--- a/src/libs/network/manageGCRRoutines.ts
+++ b/src/libs/network/manageGCRRoutines.ts
@@ -363,6 +363,7 @@ export default async function manageGCRRoutines(
         case "getStorageProgramsByOwner": {
             const owner = params[0]
             const requesterAddress = params[1] // Optional identity for ACL filtering
+            const options = params[2] || {} // Optional { limit, offset }
 
             if (!owner) {
                 response.result = 400
@@ -377,7 +378,7 @@ export default async function manageGCRRoutines(
                     .getDataSource()
                     .getRepository(GCRStorageProgram)
 
-                // ACL filtering happens in SQL.
+                // ACL filtering and pagination both happen in SQL.
                 const accessiblePrograms =
                     await GCRStorageProgramRoutines.getStorageProgramsByOwner(
                         owner,
@@ -386,6 +387,16 @@ export default async function manageGCRRoutines(
                             requesterAddress.length > 0
                             ? requesterAddress
                             : undefined,
+                        {
+                            limit:
+                                typeof options.limit === "number"
+                                    ? options.limit
+                                    : undefined,
+                            offset:
+                                typeof options.offset === "number"
+                                    ? options.offset
+                                    : undefined,
+                        },
                     )
 
                 response.response = accessiblePrograms.map(p => ({

--- a/src/libs/network/manageGCRRoutines.ts
+++ b/src/libs/network/manageGCRRoutines.ts
@@ -377,19 +377,16 @@ export default async function manageGCRRoutines(
                     .getDataSource()
                     .getRepository(GCRStorageProgram)
 
-                const programs =
+                // ACL filtering happens in SQL.
+                const accessiblePrograms =
                     await GCRStorageProgramRoutines.getStorageProgramsByOwner(
                         owner,
                         repository,
+                        typeof requesterAddress === "string" &&
+                            requesterAddress.length > 0
+                            ? requesterAddress
+                            : undefined,
                     )
-
-                // Filter to only programs the requester can read
-                const accessiblePrograms = programs.filter(program =>
-                    GCRStorageProgramRoutines.checkReadPermission(
-                        program,
-                        requesterAddress,
-                    ),
-                )
 
                 response.response = accessiblePrograms.map(p => ({
                     storageAddress: p.storageAddress,
@@ -432,7 +429,10 @@ export default async function manageGCRRoutines(
                     .getDataSource()
                     .getRepository(GCRStorageProgram)
 
-                const programs =
+                // ACL filtering happens in SQL so LIMIT/OFFSET produce full
+                // pages (no post-fetch JS filter that would silently shorten
+                // them).
+                const accessiblePrograms =
                     await GCRStorageProgramRoutines.searchStorageProgramsByName(
                         typeof query === "string"
                             ? query.trim()
@@ -442,16 +442,13 @@ export default async function manageGCRRoutines(
                             limit: options.limit || 50,
                             offset: options.offset || 0,
                             exactMatch: options.exactMatch || false,
+                            requesterAddress:
+                                typeof requesterAddress === "string" &&
+                                requesterAddress.length > 0
+                                    ? requesterAddress
+                                    : undefined,
                         },
                     )
-
-                // Filter to only programs the requester can read
-                const accessiblePrograms = programs.filter(program =>
-                    GCRStorageProgramRoutines.checkReadPermission(
-                        program,
-                        requesterAddress,
-                    ),
-                )
 
                 response.response = accessiblePrograms.map(p => ({
                     storageAddress: p.storageAddress,

--- a/src/libs/network/manageNodeCall.ts
+++ b/src/libs/network/manageNodeCall.ts
@@ -28,7 +28,15 @@ export async function manageNodeCall(content: NodeCall): Promise<RPCResponse> {
         return await handler(data, response)
     }
 
-    log.warning("[SERVER] Received unknown message")
-    response.response = '{ error: "Unknown message"}'
+    // Return a real 404 with a structured error body so SDK clients can
+    // detect unsupported methods. The previous implementation returned 200
+    // with a Python-dict-shaped string, which the SDK couldn't distinguish
+    // from a successful response.
+    log.warning(`[SERVER] Received unknown message: ${content?.message}`)
+    response.result = 404
+    response.response = {
+        error: "Unknown message",
+        message: content?.message,
+    }
     return response
 }

--- a/src/libs/network/middleware/rateLimiter.ts
+++ b/src/libs/network/middleware/rateLimiter.ts
@@ -282,6 +282,15 @@ export class RateLimiter {
                 return await next()
             }
 
+            // Skip rate limiting for infra/probe endpoints. LB and k8s
+            // liveness/readiness probes hit /health frequently from a single
+            // source IP and should never be 429-throttled. /version is small
+            // and equally cheap to serve unconditionally.
+            const path = new URL(req.url).pathname
+            if (path === "/health" || path === "/version") {
+                return await next()
+            }
+
             // Check for identity/signature headers for key-based whitelisting
             const identity = req.headers.get("identity")
             const signature = req.headers.get("signature")
@@ -435,6 +444,35 @@ export class RateLimiter {
 
             return await next()
         }
+    }
+
+    /**
+     * Return the current rate-limit window state for a given IP. Used by
+     * server_rpc to surface `X-RateLimit-{Limit,Remaining,Reset}` headers
+     * on POST `/` responses so SDK clients can self-throttle.
+     *
+     * Returns null when the IP has no active window yet (no requests seen).
+     */
+    public getCurrentLimits(ip: string): {
+        limit: number
+        remaining: number
+        resetEpochSeconds: number
+    } | null {
+        const ipData = this.ipRequests.get(ip)
+        if (!ipData) {
+            return null
+        }
+
+        // Match middleware: POST `/` resolves to the "POST" method bucket,
+        // falling back to defaultLimit when not configured explicitly.
+        const limitConfig = this.getLimitForMethod("POST")
+        const limit = limitConfig.maxRequests
+        const remaining = Math.max(0, limit - ipData.count)
+        const resetEpochSeconds = Math.floor(
+            (ipData.firstRequest + limitConfig.windowMs) / 1000,
+        )
+
+        return { limit, remaining, resetEpochSeconds }
     }
 
     public getStats(): {

--- a/src/libs/network/routines/nodecalls/getStorageProgram.ts
+++ b/src/libs/network/routines/nodecalls/getStorageProgram.ts
@@ -1,0 +1,47 @@
+import { RPCResponse } from "@kynesyslabs/demosdk/types"
+import log from "src/utilities/logger"
+import {
+    getAccessibleProgram,
+    rpc,
+    rpcInternalError,
+    toStorageProgramData,
+} from "./storageProgramShared"
+
+interface GetStorageProgramData {
+    storageAddress?: unknown
+    requesterAddress?: unknown
+}
+
+/**
+ * Read a single storage program by address.
+ *
+ * Returns 200/null when the program does not exist or is soft-deleted (the
+ * SDK treats null and 404 the same way; we favour 200/null per the
+ * cross-repo contract).
+ *
+ * Enforces ACL via checkReadPermission. Anonymous callers can read public
+ * programs; restricted/owner programs require requesterAddress.
+ */
+export default async function getStorageProgram(
+    data: GetStorageProgramData,
+): Promise<RPCResponse> {
+    try {
+        const requesterAddress =
+            typeof data?.requesterAddress === "string"
+                ? data.requesterAddress
+                : undefined
+
+        const result = await getAccessibleProgram(
+            data?.storageAddress,
+            requesterAddress,
+        )
+        if (result.error) {
+            return result.error
+        }
+
+        return rpc(200, toStorageProgramData(result.program!))
+    } catch (error) {
+        log.error("[getStorageProgram] Error:", error)
+        return rpcInternalError(error)
+    }
+}

--- a/src/libs/network/routines/nodecalls/getStorageProgramAll.ts
+++ b/src/libs/network/routines/nodecalls/getStorageProgramAll.ts
@@ -1,0 +1,45 @@
+import { RPCResponse } from "@kynesyslabs/demosdk/types"
+import log from "src/utilities/logger"
+import {
+    getAccessibleProgram,
+    rpc,
+    rpcInternalError,
+    toStorageProgramData,
+} from "./storageProgramShared"
+
+interface GetStorageProgramAllData {
+    storageAddress?: unknown
+    requesterAddress?: unknown
+}
+
+/**
+ * Read full storage program data by address.
+ *
+ * The SDK documents this as an "alias for getByAddress with full data" and
+ * types the response as `StorageProgramData`, so we return the same shape as
+ * `getStorageProgram` (Date fields converted to ISO 8601 strings).
+ *
+ * Returns 200/null when the program is missing / soft-deleted.
+ * Enforces ACL via checkReadPermission.
+ */
+export default async function getStorageProgramAll(
+    data: GetStorageProgramAllData,
+): Promise<RPCResponse> {
+    try {
+        const requesterAddress =
+            typeof data?.requesterAddress === "string"
+                ? data.requesterAddress
+                : undefined
+
+        const result = await getAccessibleProgram(
+            data?.storageAddress,
+            requesterAddress,
+        )
+        if (result.error) return result.error
+
+        return rpc(200, toStorageProgramData(result.program!))
+    } catch (error) {
+        log.error("[getStorageProgramAll] Error:", error)
+        return rpcInternalError(error)
+    }
+}

--- a/src/libs/network/routines/nodecalls/getStorageProgramFieldType.ts
+++ b/src/libs/network/routines/nodecalls/getStorageProgramFieldType.ts
@@ -1,0 +1,21 @@
+import {
+    getValueType,
+    rpc,
+    withFieldRead,
+} from "./storageProgramShared"
+
+/**
+ * Get the JSON type of a top-level field on a storage program.
+ *
+ * JSON-only: binary-encoded programs return 400 / INVALID_FIELD_TYPE.
+ * Field-not-found returns 404 / FIELD_NOT_FOUND (matches the HTTP route at
+ * features/storageprogram/routes.ts:513-578).
+ * Returns null when the program is missing / soft-deleted (200/null).
+ *
+ * The validate-resolve-checkType-checkField envelope is shared with sibling
+ * field-read handlers; see {@link withFieldRead}.
+ */
+export default withFieldRead(
+    "getStorageProgramFieldType",
+    ({ field, value }) => rpc(200, { field, type: getValueType(value) }),
+)

--- a/src/libs/network/routines/nodecalls/getStorageProgramFields.ts
+++ b/src/libs/network/routines/nodecalls/getStorageProgramFields.ts
@@ -1,0 +1,46 @@
+import { RPCResponse } from "@kynesyslabs/demosdk/types"
+import log from "src/utilities/logger"
+import {
+    getAccessibleProgram,
+    requireJsonObject,
+    rpc,
+    rpcInternalError,
+} from "./storageProgramShared"
+
+interface GetStorageProgramFieldsData {
+    storageAddress?: unknown
+    requesterAddress?: unknown
+}
+
+/**
+ * Get all top-level field names of a JSON storage program.
+ *
+ * JSON-only: binary-encoded programs return 400 / INVALID_FIELD_TYPE.
+ * Returns null when the program is missing / soft-deleted (200/null).
+ */
+export default async function getStorageProgramFields(
+    data: GetStorageProgramFieldsData,
+): Promise<RPCResponse> {
+    try {
+        const requesterAddress =
+            typeof data?.requesterAddress === "string"
+                ? data.requesterAddress
+                : undefined
+
+        const result = await getAccessibleProgram(
+            data?.storageAddress,
+            requesterAddress,
+        )
+        if (result.error) return result.error
+
+        const program = result.program!
+        const typeError = requireJsonObject(program)
+        if (typeError) return typeError
+
+        const fields = Object.keys(program.data as Record<string, unknown>)
+        return rpc(200, { fields, count: fields.length })
+    } catch (error) {
+        log.error("[getStorageProgramFields] Error:", error)
+        return rpcInternalError(error)
+    }
+}

--- a/src/libs/network/routines/nodecalls/getStorageProgramItem.ts
+++ b/src/libs/network/routines/nodecalls/getStorageProgramItem.ts
@@ -1,0 +1,88 @@
+import { RPCResponse } from "@kynesyslabs/demosdk/types"
+import log from "src/utilities/logger"
+import {
+    getAccessibleProgram,
+    requireJsonObject,
+    rpc,
+    rpcBadRequest,
+    rpcInternalError,
+} from "./storageProgramShared"
+
+interface GetStorageProgramItemData {
+    storageAddress?: unknown
+    field?: unknown
+    index?: unknown
+    requesterAddress?: unknown
+}
+
+/**
+ * Get an array element by index from a JSON storage program field.
+ *
+ * Supports negative indexing (-1 = last). JSON-only.
+ * Returns null when the program is missing / soft-deleted (200/null).
+ */
+export default async function getStorageProgramItem(
+    data: GetStorageProgramItemData,
+): Promise<RPCResponse> {
+    try {
+        if (typeof data?.field !== "string" || data.field.length === 0) {
+            return rpcBadRequest("Missing or invalid 'field' field")
+        }
+        const field = data.field
+
+        if (typeof data?.index !== "number" || !Number.isFinite(data.index)) {
+            return rpcBadRequest("Missing or invalid 'index' field")
+        }
+        const rawIndex = Math.trunc(data.index)
+
+        const requesterAddress =
+            typeof data?.requesterAddress === "string"
+                ? data.requesterAddress
+                : undefined
+
+        const result = await getAccessibleProgram(
+            data?.storageAddress,
+            requesterAddress,
+        )
+        if (result.error) return result.error
+
+        const program = result.program!
+        const typeError = requireJsonObject(program)
+        if (typeError) return typeError
+
+        const obj = program.data as Record<string, unknown>
+        if (!(field in obj)) {
+            return rpc(404, {
+                error: `Field not found: ${field}`,
+                errorCode: "FIELD_NOT_FOUND",
+            })
+        }
+
+        const arr = obj[field]
+        if (!Array.isArray(arr)) {
+            return rpc(400, {
+                error: `Field is not an array: ${field}`,
+                errorCode: "INVALID_FIELD_TYPE",
+            })
+        }
+
+        // Resolve negative indexing.
+        const resolvedIndex = rawIndex < 0 ? arr.length + rawIndex : rawIndex
+        if (resolvedIndex < 0 || resolvedIndex >= arr.length) {
+            return rpc(400, {
+                error: `Index out of bounds: ${rawIndex} (array length: ${arr.length})`,
+                errorCode: "INDEX_OUT_OF_BOUNDS",
+            })
+        }
+
+        return rpc(200, {
+            field,
+            index: resolvedIndex,
+            value: arr[resolvedIndex],
+            arrayLength: arr.length,
+        })
+    } catch (error) {
+        log.error("[getStorageProgramItem] Error:", error)
+        return rpcInternalError(error)
+    }
+}

--- a/src/libs/network/routines/nodecalls/getStorageProgramItem.ts
+++ b/src/libs/network/routines/nodecalls/getStorageProgramItem.ts
@@ -51,7 +51,9 @@ export default async function getStorageProgramItem(
         if (typeError) return typeError
 
         const obj = program.data as Record<string, unknown>
-        if (!(field in obj)) {
+        // Use own-property check so prototype keys (toString, __proto__,
+        // hasOwnProperty, ...) don't masquerade as user fields.
+        if (!Object.prototype.hasOwnProperty.call(obj, field)) {
             return rpc(404, {
                 error: `Field not found: ${field}`,
                 errorCode: "FIELD_NOT_FOUND",

--- a/src/libs/network/routines/nodecalls/getStorageProgramValue.ts
+++ b/src/libs/network/routines/nodecalls/getStorageProgramValue.ts
@@ -1,0 +1,20 @@
+import {
+    getValueType,
+    rpc,
+    withFieldRead,
+} from "./storageProgramShared"
+
+/**
+ * Get a single field's value from a JSON storage program.
+ *
+ * JSON-only: binary-encoded programs return 400 / INVALID_FIELD_TYPE.
+ * Field-not-found returns 404 / FIELD_NOT_FOUND (matches the HTTP route).
+ * Returns null when the program is missing / soft-deleted (200/null).
+ *
+ * The validate-resolve-checkType-checkField envelope is shared with sibling
+ * field-read handlers; see {@link withFieldRead}.
+ */
+export default withFieldRead(
+    "getStorageProgramValue",
+    ({ field, value }) => rpc(200, { field, value, type: getValueType(value) }),
+)

--- a/src/libs/network/routines/nodecalls/getStorageProgramsByOwner.ts
+++ b/src/libs/network/routines/nodecalls/getStorageProgramsByOwner.ts
@@ -17,15 +17,15 @@ interface GetStorageProgramsByOwnerData {
 }
 
 /**
- * List storage programs owned by an address, ACL-filtered for the requester.
+ * List storage programs owned by an address, ACL-filtered for the requester
+ * and paginated at the SQL layer.
  *
  * Owner sees all their own programs. Other requesters see only programs they
  * have read access to (per checkReadPermission).
  *
  * Pagination: limit clamped to [1, 200] (default 100), offset >= 0 (default 0).
- * Mirrors the HTTP route at features/storageprogram/routes.ts:617-696, but
- * paginates the post-filter list (HTTP route currently does not paginate this
- * endpoint).
+ * The default will drop to 100 in a future release — callers that rely on
+ * the implicit cap should pass an explicit `limit`.
  *
  * Always returns an array — never null.
  */
@@ -49,20 +49,20 @@ export default async function getStorageProgramsByOwner(
         const rawOffset = typeof data?.offset === "number" ? data.offset : 0
         const offset = Math.max(0, Math.floor(rawOffset))
 
-        // ACL filtering happens in SQL — GCRStorageProgramRoutines handles
-        // the owner-fast-path internally when requesterAddress === owner.
-        // Anonymous and non-owner requesters get the SQL ACL predicate so
-        // pagination produces full pages and never leaks restricted rows.
+        // SQL-level pagination: the routine applies LIMIT/OFFSET directly
+        // and never materialises the full owner result set in memory. The
+        // owner-fast-path (requesterAddress === owner) skips the jsonb ACL
+        // predicate and uses the existing owner index.
         const repository = await getStorageProgramRepository()
         const accessiblePrograms =
             await GCRStorageProgramRoutines.getStorageProgramsByOwner(
                 owner,
                 repository,
                 requesterAddress,
+                { limit, offset },
             )
 
-        const paginated = accessiblePrograms.slice(offset, offset + limit)
-        return rpc(200, paginated.map(toStorageProgramListItem))
+        return rpc(200, accessiblePrograms.map(toStorageProgramListItem))
     } catch (error) {
         log.error("[getStorageProgramsByOwner] Error:", error)
         return rpcInternalError(error)

--- a/src/libs/network/routines/nodecalls/getStorageProgramsByOwner.ts
+++ b/src/libs/network/routines/nodecalls/getStorageProgramsByOwner.ts
@@ -1,0 +1,70 @@
+import { RPCResponse } from "@kynesyslabs/demosdk/types"
+import log from "src/utilities/logger"
+import { GCRStorageProgramRoutines } from "src/libs/blockchain/gcr/gcr_routines/GCRStorageProgramRoutines"
+import {
+    getStorageProgramRepository,
+    rpc,
+    rpcBadRequest,
+    rpcInternalError,
+    toStorageProgramListItem,
+} from "./storageProgramShared"
+
+interface GetStorageProgramsByOwnerData {
+    owner?: unknown
+    requesterAddress?: unknown
+    limit?: unknown
+    offset?: unknown
+}
+
+/**
+ * List storage programs owned by an address, ACL-filtered for the requester.
+ *
+ * Owner sees all their own programs. Other requesters see only programs they
+ * have read access to (per checkReadPermission).
+ *
+ * Pagination: limit clamped to [1, 200] (default 100), offset >= 0 (default 0).
+ * Mirrors the HTTP route at features/storageprogram/routes.ts:617-696, but
+ * paginates the post-filter list (HTTP route currently does not paginate this
+ * endpoint).
+ *
+ * Always returns an array — never null.
+ */
+export default async function getStorageProgramsByOwner(
+    data: GetStorageProgramsByOwnerData,
+): Promise<RPCResponse> {
+    try {
+        if (typeof data?.owner !== "string" || data.owner.length === 0) {
+            return rpcBadRequest("Missing or invalid 'owner' field")
+        }
+        const owner = data.owner
+
+        const requesterAddress =
+            typeof data?.requesterAddress === "string" &&
+            data.requesterAddress.length > 0
+                ? data.requesterAddress
+                : undefined
+
+        const rawLimit = typeof data?.limit === "number" ? data.limit : 100
+        const limit = Math.min(Math.max(1, Math.floor(rawLimit)), 200)
+        const rawOffset = typeof data?.offset === "number" ? data.offset : 0
+        const offset = Math.max(0, Math.floor(rawOffset))
+
+        // ACL filtering happens in SQL — GCRStorageProgramRoutines handles
+        // the owner-fast-path internally when requesterAddress === owner.
+        // Anonymous and non-owner requesters get the SQL ACL predicate so
+        // pagination produces full pages and never leaks restricted rows.
+        const repository = await getStorageProgramRepository()
+        const accessiblePrograms =
+            await GCRStorageProgramRoutines.getStorageProgramsByOwner(
+                owner,
+                repository,
+                requesterAddress,
+            )
+
+        const paginated = accessiblePrograms.slice(offset, offset + limit)
+        return rpc(200, paginated.map(toStorageProgramListItem))
+    } catch (error) {
+        log.error("[getStorageProgramsByOwner] Error:", error)
+        return rpcInternalError(error)
+    }
+}

--- a/src/libs/network/routines/nodecalls/getTransactionStatus.ts
+++ b/src/libs/network/routines/nodecalls/getTransactionStatus.ts
@@ -1,0 +1,54 @@
+import { RPCResponse } from "@kynesyslabs/demosdk/types"
+import Chain from "src/libs/blockchain/chain"
+import log from "src/utilities/logger"
+
+const TX_HASH_REGEX = /^[0-9a-fA-F]{64}$/
+
+interface InterfaceGetTransactionStatusData {
+    hash: unknown
+}
+
+/**
+ * Returns the lifecycle state of a transaction by hash:
+ *   - "pending"  — present in mempool
+ *   - "included" — present in transactions table (with blockNumber)
+ *   - "failed"   — reserved (not currently produced — see Chain.getTransactionStatus)
+ *   - "unknown"  — not found anywhere
+ */
+export default async function getTransactionStatus(
+    data: InterfaceGetTransactionStatusData,
+): Promise<RPCResponse> {
+    const hash = data?.hash
+    if (typeof hash !== "string" || !TX_HASH_REGEX.test(hash)) {
+        return {
+            result: 400,
+            response: { error: "Missing or invalid 'hash' field" },
+            extra: "",
+            require_reply: false,
+        }
+    }
+    const normalizedHash = hash.toLowerCase()
+
+    try {
+        const status = await Chain.getTransactionStatus(normalizedHash)
+        return {
+            result: 200,
+            response: status,
+            extra: "",
+            require_reply: false,
+        }
+    } catch (error) {
+        log.error(
+            "[getTransactionStatus] Error fetching tx status:",
+            error,
+        )
+        return {
+            result: 500,
+            response: { error: "INTERNAL_ERROR" },
+            extra: `Error: ${
+                error instanceof Error ? error.message : "Unknown error"
+            }`,
+            require_reply: false,
+        }
+    }
+}

--- a/src/libs/network/routines/nodecalls/hasStorageProgramField.ts
+++ b/src/libs/network/routines/nodecalls/hasStorageProgramField.ts
@@ -47,8 +47,13 @@ export default async function hasStorageProgramField(
             program.data &&
             typeof program.data === "object" &&
             !Array.isArray(program.data)
+        // Use own-property check so prototype keys (toString, __proto__,
+        // hasOwnProperty, ...) don't masquerade as user fields.
         const exists = isJsonObject
-            ? field in (program.data as Record<string, unknown>)
+            ? Object.prototype.hasOwnProperty.call(
+                  program.data as Record<string, unknown>,
+                  field,
+              )
             : false
 
         return rpc(200, { field, exists })

--- a/src/libs/network/routines/nodecalls/hasStorageProgramField.ts
+++ b/src/libs/network/routines/nodecalls/hasStorageProgramField.ts
@@ -1,0 +1,59 @@
+import { RPCResponse } from "@kynesyslabs/demosdk/types"
+import log from "src/utilities/logger"
+import {
+    getAccessibleProgram,
+    rpc,
+    rpcBadRequest,
+    rpcInternalError,
+} from "./storageProgramShared"
+
+interface HasStorageProgramFieldData {
+    storageAddress?: unknown
+    field?: unknown
+    requesterAddress?: unknown
+}
+
+/**
+ * Check whether a top-level field exists on a JSON storage program.
+ *
+ * JSON-only: for binary / non-object data we return `exists: false` rather
+ * than 400, mirroring the HTTP route at features/storageprogram/routes.ts:464-510
+ * (which treats non-object data as "no fields").
+ *
+ * Returns null when the program is missing / soft-deleted (200/null).
+ */
+export default async function hasStorageProgramField(
+    data: HasStorageProgramFieldData,
+): Promise<RPCResponse> {
+    try {
+        if (typeof data?.field !== "string" || data.field.length === 0) {
+            return rpcBadRequest("Missing or invalid 'field' field")
+        }
+        const field = data.field
+
+        const requesterAddress =
+            typeof data?.requesterAddress === "string"
+                ? data.requesterAddress
+                : undefined
+
+        const result = await getAccessibleProgram(
+            data?.storageAddress,
+            requesterAddress,
+        )
+        if (result.error) return result.error
+
+        const program = result.program!
+        const isJsonObject =
+            program.data &&
+            typeof program.data === "object" &&
+            !Array.isArray(program.data)
+        const exists = isJsonObject
+            ? field in (program.data as Record<string, unknown>)
+            : false
+
+        return rpc(200, { field, exists })
+    } catch (error) {
+        log.error("[hasStorageProgramField] Error:", error)
+        return rpcInternalError(error)
+    }
+}

--- a/src/libs/network/routines/nodecalls/searchStoragePrograms.ts
+++ b/src/libs/network/routines/nodecalls/searchStoragePrograms.ts
@@ -1,0 +1,82 @@
+import { RPCResponse } from "@kynesyslabs/demosdk/types"
+import log from "src/utilities/logger"
+import { GCRStorageProgramRoutines } from "src/libs/blockchain/gcr/gcr_routines/GCRStorageProgramRoutines"
+import {
+    getStorageProgramRepository,
+    rpc,
+    rpcBadRequest,
+    rpcInternalError,
+    toStorageProgramListItem,
+} from "./storageProgramShared"
+
+interface SearchStorageProgramsOptions {
+    limit?: unknown
+    offset?: unknown
+    exactMatch?: unknown
+    exact?: unknown
+}
+
+interface SearchStorageProgramsData {
+    query?: unknown
+    options?: SearchStorageProgramsOptions
+    requesterAddress?: unknown
+}
+
+/**
+ * Search storage programs by name (partial match by default, exact when
+ * options.exactMatch is true). Results are ACL-filtered for the requester.
+ *
+ * Pagination: limit clamped to [1, 200] (default 100), offset >= 0 (default 0).
+ * Matches the HTTP route at features/storageprogram/routes.ts:707-787.
+ *
+ * The SDK sends `options.exactMatch`; we also accept `options.exact` as a
+ * fallback.
+ *
+ * Always returns an array — never null.
+ */
+export default async function searchStoragePrograms(
+    data: SearchStorageProgramsData,
+): Promise<RPCResponse> {
+    try {
+        if (
+            typeof data?.query !== "string" ||
+            data.query.trim().length === 0
+        ) {
+            return rpcBadRequest("Missing or invalid 'query' field")
+        }
+        const query = data.query.trim()
+
+        const requesterAddress =
+            typeof data?.requesterAddress === "string" &&
+            data.requesterAddress.length > 0
+                ? data.requesterAddress
+                : undefined
+
+        const opts = data?.options ?? {}
+        const rawLimit = typeof opts.limit === "number" ? opts.limit : 100
+        const limit = Math.min(Math.max(1, Math.floor(rawLimit)), 200)
+        const rawOffset = typeof opts.offset === "number" ? opts.offset : 0
+        const offset = Math.max(0, Math.floor(rawOffset))
+        const exactMatch =
+            typeof opts.exactMatch === "boolean"
+                ? opts.exactMatch
+                : typeof opts.exact === "boolean"
+                  ? opts.exact
+                  : false
+
+        // ACL filtering happens in SQL so LIMIT/OFFSET produce full pages
+        // (no post-fetch JS filter that would silently shorten them).
+        const repository = await getStorageProgramRepository()
+        const programs =
+            await GCRStorageProgramRoutines.searchStorageProgramsByName(
+                query,
+                repository,
+                { limit, offset, exactMatch, requesterAddress },
+            )
+
+        return rpc(200, programs.map(toStorageProgramListItem))
+    } catch (error) {
+        log.error("[searchStoragePrograms] Error:", error)
+        return rpcInternalError(error)
+    }
+}

--- a/src/libs/network/routines/nodecalls/storageProgramShared.ts
+++ b/src/libs/network/routines/nodecalls/storageProgramShared.ts
@@ -53,13 +53,20 @@ export function rpcPermissionDenied(error = "Permission denied"): RPCResponse {
 
 /**
  * Internal error.
+ *
+ * Matches the `(error, errorCode)` envelope used by `rpcBadRequest` and
+ * `rpcPermissionDenied`: `error` carries the human-readable message and
+ * `errorCode` carries the stable machine identifier. SDK clients reading
+ * the standard envelope previously got `error === errorCode === "INTERNAL_ERROR"`
+ * and the actual message was buried in `extra` (which the SDK doesn't
+ * inspect on failure).
+ *
+ * Falls back to `String(error)` for non-Error throws so plain
+ * objects/numbers/null don't degrade to a generic "Unknown error".
  */
 export function rpcInternalError(error: unknown): RPCResponse {
-    return rpc(
-        500,
-        { error: "INTERNAL_ERROR", errorCode: "INTERNAL_ERROR" },
-        `Error: ${error instanceof Error ? error.message : "Unknown error"}`,
-    )
+    const message = error instanceof Error ? error.message : String(error)
+    return rpc(500, { error: message, errorCode: "INTERNAL_ERROR" })
 }
 
 /**

--- a/src/libs/network/routines/nodecalls/storageProgramShared.ts
+++ b/src/libs/network/routines/nodecalls/storageProgramShared.ts
@@ -273,7 +273,9 @@ export function withFieldRead(
             if (typeError) return typeError
 
             const obj = program.data as Record<string, unknown>
-            if (!(field in obj)) {
+            // Use own-property check so prototype keys (toString, __proto__,
+            // hasOwnProperty, ...) don't masquerade as user fields.
+            if (!Object.prototype.hasOwnProperty.call(obj, field)) {
                 return rpc(404, {
                     error: `Field not found: ${field}`,
                     errorCode: "FIELD_NOT_FOUND",

--- a/src/libs/network/routines/nodecalls/storageProgramShared.ts
+++ b/src/libs/network/routines/nodecalls/storageProgramShared.ts
@@ -250,7 +250,8 @@ export function withFieldRead(
             const field = data.field
 
             const requesterAddress =
-                typeof data?.requesterAddress === "string"
+                typeof data?.requesterAddress === "string" &&
+                data.requesterAddress.length > 0
                     ? data.requesterAddress
                     : undefined
 

--- a/src/libs/network/routines/nodecalls/storageProgramShared.ts
+++ b/src/libs/network/routines/nodecalls/storageProgramShared.ts
@@ -1,0 +1,281 @@
+import { RPCResponse } from "@kynesyslabs/demosdk/types"
+import Datasource from "src/model/datasource"
+import { GCRStorageProgram } from "src/model/entities/GCRv2/GCR_StorageProgram"
+import { GCRStorageProgramRoutines } from "src/libs/blockchain/gcr/gcr_routines/GCRStorageProgramRoutines"
+import log from "src/utilities/logger"
+
+export type StorageFieldType =
+    | "string"
+    | "number"
+    | "boolean"
+    | "array"
+    | "object"
+    | "null"
+    | "undefined"
+
+/**
+ * Build a populated RPCResponse envelope.
+ */
+export function rpc(
+    result: number,
+    response: unknown,
+    extra: unknown = "",
+): RPCResponse {
+    return {
+        result,
+        response,
+        extra: extra as any,
+        require_reply: false,
+    }
+}
+
+/**
+ * Standard 200-with-null response (used for not-found / soft-deleted single reads).
+ * The SDK treats both 404 and `response === null` the same way.
+ */
+export function rpcNull(): RPCResponse {
+    return rpc(200, null)
+}
+
+/**
+ * Bad input (missing / invalid param).
+ */
+export function rpcBadRequest(error: string, errorCode = "INVALID_REQUEST"): RPCResponse {
+    return rpc(400, { error, errorCode })
+}
+
+/**
+ * Permission denied.
+ */
+export function rpcPermissionDenied(error = "Permission denied"): RPCResponse {
+    return rpc(403, { error, errorCode: "PERMISSION_DENIED" })
+}
+
+/**
+ * Internal error.
+ */
+export function rpcInternalError(error: unknown): RPCResponse {
+    return rpc(
+        500,
+        { error: "INTERNAL_ERROR", errorCode: "INTERNAL_ERROR" },
+        `Error: ${error instanceof Error ? error.message : "Unknown error"}`,
+    )
+}
+
+/**
+ * Resolve the JS type of a JSON value (matches SDK StorageFieldType).
+ */
+export function getValueType(value: unknown): StorageFieldType {
+    if (value === undefined) return "undefined"
+    if (value === null) return "null"
+    if (Array.isArray(value)) return "array"
+    if (typeof value === "string") return "string"
+    if (typeof value === "number") return "number"
+    if (typeof value === "boolean") return "boolean"
+    return "object"
+}
+
+/**
+ * Get the GCRStorageProgram repository.
+ */
+export async function getStorageProgramRepository() {
+    const db = await Datasource.getInstance()
+    return db.getDataSource().getRepository(GCRStorageProgram)
+}
+
+/**
+ * Validate a storageAddress and fetch the program with ACL enforcement.
+ *
+ * Returns either:
+ *   - { program } on success, or
+ *   - { error: RPCResponse } when the address is invalid, the program is missing
+ *     (or soft-deleted) — returns 200/null per the SDK contract — or read access
+ *     is denied (403).
+ */
+export async function getAccessibleProgram(
+    storageAddress: unknown,
+    requesterAddress?: string,
+): Promise<{ program?: GCRStorageProgram; error?: RPCResponse }> {
+    if (typeof storageAddress !== "string" || storageAddress.length === 0) {
+        return {
+            error: rpcBadRequest("Missing or invalid 'storageAddress' field"),
+        }
+    }
+    if (!storageAddress.startsWith("stor-")) {
+        return {
+            error: rpcBadRequest(
+                "Invalid storage address format. Expected: stor-{hash}",
+            ),
+        }
+    }
+
+    const repository = await getStorageProgramRepository()
+    const program = await GCRStorageProgramRoutines.getStorageProgram(
+        storageAddress,
+        repository,
+    )
+    if (!program) {
+        // Not-found / soft-deleted -> SDK contract: return 200 + null.
+        return { error: rpcNull() }
+    }
+
+    const hasReadAccess = GCRStorageProgramRoutines.checkReadPermission(
+        program,
+        requesterAddress,
+    )
+    if (!hasReadAccess) {
+        return {
+            error: rpcPermissionDenied(
+                "Permission denied: You do not have read access to this storage program",
+            ),
+        }
+    }
+
+    return { program }
+}
+
+/**
+ * Map a GCRStorageProgram entity to the SDK's StorageProgramData shape
+ * (Date -> ISO 8601 string).
+ */
+export function toStorageProgramData(p: GCRStorageProgram) {
+    return {
+        storageAddress: p.storageAddress,
+        owner: p.owner,
+        programName: p.programName,
+        encoding: p.encoding,
+        data: p.data,
+        metadata: p.metadata,
+        storageLocation: p.storageLocation,
+        sizeBytes: p.sizeBytes,
+        createdAt: p.createdAt.toISOString(),
+        updatedAt: p.updatedAt.toISOString(),
+        createdByTx: p.createdByTx,
+        lastModifiedByTx: p.lastModifiedByTx,
+        interactionTxs: p.interactionTxs,
+    }
+}
+
+/**
+ * Map a GCRStorageProgram entity to the SDK's StorageProgramListItem shape.
+ */
+export function toStorageProgramListItem(p: GCRStorageProgram) {
+    return {
+        storageAddress: p.storageAddress,
+        programName: p.programName,
+        encoding: p.encoding,
+        sizeBytes: p.sizeBytes,
+        storageLocation: p.storageLocation,
+        createdAt: p.createdAt.toISOString(),
+        updatedAt: p.updatedAt.toISOString(),
+    }
+}
+
+/**
+ * Validate the program holds JSON object data (granular ops are JSON-only).
+ *
+ * Returns an error RPCResponse on mismatch, or undefined when the data is a
+ * plain JSON object.
+ */
+export function requireJsonObject(
+    program: GCRStorageProgram,
+): RPCResponse | undefined {
+    if (
+        !program.data ||
+        typeof program.data !== "object" ||
+        Array.isArray(program.data)
+    ) {
+        return rpc(400, {
+            error: `Field operations are only available for JSON object data. Found: ${
+                Array.isArray(program.data) ? "array" : typeof program.data
+            }.`,
+            errorCode: "INVALID_FIELD_TYPE",
+        })
+    }
+    return undefined
+}
+
+/**
+ * Input shape consumed by every JSON-object field-read handler.
+ */
+export interface FieldReadInput {
+    storageAddress?: unknown
+    field?: unknown
+    requesterAddress?: unknown
+}
+
+/**
+ * Context handed to a field-read reducer once all the envelope checks pass.
+ */
+export interface FieldReadContext {
+    field: string
+    value: unknown
+    program: GCRStorageProgram
+}
+
+/**
+ * Higher-order helper that handles the common envelope shared by the
+ * "single JSON field read" RPC handlers (getStorageProgramValue,
+ * getStorageProgramFieldType, ...).
+ *
+ * The envelope is identical across these handlers:
+ *   1. validate `field` arg (non-empty string) -> 400 / INVALID_REQUEST
+ *   2. coerce `requesterAddress` to string|undefined
+ *   3. resolve the program with ACL enforcement (404/403/null already
+ *      handled inside getAccessibleProgram)
+ *   4. require JSON object data -> 400 / INVALID_FIELD_TYPE
+ *   5. confirm the requested field exists on the object -> 404 /
+ *      FIELD_NOT_FOUND
+ *   6. delegate the response shape to the reducer
+ *   7. catch + log + 500 / INTERNAL_ERROR
+ *
+ * The reducer is the only thing that varies between handlers, so we keep
+ * it tiny: it receives the resolved {field, value, program} and returns
+ * the RPCResponse the handler wants to ship.
+ *
+ * @param handlerName - Used for the log prefix (e.g. "getStorageProgramValue")
+ * @param reducer - Builds the success RPCResponse from the resolved field
+ */
+export function withFieldRead(
+    handlerName: string,
+    reducer: (ctx: FieldReadContext) => RPCResponse,
+): (data: FieldReadInput) => Promise<RPCResponse> {
+    return async function fieldReadHandler(
+        data: FieldReadInput,
+    ): Promise<RPCResponse> {
+        try {
+            if (typeof data?.field !== "string" || data.field.length === 0) {
+                return rpcBadRequest("Missing or invalid 'field' field")
+            }
+            const field = data.field
+
+            const requesterAddress =
+                typeof data?.requesterAddress === "string"
+                    ? data.requesterAddress
+                    : undefined
+
+            const result = await getAccessibleProgram(
+                data?.storageAddress,
+                requesterAddress,
+            )
+            if (result.error) return result.error
+
+            const program = result.program!
+            const typeError = requireJsonObject(program)
+            if (typeError) return typeError
+
+            const obj = program.data as Record<string, unknown>
+            if (!(field in obj)) {
+                return rpc(404, {
+                    error: `Field not found: ${field}`,
+                    errorCode: "FIELD_NOT_FOUND",
+                })
+            }
+
+            return reducer({ field, value: obj[field], program })
+        } catch (error) {
+            log.error(`[${handlerName}] Error:`, error)
+            return rpcInternalError(error)
+        }
+    }
+}

--- a/src/libs/network/server_rpc.ts
+++ b/src/libs/network/server_rpc.ts
@@ -4,6 +4,7 @@ import log from "src/utilities/logger"
 import sharedState, { getSharedState } from "src/utilities/sharedState"
 import { PeerManager } from "../peer"
 import Chain from "../blockchain/chain"
+import Mempool from "../blockchain/mempool"
 import { BunServer, cors, json, jsonResponse } from "./bunServer"
 import { RateLimiter } from "./middleware/rateLimiter"
 import { getAuthContext } from "./authContext"
@@ -49,6 +50,35 @@ export async function serverRpcBun() {
             version_name: getSharedState.version_name,
             ...info,
         })
+    })
+
+    server.get("/health", async () => {
+        // Accepting traffic only when fully synced and not in the middle of
+        // a sync loop.
+        const accepting =
+            getSharedState.syncStatus && !getSharedState.inSyncLoop
+
+        // Mempool.count() hits the DB; isolate failures so a transient DB
+        // outage doesn't 500 the health probe.
+        let mempoolSize: number | null = null
+        try {
+            mempoolSize = await Mempool.count()
+        } catch (err) {
+            log.error("[/health] Mempool.count() failed:", err)
+        }
+
+        const body = {
+            version: getSharedState.version,
+            version_name: getSharedState.version_name,
+            accepting,
+            mempool_size: mempoolSize,
+            uptime_s: getSharedState.getUptimeSeconds(),
+        }
+
+        // Surface health via HTTP status so LB/k8s probes can detect an
+        // unhealthy node without parsing the JSON body.
+        const healthy = accepting && mempoolSize !== null
+        return jsonResponse(body, healthy ? 200 : 503)
     })
 
     server.get("/version", () => jsonResponse(getSharedState.version))
@@ -126,7 +156,18 @@ export async function serverRpcBun() {
             const authCtx = getAuthContext(req)
             const sender = authCtx.publicKey || ""
             const response = await processPayload(payload, sender)
-            return jsonResponse(response)
+
+            // Surface current rate-limit window so SDK clients can
+            // self-throttle (best-effort: skip when no IP data yet).
+            const limits = rateLimiter.getCurrentLimits(clientIP)
+            const extraHeaders = limits
+                ? {
+                      "X-RateLimit-Limit": String(limits.limit),
+                      "X-RateLimit-Remaining": String(limits.remaining),
+                      "X-RateLimit-Reset": String(limits.resetEpochSeconds),
+                  }
+                : undefined
+            return jsonResponse(response, 200, extraHeaders)
         } catch (e) {
             handleError(e, "NETWORK", { source: "serverRpcBun" })
             return jsonResponse({ error: "Invalid request format" }, 400)

--- a/src/utilities/sharedState.ts
+++ b/src/utilities/sharedState.ts
@@ -47,6 +47,17 @@ export default class SharedState {
     version_name = APP_VERSION_NAME
     signingAlgorithm = DEFAULT_SIGNING_ALGORITHM as SigningAlgorithm
 
+    // Node start time in milliseconds since epoch — set when this singleton
+    // is first imported. Used by /health to report uptime.
+    nodeStartTime = Date.now()
+
+    /**
+     * Seconds since the node process started, rounded down. Used by /health.
+     */
+    public getUptimeSeconds(): number {
+        return Math.floor((Date.now() - this.nodeStartTime) / 1000)
+    }
+
     block_time = DEFAULT_BLOCK_TIME // TODO Get it from the genesis (or see Consensus module)
 
     currentTimestamp = 0

--- a/tests/storageprogram/routines.test.ts
+++ b/tests/storageprogram/routines.test.ts
@@ -1126,8 +1126,17 @@ describe("GCRStorageProgramRoutines", () => {
 
             expect(repo.find).not.toHaveBeenCalled()
             expect(repo.createQueryBuilder).toHaveBeenCalledWith("sp")
-            // Anonymous gets the public-only branch, no requesterAddress param.
-            expect(findAndWhereCall(qb, "'public'")).toBeDefined()
+            // Anonymous gets the public-only branch — must contain 'public'
+            // AND must NOT bind requesterAddress (the identified branch also
+            // contains 'public', so a less strict assertion would pass for
+            // the wrong branch).
+            const hasPublicOnly = qb.andWhere.mock.calls.some(
+                (c: unknown[]) =>
+                    typeof c[0] === "string" &&
+                    (c[0] as string).includes("'public'") &&
+                    !(c[0] as string).includes(":requesterAddress"),
+            )
+            expect(hasPublicOnly).toBe(true)
         })
 
         it("getStorageProgramsByOwner non-owner requester binds requesterAddress to ACL predicate", async () => {

--- a/tests/storageprogram/routines.test.ts
+++ b/tests/storageprogram/routines.test.ts
@@ -36,9 +36,10 @@ const entityFixtures = JSON.parse(
 let GCRStorageProgramRoutines: typeof import("src/libs/blockchain/gcr/gcr_routines/GCRStorageProgramRoutines")["GCRStorageProgramRoutines"]
 
 beforeAll(async () => {
-    ;({ GCRStorageProgramRoutines } = await import(
+    const mod = await import(
         "src/libs/blockchain/gcr/gcr_routines/GCRStorageProgramRoutines"
-    ))
+    )
+    GCRStorageProgramRoutines = mod.GCRStorageProgramRoutines
 })
 
 function createMockRepository() {
@@ -55,6 +56,55 @@ function createMockRepository() {
             getMany: jest.fn().mockResolvedValue([]),
         })),
     }
+}
+
+/**
+ * Build a chainable QueryBuilder mock. The chain methods return `this`, and
+ * `getMany` resolves with the rows the test wants the DB to "return".
+ *
+ * `withPagination: true` adds the `take`/`skip` chain methods used by the
+ * search routine (the by-owner routine's QueryBuilder path doesn't paginate).
+ */
+type MockQB = {
+    where: jest.Mock
+    andWhere: jest.Mock
+    orderBy: jest.Mock
+    getMany: jest.Mock
+    take?: jest.Mock
+    skip?: jest.Mock
+}
+function makeMockQueryBuilder(options?: {
+    rows?: unknown[]
+    withPagination?: boolean
+}): MockQB {
+    const qb: MockQB = {
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        getMany: jest
+            .fn<() => Promise<unknown[]>>()
+            .mockResolvedValue(options?.rows ?? []),
+    }
+    if (options?.withPagination) {
+        qb.take = jest.fn().mockReturnThis()
+        qb.skip = jest.fn().mockReturnThis()
+    }
+    return qb
+}
+
+/**
+ * Find the andWhere() call whose SQL fragment matches a substring. Returns
+ * the [sql, params] tuple or undefined. Used to assert that a specific ACL
+ * branch was added to the QueryBuilder.
+ */
+function findAndWhereCall(
+    qb: MockQB,
+    sqlFragment: string,
+): [string, Record<string, unknown> | undefined] | undefined {
+    return qb.andWhere.mock.calls.find(
+        (c: unknown[]) =>
+            typeof c[0] === "string" && (c[0] as string).includes(sqlFragment),
+    ) as [string, Record<string, unknown> | undefined] | undefined
 }
 
 function makeEdit(
@@ -1042,7 +1092,9 @@ describe("GCRStorageProgramRoutines", () => {
             expect(result?.storageAddress).toBe("stor-abc123def456")
         })
 
-        it("getStorageProgramsByOwner returns non-deleted only", async () => {
+        it("getStorageProgramsByOwner owner fast-path uses repo.find with owner index", async () => {
+            // When the requester IS the owner, we skip the jsonb ACL
+            // predicate and rely on the existing owner index for max speed.
             repo.find.mockResolvedValue([
                 entityFixtures.public_json_program,
             ])
@@ -1051,6 +1103,7 @@ describe("GCRStorageProgramRoutines", () => {
                 await GCRStorageProgramRoutines.getStorageProgramsByOwner(
                     "owner_addr_1",
                     repo as any,
+                    "owner_addr_1",
                 )
             expect(results.length).toBeGreaterThan(0)
             expect(repo.find).toHaveBeenCalledWith(
@@ -1058,6 +1111,94 @@ describe("GCRStorageProgramRoutines", () => {
                     where: { owner: "owner_addr_1", isDeleted: false },
                 }),
             )
+        })
+
+        it("getStorageProgramsByOwner anonymous goes through SQL ACL filter (not repo.find)", async () => {
+            // Anonymous caller: must NOT take the owner fast-path. The
+            // QueryBuilder is invoked with the public-only ACL predicate.
+            const qb = makeMockQueryBuilder()
+            repo.createQueryBuilder = jest.fn(() => qb) as any
+
+            await GCRStorageProgramRoutines.getStorageProgramsByOwner(
+                "owner_addr_1",
+                repo as any,
+            )
+
+            expect(repo.find).not.toHaveBeenCalled()
+            expect(repo.createQueryBuilder).toHaveBeenCalledWith("sp")
+            // Anonymous gets the public-only branch, no requesterAddress param.
+            expect(findAndWhereCall(qb, "'public'")).toBeDefined()
+        })
+
+        it("getStorageProgramsByOwner non-owner requester binds requesterAddress to ACL predicate", async () => {
+            const qb = makeMockQueryBuilder()
+            repo.createQueryBuilder = jest.fn(() => qb) as any
+
+            await GCRStorageProgramRoutines.getStorageProgramsByOwner(
+                "owner_addr_1",
+                repo as any,
+                "addr_allowed_1",
+            )
+
+            // ACL predicate is added with requesterAddress bound as a
+            // parameter — this protects against SQL injection.
+            const aclCall = findAndWhereCall(qb, ":requesterAddress")
+            expect(aclCall).toBeDefined()
+            expect(aclCall?.[1]).toMatchObject({
+                requesterAddress: "addr_allowed_1",
+            })
+        })
+
+        it("searchStorageProgramsByName ACL-filters at SQL layer (no post-filter shortening of pages)", async () => {
+            // Regression test for the post-pagination ACL bug. Even when
+            // the DB page returns just one row (because the rest were
+            // filtered out by the SQL ACL predicate), we should pass that
+            // through unchanged — pagination is the DB's job, not JS's.
+            const accessibleRow = entityFixtures.public_json_program
+            const qb = makeMockQueryBuilder({
+                rows: [accessibleRow],
+                withPagination: true,
+            })
+            repo.createQueryBuilder = jest.fn(() => qb) as any
+
+            const results =
+                await GCRStorageProgramRoutines.searchStorageProgramsByName(
+                    "config",
+                    repo as any,
+                    {
+                        limit: 10,
+                        offset: 0,
+                        requesterAddress: "addr_allowed_1",
+                    },
+                )
+
+            expect(results).toEqual([accessibleRow])
+            // SQL pagination really happens (no post-filter slice).
+            expect(qb.take).toHaveBeenCalledWith(10)
+            expect(qb.skip).toHaveBeenCalledWith(0)
+            // ACL predicate is applied with requesterAddress.
+            expect(findAndWhereCall(qb, ":requesterAddress")).toBeDefined()
+        })
+
+        it("searchStorageProgramsByName anonymous receives only public branch", async () => {
+            const qb = makeMockQueryBuilder({ withPagination: true })
+            repo.createQueryBuilder = jest.fn(() => qb) as any
+
+            await GCRStorageProgramRoutines.searchStorageProgramsByName(
+                "config",
+                repo as any,
+                { limit: 10, offset: 0 },
+            )
+
+            // Anonymous SQL is just `acl->>'mode' = 'public'` — no requester
+            // bind, no jsonb_each subquery for groups.
+            const hasPublicOnly = qb.andWhere.mock.calls.some(
+                (c: unknown[]) =>
+                    typeof c[0] === "string" &&
+                    (c[0] as string).includes("'public'") &&
+                    !(c[0] as string).includes(":requesterAddress"),
+            )
+            expect(hasPublicOnly).toBe(true)
         })
     })
 

--- a/tests/storageprogram/routines.test.ts
+++ b/tests/storageprogram/routines.test.ts
@@ -75,19 +75,22 @@ type MockQB = {
 }
 function makeMockQueryBuilder(options?: {
     rows?: unknown[]
+    /**
+     * Retained for backward compatibility — `take`/`skip` are now always
+     * mocked because both `searchStorageProgramsByName` and
+     * `getStorageProgramsByOwner` apply SQL pagination.
+     */
     withPagination?: boolean
 }): MockQB {
     const qb: MockQB = {
         where: jest.fn().mockReturnThis(),
         andWhere: jest.fn().mockReturnThis(),
         orderBy: jest.fn().mockReturnThis(),
+        take: jest.fn().mockReturnThis(),
+        skip: jest.fn().mockReturnThis(),
         getMany: jest
             .fn<() => Promise<unknown[]>>()
             .mockResolvedValue(options?.rows ?? []),
-    }
-    if (options?.withPagination) {
-        qb.take = jest.fn().mockReturnThis()
-        qb.skip = jest.fn().mockReturnThis()
     }
     return qb
 }


### PR DESCRIPTION
Replaces #796 (closed — wrong base branch).

Lands the storage-program read RPC family, `/health` endpoint, rate-limit
client signal, and the security/correctness review fixes from PR #796 —
all adapted to stabilisation's modular handler-registry architecture.

## What's in this PR

### Features

- **9 storage-program read RPCs** (`getStorageProgram`, `getStorageProgramAll`,
  `getStorageProgramFields`, `getStorageProgramFieldType`, `getStorageProgramItem`,
  `getStorageProgramValue`, `getStorageProgramsByOwner`, `hasStorageProgramField`,
  `searchStoragePrograms`) registered via a new `storageProgramHandlers` module
  in the modular dispatch registry.
- **`getTransactionStatus` RPC** for transaction lifecycle tracking (pending /
  included / unknown), with sha256-hex regex validation and case-insensitive
  normalised lookup.
- **`GET /health`** endpoint reporting `{version, version_name, accepting,
  mempool_size, uptime_s}`. Returns HTTP 503 when the node isn't accepting
  traffic or the mempool DB is unreachable, so LB/k8s probes can detect
  unhealthy nodes by status code alone.
- **`X-RateLimit-{Limit,Remaining,Reset}` headers** on POST `/` responses so
  SDK clients can self-throttle.
- **`/health` and `/version` exempt** from the global rate limiter so probes
  can't be 429-throttled under load.

### Fixes (security / correctness)

- **Unknown-message dispatcher**: returns HTTP 404 with `{error, message}`
  instead of HTTP 200 with a Python-dict-shaped string. SDK clients can now
  detect unsupported methods.
- **ACL bypass** (was P1): the `!requesterAddress || ... === owner` pattern
  treated anonymous (undefined or empty-string) callers as the owner and
  leaked owner/restricted programs. Fixed in both the new RPC handler and
  the older HTTP route handler.
- **Post-pagination ACL filter**: `searchStorageProgramsByName` paginated at
  the SQL layer then JS-filtered, producing short pages and hidden
  accessible rows. Now uses a jsonb WHERE predicate that mirrors
  `checkReadPermission` exactly, so LIMIT/OFFSET produce full pages.

### Hardening

- `jsonResponse` accepts `extraHeaders` and forces Content-Type last so
  caller-supplied headers can't override the JSON content type.
- Storage program error logs pass the `error` object as a separate argument
  instead of string-concatenating, preserving non-Error throws as
  diagnostic data instead of `[object Object]`.

## Performance — SQL ACL filter design notes

The post-pagination ACL fix is the only place where the perf surface
materially changed. Highlights:

- **Owner fast-path**: `requesterAddress === owner` skips the jsonb
  predicate entirely, uses `idx_gcr_storageprogram_owner`. Same plan as
  before for the common owner-lists-own-programs case.
- **Anonymous fast-path**: predicate collapses to `acl->>'mode' = 'public'`
  — single text comparison, no jsonb_each subquery, no parameter bind.
- **No GIN index added** on `acl`: the query is already gated by ILIKE /
  owner / isDeleted, so the predicate runs on a small post-prune candidate
  set. Adding a GIN would slow every storage-program write (a hot path)
  for no win on this query.
- **JS-side**: strictly less work — only accessible rows are hydrated
  through the ORM and mapped through `toStorageProgramListItem`.

## Verification

- ESLint on changed files: 0 errors, 6 pre-existing `result.program!`
  non-null-assertion warnings (project-wide style)
- `tsc --noEmit` on changed files: clean — pre-existing errors in
  `chainBlocks.ts`, `chainTransactions.ts`, FHE/ZK tests are not
  introduced by this work (verified by stash-and-recheck)

## Tests

Regression tests added for:
- short-page case (one accessible row in the SQL window)
- owner fast-path (uses `repo.find` not QueryBuilder)
- anonymous-only-sees-public (no requester bind)
- SQL-injection safety (predicate uses bound `:requesterAddress` parameter)

## History

Originally targeted `testnet` as PR #796. Closed and reopened against
`stabilisation` per direction that stabilisation will replace testnet.
The original testnet branch (`claude/checkout-branches-WQCIg`) is
preserved at commit `8c9f6628` for history.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Transaction status RPC; storage program read/search/value/field endpoints; GET /health reports uptime and mempool size; rate-limit headers added to responses.

* **Bug Fixes**
  * Storage program pagination and ACL enforcement moved to the database layer to preserve correct results and pagination.

* **Refactor**
  * Improved structured error for unknown RPC messages.

* **Documentation**
  * Added planning document outlining SDK capability-detection approach.

* **Tests**
  * Expanded tests for storage program ACL and query behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->