### PR TITLE
fix(docker-run): match compose's hardcoded volume names

### DIFF
--- a/scripts/docker-run
+++ b/scripts/docker-run
@@ -159,17 +159,20 @@ fi
 
 # --clean: bring everything down + drop the named volumes before `up`.
 # Only fires when SUBCOMMAND ends up as `up`; for explicit `down`/`logs`/etc
-# the wipe would be confusing. Compose project name defaults to the
-# repo basename (`node`); allow COMPOSE_PROJECT_NAME override.
+# the wipe would be confusing.
+#
+# Volume names are hardcoded as `demos_*` in docker-compose.yml `volumes:`
+# section via `name:` overrides — NOT derived from the compose project
+# name. Do NOT prefix with $(basename $REPO_ROOT) here; that targets a
+# parallel volume that compose never mounts.
 if [[ "$WIPE_VOLUMES" == "true" && "$SUBCOMMAND" == "up" ]]; then
-    PROJECT_NAME="${COMPOSE_PROJECT_NAME:-$(basename "$REPO_ROOT")}"
-    echo "+ --clean: tearing down stack + wiping volumes for project '$PROJECT_NAME'"
+    echo "+ --clean: tearing down stack + wiping volumes (demos_pgdata, demos_node_data)"
     # Down with --volumes so anonymous volumes go too; named volumes
     # still need explicit removal below because compose only drops them
     # when `--volumes` is paired with full project teardown AND no other
     # containers reference them.
     docker compose "${COMPOSE_ARGS[@]}" ${PROFILES[@]+"${PROFILES[@]}"} ${EXTRA_PROFILES[@]+"${EXTRA_PROFILES[@]}"} down --volumes --remove-orphans || true
-    for vol in "${PROJECT_NAME}_pgdata" "${PROJECT_NAME}_node_data"; do
+    for vol in demos_pgdata demos_node_data; do
         if docker volume inspect "$vol" >/dev/null 2>&1; then
             echo "+ --clean: removing volume $vol"
             docker volume rm "$vol" || true
@@ -206,8 +209,11 @@ fi
 #     (0600, owned by uid 1000 to match the demos user inside the image).
 HOST_IDENTITY_FILE="${REPO_ROOT}/.demos_identity"
 if [[ "$SUBCOMMAND" == "up" && -f "$HOST_IDENTITY_FILE" ]]; then
-    PROJECT_NAME="${COMPOSE_PROJECT_NAME:-$(basename "$REPO_ROOT")}"
-    STATE_VOL="${PROJECT_NAME}_node_state"
+    # Volume name is hardcoded in docker-compose.yml via `name:` override
+    # (`demos_node_state`), NOT derived from the compose project name. Match
+    # the literal name here so the seeded mnemonic lands in the volume
+    # that compose actually mounts at /app/state.
+    STATE_VOL="demos_node_state"
     # Create the volume if it doesn't already exist so compose can mount it.
     docker volume inspect "$STATE_VOL" >/dev/null 2>&1 || docker volume create "$STATE_VOL" >/dev/null
     echo "+ syncing .demos_identity -> $STATE_VOL"


### PR DESCRIPTION
## Problem

Both the \`--clean\` wipe and the always-on identity-sync (PR #853) derived volume names from \`\$(basename \$REPO_ROOT)\`. That gives \`<dir>_pgdata\` / \`<dir>_node_state\` etc.

But \`docker-compose.yml\` hardcodes \`name: demos_pgdata\` (and siblings) in the top-level \`volumes:\` section, overriding compose's default project-prefixed naming. So the launcher created + seeded / wiped a parallel set of volumes that compose never mounted. Operators saw the script log \`+ syncing .demos_identity -> node-dev_node_state\` but the container booted with an auto-generated mnemonic because it read from the actual \`demos_node_state\` volume.

Empirically reproduced on devnet (\`~/node-dev/\` clone): repo \`.demos_identity\` derives \`0xf132cc...\`, but after \`./run --docker --clean -d\` the container served pubkey \`0xedc880aa...\` (fresh auto-gen). Bug: sync wrote to \`node-dev_node_state\`, container mounted \`demos_node_state\`.

Same bug in \`--clean\` wipe: on any repo dir not named \`node\`, the loop targeted nonexistent volumes and silently no-op'd, leaving stale data.

## Fix

Hardcode \`demos_node_state\` / \`demos_pgdata\` / \`demos_node_data\` in the launcher to match the compose \`name:\` overrides.

## Test plan

- [ ] On a repo clone NOT named \`node\` (e.g. \`node-dev\`), \`./run --docker --clean -d\` actually wipes \`demos_pgdata\` + \`demos_node_data\` (verify with \`docker volume ls\`).
- [ ] On the same clone, \`./run --docker -d\` with \`.demos_identity\` present seeds the file into \`demos_node_state\` (verify \`docker run --rm -v demos_node_state:/state alpine head -c 80 /state/.demos_identity\` matches host).
- [ ] Container \`curl http://localhost:53550/publickey\` returns the pubkey derived from the repo's mnemonic, not an auto-generated one.