### PR TITLE
feat(tlsnotary): support reverse-proxy routing in WS URL construction

### DIFF
--- a/src/features/tlsnotary/proxyManager.ts
+++ b/src/features/tlsnotary/proxyManager.ts
@@ -169,6 +169,23 @@ export function extractDomainAndPort(targetUrl: string): {
 }
 
 /**
+ * Build a public WebSocket URL from a base HTTP(S)/WS(S) URL and a local port.
+ * Path mode: when the base URL has a path, route through a reverse proxy at
+ * `url.host` (port preserved) that maps `<path>/<port>` to the local port
+ * (single nginx rule). No-path mode: connect directly to `url.hostname` on
+ * the target port.
+ */
+export function buildWsUrl(base: string, port: number | string): string {
+    const url = new URL(base)
+    const secure = url.protocol === "https:" || url.protocol === "wss:"
+    const wsScheme = secure ? "wss" : "ws"
+    const path = url.pathname.replace(/\/+$/, "")
+    return path
+        ? `${wsScheme}://${url.host}${path}/${port}/`
+        : `${wsScheme}://${url.hostname}:${port}`
+}
+
+/**
  * Build the public WebSocket URL for the proxy
  * @param localPort - Local port the proxy is listening on
  * @param requestOrigin - Optional request origin for auto-detection
@@ -178,16 +195,10 @@ export function getPublicUrl(
     localPort: number,
     requestOrigin?: string,
 ): string {
-    const build = (base: string) => {
-        const url = new URL(base)
-        const wsScheme = url.protocol === "https:" ? "wss" : "ws"
-        return `${wsScheme}://${url.hostname}:${localPort}`
-    }
-
     // 1. Try auto-detect from request origin (if available in headers)
     if (requestOrigin) {
         try {
-            return build(requestOrigin)
+            return buildWsUrl(requestOrigin, localPort)
         } catch {
             // Invalid origin, continue to fallback
         }
@@ -196,16 +207,15 @@ export function getPublicUrl(
     // 2. Fall back to EXPOSED_URL
     if (process.env.EXPOSED_URL) {
         try {
-            return build(process.env.EXPOSED_URL)
+            return buildWsUrl(process.env.EXPOSED_URL, localPort)
         } catch {
             // Invalid EXPOSED_URL, continue to fallback
         }
     }
 
     // 3. Fall back to sharedState.exposedUrl
-    const sharedState = getSharedState
     try {
-        return build(sharedState.exposedUrl)
+        return buildWsUrl(getSharedState.exposedUrl, localPort)
     } catch {
         // Last resort: localhost
         return `ws://localhost:${localPort}`

--- a/src/libs/network/handlers/tlsnotaryHandlers.ts
+++ b/src/libs/network/handlers/tlsnotaryHandlers.ts
@@ -1,4 +1,3 @@
-import { getSharedState } from "src/utilities/sharedState"
 import { Config } from "src/config"
 import log from "src/utilities/logger"
 import type { NodeCallHandler } from "./types"
@@ -126,23 +125,12 @@ export const tlsnotaryHandlers: Record<string, NodeCallHandler> = {
 
             const proxyPort = Config.getInstance().tlsnotary.proxyPort
 
-            const { buildWsUrl } = await import(
+            const { getPublicUrl } = await import(
                 "@/features/tlsnotary/proxyManager"
             )
-            const buildUrl = (p: number | string) => {
-                const exposedUrl = getSharedState.exposedUrl
-                if (exposedUrl) {
-                    try {
-                        return buildWsUrl(exposedUrl, p)
-                    } catch {
-                        // Fall back to localhost if URL parsing fails
-                    }
-                }
-                return `ws://localhost:${p}`
-            }
 
-            const notaryUrl = buildUrl(port)
-            const proxyUrl = buildUrl(proxyPort)
+            const notaryUrl = getPublicUrl(port)
+            const proxyUrl = getPublicUrl(proxyPort)
 
             response.response = {
                 notaryUrl,

--- a/src/libs/network/handlers/tlsnotaryHandlers.ts
+++ b/src/libs/network/handlers/tlsnotaryHandlers.ts
@@ -126,23 +126,23 @@ export const tlsnotaryHandlers: Record<string, NodeCallHandler> = {
 
             const proxyPort = Config.getInstance().tlsnotary.proxyPort
 
-            let nodeHost = "localhost"
-            const wsScheme = (() => {
-                try {
-                    const exposedUrl = getSharedState.exposedUrl
-                    if (exposedUrl) {
-                        const url = new URL(exposedUrl)
-                        nodeHost = url.hostname
-                        return url.protocol === "https:" ? "wss" : "ws"
+            const { buildWsUrl } = await import(
+                "@/features/tlsnotary/proxyManager"
+            )
+            const buildUrl = (p: number | string) => {
+                const exposedUrl = getSharedState.exposedUrl
+                if (exposedUrl) {
+                    try {
+                        return buildWsUrl(exposedUrl, p)
+                    } catch {
+                        // Fall back to localhost if URL parsing fails
                     }
-                } catch {
-                    // Fall back to localhost and ws if URL parsing fails
                 }
-                return "ws"
-            })()
+                return `ws://localhost:${p}`
+            }
 
-            const notaryUrl = `${wsScheme}://${nodeHost}:${port}`
-            const proxyUrl = `${wsScheme}://${nodeHost}:${proxyPort}`
+            const notaryUrl = buildUrl(port)
+            const proxyUrl = buildUrl(proxyPort)
 
             response.response = {
                 notaryUrl,


### PR DESCRIPTION
Supersedes #813 (which targeted the pre-handler-registry layout of `manageNodeCall.ts` and no longer merges cleanly into current `stabilisation`). Same fix, re-applied on the post-registry file structure.

## What

Extracts a shared `buildWsUrl(base, port)` helper into [proxyManager.ts](src/features/tlsnotary/proxyManager.ts) and uses it from both `getPublicUrl` (returned to SDK by `requestTLSNproxy`) and the `tlsnotary.getInfo` handler in [tlsnotaryHandlers.ts](src/libs/network/handlers/tlsnotaryHandlers.ts).

## Why

For HTTPS deployments behind a reverse proxy, the node can't expose raw ports (e.g. `7047`, `55688`) — they're not reachable. The SDK currently builds `wss://host:7047` from `EXPOSED_URL` and the connection fails. With this change, when `EXPOSED_URL` has a path (e.g. `https://demosnode.discus.sh/tlsn`), the node returns `wss://demosnode.discus.sh/tlsn/7047/` — a single nginx rule `^/tlsn/(\d+)/(.*)$ → http://127.0.0.1:$1/$2` handles all TLSN ports.

## Behaviour

- **No path** (`http://localhost:53550`) → legacy `ws://hostname:<port>`, no regression.
- **With path** (`https://host/tlsn`) → `wss://host/tlsn/<port>/`.
- **Reverse proxy on non-standard port** (`https://host:8443/tlsn`) → `wss://host:8443/tlsn/<port>/` — `url.host` (port-preserving) in the path branch is intentional.
- **`ws:`/`wss:` base** is passed through; no downgrade.

## Verification

Ran end-to-end against the local node:

```bash
curl -s -X POST -H "Content-Type: application/json" \
  -d '{"method":"nodeCall","params":[{"type":"nodeCall","message":"tlsnotary.getInfo","data":{}}]}' \
  http://localhost:53550 | jq .response
```

| EXPOSED_URL | notaryUrl | proxyUrl |
|---|---|---|
| `http://localhost:53550` | `ws://localhost:7047` | `ws://localhost:55688` |
| `https://demosnode.discus.sh/tlsn` | `wss://demosnode.discus.sh/tlsn/7047/` | `wss://demosnode.discus.sh/tlsn/55688/` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)