### PR TITLE
fix(docker): prune rule deletes runtime modules named like docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -80,22 +80,27 @@ RUN set -eu; \
 ARG PRUNE_MODULES=true
 RUN if [ "$PRUNE_MODULES" = "true" ]; then \
         echo "node_modules size before prune: $(du -sh node_modules | cut -f1)"; \
-        # Documentation and license files (typical: 60-100 MB)
+        # Documentation and license files (typical: 60-100 MB).
+        # IMPORTANT: only match doc-typical extensions / extensionless files,
+        # never the bare `-iname 'X*'` glob. Real packages ship runtime
+        # modules whose filename happens to start with these tokens
+        # (e.g. @mysten/sui/.../client/types/changes.js); deleting them
+        # corrupts module resolution at runtime.
         find node_modules -type f \( \
-            -iname 'README*' -o \
-            -iname 'CHANGELOG*' -o \
-            -iname 'CHANGES*' -o \
-            -iname 'HISTORY*' -o \
-            -iname 'CONTRIBUTING*' -o \
-            -iname 'AUTHORS*' -o \
-            -iname 'CONTRIBUTORS*' -o \
-            -iname 'LICEN[CS]E*' -o \
-            -iname 'NOTICE*' -o \
-            -iname 'NOTICES*' -o \
-            -iname 'PATENTS*' -o \
+            -iname 'README' -o -iname 'README.md' -o -iname 'README.txt' -o -iname 'README.rst' -o -iname 'README.markdown' -o \
+            -iname 'CHANGELOG' -o -iname 'CHANGELOG.md' -o -iname 'CHANGELOG.txt' -o -iname 'CHANGELOG.rst' -o \
+            -iname 'CHANGES' -o -iname 'CHANGES.md' -o -iname 'CHANGES.txt' -o -iname 'CHANGES.rst' -o \
+            -iname 'HISTORY' -o -iname 'HISTORY.md' -o -iname 'HISTORY.txt' -o \
+            -iname 'CONTRIBUTING' -o -iname 'CONTRIBUTING.md' -o -iname 'CONTRIBUTING.txt' -o \
+            -iname 'AUTHORS' -o -iname 'AUTHORS.md' -o -iname 'AUTHORS.txt' -o \
+            -iname 'CONTRIBUTORS' -o -iname 'CONTRIBUTORS.md' -o -iname 'CONTRIBUTORS.txt' -o \
+            -iname 'LICENSE' -o -iname 'LICENSE.md' -o -iname 'LICENSE.txt' -o -iname 'LICENSE-MIT' -o -iname 'LICENSE-APACHE' -o -iname 'LICENSE-MIT.txt' -o -iname 'LICENSE-APACHE.txt' -o \
+            -iname 'LICENCE' -o -iname 'LICENCE.md' -o -iname 'LICENCE.txt' -o \
+            -iname 'NOTICE' -o -iname 'NOTICE.md' -o -iname 'NOTICE.txt' -o \
+            -iname 'PATENTS' -o -iname 'PATENTS.md' -o -iname 'PATENTS.txt' -o \
             -iname 'governance.md' -o \
             -iname 'security.md' -o \
-            -iname 'code_of_conduct*' \
+            -iname 'CODE_OF_CONDUCT' -o -iname 'CODE_OF_CONDUCT.md' -o -iname 'CODE_OF_CONDUCT.txt' \
         \) -delete 2>/dev/null || true; \
         # Source maps (typical: 80-150 MB)
         find node_modules -type f \( -name '*.map' -o -name '*.ts.map' \) -delete 2>/dev/null || true; \


### PR DESCRIPTION
## Problem

Containerised node crashes on boot with:
```
demos-node | error: Cannot find module './changes.js' from
            '/app/node_modules/@mysten/sui/dist/cjs/client/types/index.js'
```

## Root cause

`Dockerfile:84-99` runs an aggressive `PRUNE_MODULES` pass to strip docs and license files from `node_modules`. The rule uses case-insensitive prefix globs:

```dockerfile
find node_modules -type f \( \
    -iname 'CHANGES*' -o \
    ... \
\) -delete
```

`CHANGES*` matches `changes.js` (case-insensitive) — Sui's actual runtime module `@mysten/sui/dist/cjs/client/types/changes.js`. After prune, the file is missing and `client/types/index.js` fails its `require('./changes.js')`.

Same overreach exists for every `-iname 'X*'` entry in the list (`README*`, `HISTORY*`, `CONTRIBUTING*`, `AUTHORS*`, `LICEN[CS]E*`, `NOTICE*`, `PATENTS*`, `code_of_conduct*`).

Triggered now because the snapshot-restore branch loads `@kynesyslabs/demosdk` paths that transitively pull in @mysten/sui; older code paths happened to avoid `client/types/index.js`.

## Fix

Replace each `-iname 'X*'` with an explicit set of extensionless + doc-extension forms (`X`, `X.md`, `X.txt`, `X.rst`, plus the common `LICENSE-MIT.txt` / `LICENSE-APACHE.txt` variants). Real docs still pruned (~60-100 MB savings preserved); runtime JS modules with doc-sounding names stay.

## Verification

After rebuild:
```bash
$ docker run --rm demos-node:local ls /app/node_modules/@mysten/sui/dist/cjs/client/types/changes.js
/app/node_modules/@mysten/sui/dist/cjs/client/types/changes.js

$ docker run --rm demos-node:local ls /app/node_modules/@mysten/sui/README.md
ls: cannot access '/app/node_modules/@mysten/sui/README.md': No such file or directory
```

Both required behaviors preserved.

## Test plan

- [ ] `docker compose build node` succeeds.
- [ ] `docker run --rm demos-node:local ls /app/node_modules/@mysten/sui/dist/cjs/client/types/changes.js` succeeds.
- [ ] `./run --docker --clean -d` boots the node without the `Cannot find module './changes.js'` error.
- [ ] Image size delta vs prior build is within a few MB (prune still effective).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized Docker build process by refining the cleanup of documentation and license files in dependencies. Enhanced filename matching logic improves build efficiency and image size optimization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kynesyslabs/node/pull/836?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->