### PR TITLE
fix(tlsnotary): hostname-based scheme, default /tlsn path for public …

### DIFF
--- a/src/features/tlsnotary/proxyManager.ts
+++ b/src/features/tlsnotary/proxyManager.ts
@@ -170,19 +170,21 @@ export function extractDomainAndPort(targetUrl: string): {
 
 /**
  * Build a public WebSocket URL from a base HTTP(S)/WS(S) URL and a local port.
- * Path mode: when the base URL has a path, route through a reverse proxy at
- * `url.host` (port preserved) that maps `<path>/<port>` to the local port
- * (single nginx rule). No-path mode: connect directly to `url.hostname` on
- * the target port.
+ * Local bases keep direct ws://localhost:<port> URLs for development. Public
+ * bases always route through a TLS reverse proxy path, defaulting to
+ * /tlsn/<port>/ when no explicit path is provided.
  */
 export function buildWsUrl(base: string, port: number | string): string {
     const url = new URL(base)
-    const secure = url.protocol === "https:" || url.protocol === "wss:"
-    const wsScheme = secure ? "wss" : "ws"
-    const path = url.pathname.replace(/\/+$/, "")
-    return path
-        ? `${wsScheme}://${url.host}${path}/${port}/`
-        : `${wsScheme}://${url.hostname}:${port}`
+    const isLocal =
+        url.hostname === "localhost" || url.hostname === "127.0.0.1"
+
+    if (isLocal) {
+        return `ws://${url.hostname}:${port}`
+    }
+
+    const path = url.pathname.replace(/\/+$/, "") || "/tlsn"
+    return `wss://${url.hostname}${path}/${port}/`
 }
 
 /**


### PR DESCRIPTION
…bases

EXPOSED_URL doubles as the public RPC endpoint advertised to peers for omniprotocol port discovery, so it must stay as http://host:53550 — peers fail otherwise. The previous protocol-based scheme switch forced ws://host:7047 for that base, which can't be reached through the reverse proxy.

Switch buildWsUrl to a hostname-based rule:
- localhost / 127.0.0.1  → ws://<host>:<port>      (dev, raw port)
- anything else          → wss://<host><path>/<port>/, path defaulting
                          to /tlsn when not supplied

Behaviour:
  http://localhost:53550        → ws://localhost:7047
  http://127.0.0.1:53550        → ws://127.0.0.1:7047
  http://node2.demos.sh:53550   → wss://node2.demos.sh/tlsn/7047/
  https://node2.demos.sh/tlsn   → wss://node2.demos.sh/tlsn/7047/

Public bases now always route through TLS — assumes the reverse proxy terminates HTTPS at hostname:443 (standard for the production deploy).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved proxy connection handling to better support both local and remote server configurations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kynesyslabs/node/pull/819)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->