### PR TITLE
fix(genesis): overlay genesisData.balances on snapshot rows

### DIFF
--- a/src/libs/blockchain/chainGenesis.ts
+++ b/src/libs/blockchain/chainGenesis.ts
@@ -20,6 +20,7 @@ import {
     type GenesisValidatorSeed,
 } from "src/libs/blockchain/genesis/seedValidators"
 import { applyForksAtGenesis } from "src/libs/blockchain/genesis/applyForksAtGenesis"
+import { mergeGenesisBalances } from "src/libs/blockchain/genesis/mergeGenesisBalances"
 
 const GENESIS_BLOCK_HEIGHT = 0
 
@@ -162,6 +163,16 @@ export async function generateGenesisBlock(genesisData: any): Promise<Block> {
                     genesisData.validators as GenesisValidatorSeed[],
                 )
             }
+            // Overlay genesisData.balances on top of the snapshot rows.
+            // Historical behavior silently dropped balances when a
+            // snapshot was present — operator-written top-ups (e.g.
+            // founder/incentives wallets added in `data/genesis.json`)
+            // ended up at balance=0 once `ensureGCRForUser` later
+            // created the row. Block-0 hash already commits to
+            // `genesisData.balances` via `extra.genesisData`, so making
+            // the disk reflect it does not change consensus — it just
+            // closes the gap between hash and state.
+            await mergeGenesisBalances(em, genesisData.balances)
             // Pre-apply forks deterministically at genesis. Migration output is
             // a pure function of input state — no consensus block-1 hook needed.
             // Pristine boot is fully post-fork; solo nodes don't sit at genesis.

--- a/src/libs/blockchain/genesis/mergeGenesisBalances.ts
+++ b/src/libs/blockchain/genesis/mergeGenesisBalances.ts
@@ -1,0 +1,233 @@
+/**
+ * Genesis balance overlay (post-snapshot).
+ *
+ * Bug history: when `data/snapshot/` is present, `restoreSnapshot` owns
+ * every gcr_main row and the legacy `genesisData.balances` array was
+ * silently ignored (see chainGenesis.ts:131-138 historical comment). An
+ * operator who edited `data/genesis.json` to top up an address would
+ * see block-0 hash change (because `extra.genesisData` carries the raw
+ * JSON) but the address balance would remain at whatever the snapshot
+ * row said — or, for an address absent from the snapshot, at 0 once
+ * `ensureGCRForUser` later created the row.
+ *
+ * Fix (this module): after `restoreSnapshot`, UPSERT every entry in
+ * `genesisData.balances` over the snapshot rows. `genesis.balances`
+ * wins on conflict — that matches operator intent: the snapshot is the
+ * historical state, `genesis.balances` is the deliberate top-up shipped
+ * with the new genesis. Runs inside the caller-owned transaction so a
+ * mid-overlay crash rolls back the whole genesis bootstrap.
+ *
+ * Consensus impact: NONE. Block-0 hash is computed from
+ * `serializeBlockContent` whose `extra.genesisData` already includes the
+ * `balances` array. Every honest node parsing the same genesis.json
+ * derives the same gcr_main state after this overlay, so two nodes
+ * disagreeing on post-genesis balances were already in the broken
+ * pre-fix state — this just makes the disk reflect what the hash already
+ * commits to.
+ *
+ * Row shape: new rows (pubkey absent from snapshot) get the same
+ * defaults `HandleGCR.createAccount` would assign — empty identities,
+ * generated referral code, zero points — so they look identical to
+ * organically-created accounts the first time `ensureGCRForUser`
+ * touches them. Existing rows have ONLY their `balance` column
+ * overwritten; identities/points/referralInfo/flags are preserved from
+ * the snapshot (operator intent is "fix the balance", not "wipe the
+ * account").
+ */
+
+import type { EntityManager } from "typeorm"
+
+import log from "src/utilities/logger"
+import { GCRMain } from "src/model/entities/GCRv2/GCR_Main"
+import type { SavedUdIdentity } from "src/model/entities/types/IdentityTypes"
+import { Referrals } from "@/features/incentive/referrals"
+
+/**
+ * Parse a `genesisData.balances` entry into `[pubkey, bigint]`.
+ *
+ * `data/genesis.json` historically allows the balance side to be a
+ * decimal string, a number, or a bigint-string. We coerce to bigint
+ * (OS denomination) here and fail loudly on anything malformed — a
+ * silent BigInt(0) on a typo would re-introduce the same class of
+ * "operator wrote it but the chain doesn't know" bug we're fixing.
+ */
+function parseGenesisBalanceEntry(
+    entry: unknown,
+    idx: number,
+): [string, bigint] {
+    if (!Array.isArray(entry) || entry.length < 2) {
+        throw new Error(
+            `[GENESIS][BALANCES] entry ${idx} is not a [pubkey, balance] tuple`,
+        )
+    }
+    const [pubkey, rawBalance] = entry as [unknown, unknown]
+    if (typeof pubkey !== "string" || pubkey.trim().length === 0) {
+        throw new Error(
+            `[GENESIS][BALANCES] entry ${idx} pubkey is not a non-empty string`,
+        )
+    }
+    let balance: bigint
+    try {
+        if (typeof rawBalance === "bigint") {
+            balance = rawBalance
+        } else if (typeof rawBalance === "number") {
+            if (!Number.isFinite(rawBalance) || !Number.isInteger(rawBalance)) {
+                throw new Error(
+                    `numeric balance must be a finite integer, got ${rawBalance}`,
+                )
+            }
+            balance = BigInt(rawBalance)
+        } else if (typeof rawBalance === "string") {
+            balance = BigInt(rawBalance.trim())
+        } else {
+            throw new Error(
+                `unsupported balance type ${typeof rawBalance}`,
+            )
+        }
+    } catch (e) {
+        throw new Error(
+            `[GENESIS][BALANCES] entry ${idx} (${pubkey}) has invalid balance: ${
+                e instanceof Error ? e.message : String(e)
+            }`,
+        )
+    }
+    if (balance < 0n) {
+        throw new Error(
+            `[GENESIS][BALANCES] entry ${idx} (${pubkey}) has negative balance ${balance.toString()}`,
+        )
+    }
+    return [pubkey, balance]
+}
+
+/**
+ * Default JSON columns used for freshly-inserted gcr_main rows. Mirrors
+ * the shape `HandleGCR.createAccount` writes so the row is
+ * indistinguishable from one created via the normal account flow.
+ */
+function defaultEmptyAccountFields(pubkey: string) {
+    const now = new Date()
+    return {
+        assignedTxs: [] as string[],
+        identities: {
+            xm: {},
+            web2: {},
+            pqc: {},
+            ud: [] as SavedUdIdentity[],
+        },
+        nonce: 0,
+        points: {
+            totalPoints: 0,
+            breakdown: {
+                web3Wallets: {} as Record<string, number>,
+                socialAccounts: {
+                    twitter: 0,
+                    github: 0,
+                    discord: 0,
+                },
+                referrals: 0,
+                demosFollow: 0,
+            },
+            lastUpdated: now,
+        },
+        referralInfo: {
+            totalReferrals: 0,
+            referralCode: Referrals.generateReferralCode(pubkey),
+            referrals: [] as Array<{
+                referredUserId: string
+                referredAt: string
+                pointsAwarded: number
+            }>,
+            referredBy: null as string | null,
+        },
+        flagged: false,
+        flaggedReason: "" as const,
+        reviewed: false,
+        createdAt: now,
+        updatedAt: now,
+    }
+}
+
+export interface MergeGenesisBalancesResult {
+    /** Total entries processed from genesisData.balances */
+    total: number
+    /** Rows whose balance was overwritten over an existing snapshot row */
+    updated: number
+    /** Rows freshly inserted because the pubkey was absent from snapshot */
+    inserted: number
+}
+
+/**
+ * Apply `genesisData.balances` over the gcr_main rows restored by
+ * `restoreSnapshot`. Must run inside the same transaction so rollback
+ * stays atomic with the snapshot restore.
+ *
+ * @param em       EntityManager bound to the genesis transaction
+ * @param balances Raw `genesisData.balances` array (tuples of
+ *                 `[pubkey, balance]`). May be undefined/empty — no-op
+ *                 in that case.
+ */
+export async function mergeGenesisBalances(
+    em: EntityManager,
+    balances: unknown,
+): Promise<MergeGenesisBalancesResult> {
+    const result: MergeGenesisBalancesResult = {
+        total: 0,
+        updated: 0,
+        inserted: 0,
+    }
+
+    if (balances === undefined || balances === null) {
+        return result
+    }
+    if (!Array.isArray(balances)) {
+        throw new Error(
+            "[GENESIS][BALANCES] genesisData.balances is present but not an array",
+        )
+    }
+    if (balances.length === 0) {
+        return result
+    }
+
+    log.info(
+        `[GENESIS][BALANCES] overlaying ${balances.length} entries from genesisData.balances`,
+    )
+
+    // Parse + dedupe upfront so we fail before any DB write if the
+    // operator shipped a malformed entry. Last-wins on duplicate pubkey
+    // — same rule createAccount would apply if called twice.
+    const parsed = new Map<string, bigint>()
+    for (let i = 0; i < balances.length; i++) {
+        const [pubkey, balance] = parseGenesisBalanceEntry(balances[i], i)
+        parsed.set(pubkey, balance)
+    }
+    result.total = parsed.size
+
+    const repo = em.getRepository(GCRMain)
+
+    for (const [pubkey, balance] of parsed) {
+        const existing = await repo.findOne({ where: { pubkey } })
+        if (existing) {
+            // Only the balance column is overwritten; everything else
+            // (identities, points, referralInfo, flagged, …) belongs to
+            // the snapshot row and we have no business stomping it.
+            existing.balance = balance
+            existing.updatedAt = new Date()
+            await repo.save(existing)
+            result.updated++
+        } else {
+            const fresh = repo.create({
+                pubkey,
+                balance,
+                ...defaultEmptyAccountFields(pubkey),
+            })
+            await repo.save(fresh)
+            result.inserted++
+        }
+    }
+
+    log.info(
+        `[GENESIS][BALANCES] overlay done — total=${result.total} updated=${result.updated} inserted=${result.inserted}`,
+    )
+
+    return result
+}

--- a/testing/genesis/mergeGenesisBalances.test.ts
+++ b/testing/genesis/mergeGenesisBalances.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Unit tests for src/libs/blockchain/genesis/mergeGenesisBalances.ts
+ *
+ * Covers:
+ *  - empty / undefined / null input is a no-op
+ *  - non-array input throws
+ *  - balance coercion: string, number, bigint
+ *  - rejects fractional, NaN, negative balances
+ *  - rejects malformed entry shapes
+ *  - dedup last-wins on duplicate pubkey
+ *  - UPDATE path: existing row → balance overwritten, other fields preserved
+ *  - INSERT path: missing row → fresh row with default columns
+ *  - mixed batch: counts (updated, inserted, total) are correct
+ *
+ * Test isolation: no real DB. EntityManager is a hand-rolled mock that
+ * tracks rows in a Map and exposes the same `getRepository(GCRMain)`
+ * surface mergeGenesisBalances uses (findOne / save / create).
+ */
+
+import { describe, it, expect } from "bun:test"
+
+import { mergeGenesisBalances } from "src/libs/blockchain/genesis/mergeGenesisBalances"
+import { GCRMain } from "src/model/entities/GCRv2/GCR_Main"
+
+// =============================================================================
+// EntityManager mock
+// =============================================================================
+
+type Row = Partial<GCRMain> & { pubkey: string; balance: bigint }
+
+function makeMockEm() {
+    const rows = new Map<string, Row>()
+
+    const repo = {
+        findOne: async (opts: { where: { pubkey: string } }) => {
+            return rows.get(opts.where.pubkey) ?? null
+        },
+        save: async (row: Row) => {
+            rows.set(row.pubkey, { ...row })
+            return row
+        },
+        create: (row: Row) => row,
+    }
+
+    return {
+        em: { getRepository: (_e: unknown) => repo } as any,
+        rows,
+    }
+}
+
+function seed(rows: Map<string, Row>, pubkey: string, extras: Partial<Row> = {}) {
+    rows.set(pubkey, {
+        pubkey,
+        balance: 0n,
+        flagged: false,
+        flaggedReason: "" as const,
+        reviewed: false,
+        ...extras,
+    } as Row)
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe("mergeGenesisBalances", () => {
+    it("no-op on undefined", async () => {
+        const { em, rows } = makeMockEm()
+        const r = await mergeGenesisBalances(em, undefined)
+        expect(r).toEqual({ total: 0, updated: 0, inserted: 0 })
+        expect(rows.size).toBe(0)
+    })
+
+    it("no-op on null", async () => {
+        const { em, rows } = makeMockEm()
+        const r = await mergeGenesisBalances(em, null)
+        expect(r).toEqual({ total: 0, updated: 0, inserted: 0 })
+        expect(rows.size).toBe(0)
+    })
+
+    it("no-op on empty array", async () => {
+        const { em, rows } = makeMockEm()
+        const r = await mergeGenesisBalances(em, [])
+        expect(r).toEqual({ total: 0, updated: 0, inserted: 0 })
+        expect(rows.size).toBe(0)
+    })
+
+    it("throws on non-array input", async () => {
+        const { em } = makeMockEm()
+        await expect(
+            mergeGenesisBalances(em, { not: "an array" } as any),
+        ).rejects.toThrow(/not an array/)
+    })
+
+    it("rejects malformed entry shape", async () => {
+        const { em } = makeMockEm()
+        await expect(
+            mergeGenesisBalances(em, [["0xabc"] as any]),
+        ).rejects.toThrow(/not a \[pubkey, balance\] tuple/)
+    })
+
+    it("rejects empty pubkey", async () => {
+        const { em } = makeMockEm()
+        await expect(
+            mergeGenesisBalances(em, [["", "100"]]),
+        ).rejects.toThrow(/pubkey is not a non-empty string/)
+    })
+
+    it("rejects negative balance", async () => {
+        const { em } = makeMockEm()
+        await expect(
+            mergeGenesisBalances(em, [["0xabc", "-1"]]),
+        ).rejects.toThrow(/negative balance/)
+    })
+
+    it("rejects fractional number balance", async () => {
+        const { em } = makeMockEm()
+        await expect(
+            mergeGenesisBalances(em, [["0xabc", 1.5]]),
+        ).rejects.toThrow(/must be a finite integer/)
+    })
+
+    it("rejects NaN balance", async () => {
+        const { em } = makeMockEm()
+        await expect(
+            mergeGenesisBalances(em, [["0xabc", NaN]]),
+        ).rejects.toThrow(/must be a finite integer/)
+    })
+
+    it("rejects unsupported balance type", async () => {
+        const { em } = makeMockEm()
+        await expect(
+            mergeGenesisBalances(em, [["0xabc", { v: 1 } as any]]),
+        ).rejects.toThrow(/unsupported balance type/)
+    })
+
+    it("coerces string balance to bigint", async () => {
+        const { em, rows } = makeMockEm()
+        await mergeGenesisBalances(em, [["0xaa00000000000000000000000000000000000000000000000000000000000001", "1000000000000000000"]])
+        expect(rows.get("0xaa00000000000000000000000000000000000000000000000000000000000001")?.balance).toBe(1000000000000000000n)
+    })
+
+    it("coerces integer number balance to bigint", async () => {
+        const { em, rows } = makeMockEm()
+        await mergeGenesisBalances(em, [["0xaa00000000000000000000000000000000000000000000000000000000000001", 42]])
+        expect(rows.get("0xaa00000000000000000000000000000000000000000000000000000000000001")?.balance).toBe(42n)
+    })
+
+    it("preserves bigint balance", async () => {
+        const { em, rows } = makeMockEm()
+        await mergeGenesisBalances(em, [["0xaa00000000000000000000000000000000000000000000000000000000000001", 99n]])
+        expect(rows.get("0xaa00000000000000000000000000000000000000000000000000000000000001")?.balance).toBe(99n)
+    })
+
+    it("dedup: last-wins on duplicate pubkey", async () => {
+        const { em, rows } = makeMockEm()
+        const r = await mergeGenesisBalances(em, [
+            ["0xaa00000000000000000000000000000000000000000000000000000000000001", "1"],
+            ["0xaa00000000000000000000000000000000000000000000000000000000000001", "999"],
+        ])
+        expect(r.total).toBe(1)
+        expect(rows.get("0xaa00000000000000000000000000000000000000000000000000000000000001")?.balance).toBe(999n)
+    })
+
+    it("UPDATE path: existing row → balance overwritten, identity preserved", async () => {
+        const { em, rows } = makeMockEm()
+        seed(rows, "0xaa00000000000000000000000000000000000000000000000000000000000001", {
+            balance: 5n,
+            identities: { xm: { ok: true } } as any,
+            nonce: 7,
+        })
+        const r = await mergeGenesisBalances(em, [["0xaa00000000000000000000000000000000000000000000000000000000000001", "1000"]])
+        expect(r).toEqual({ total: 1, updated: 1, inserted: 0 })
+        const row = rows.get("0xaa00000000000000000000000000000000000000000000000000000000000001")!
+        expect(row.balance).toBe(1000n)
+        // Snapshot-owned columns left intact
+        expect((row.identities as any)?.xm).toEqual({ ok: true })
+        expect(row.nonce).toBe(7)
+    })
+
+    it("INSERT path: missing row → fresh row with defaults", async () => {
+        const { em, rows } = makeMockEm()
+        const r = await mergeGenesisBalances(em, [["0xcc00000000000000000000000000000000000000000000000000000000000003", "500"]])
+        expect(r).toEqual({ total: 1, updated: 0, inserted: 1 })
+        const row = rows.get("0xcc00000000000000000000000000000000000000000000000000000000000003")!
+        expect(row.balance).toBe(500n)
+        expect(row.flagged).toBe(false)
+        expect(row.flaggedReason).toBe("")
+        expect(row.reviewed).toBe(false)
+        expect(row.nonce).toBe(0)
+        expect(row.identities).toEqual({ xm: {}, web2: {}, pqc: {}, ud: [] })
+        expect(row.referralInfo?.referralCode).toBeTruthy()
+    })
+
+    it("mixed batch: counts updated + inserted correctly", async () => {
+        const { em, rows } = makeMockEm()
+        seed(rows, "0xaa00000000000000000000000000000000000000000000000000000000000001", { balance: 1n })
+        seed(rows, "0xbb00000000000000000000000000000000000000000000000000000000000002", { balance: 2n })
+        const r = await mergeGenesisBalances(em, [
+            ["0xaa00000000000000000000000000000000000000000000000000000000000001", "100"],
+            ["0xbb00000000000000000000000000000000000000000000000000000000000002", "200"],
+            ["0xdd00000000000000000000000000000000000000000000000000000000000004", "300"],
+            ["0xee00000000000000000000000000000000000000000000000000000000000005", "400"],
+        ])
+        expect(r).toEqual({ total: 4, updated: 2, inserted: 2 })
+        expect(rows.get("0xaa00000000000000000000000000000000000000000000000000000000000001")?.balance).toBe(100n)
+        expect(rows.get("0xbb00000000000000000000000000000000000000000000000000000000000002")?.balance).toBe(200n)
+        expect(rows.get("0xdd00000000000000000000000000000000000000000000000000000000000004")?.balance).toBe(300n)
+        expect(rows.get("0xee00000000000000000000000000000000000000000000000000000000000005")?.balance).toBe(400n)
+    })
+
+    it("zero balance still applied (operator intent)", async () => {
+        const { em, rows } = makeMockEm()
+        seed(rows, "0xaa00000000000000000000000000000000000000000000000000000000000001", { balance: 999n })
+        await mergeGenesisBalances(em, [["0xaa00000000000000000000000000000000000000000000000000000000000001", "0"]])
+        expect(rows.get("0xaa00000000000000000000000000000000000000000000000000000000000001")?.balance).toBe(0n)
+    })
+})


### PR DESCRIPTION
## Summary

When `data/snapshot/` is present, `restoreSnapshot` owns every `gcr_main` row and the legacy `genesisData.balances` array was **silently dropped** (per `chainGenesis.ts:131-138` historical comment). An operator who edited `data/genesis.json` to add an address would see block-0 hash change (`extra.genesisData` carries the raw JSON) but the address balance would stay at whatever the snapshot row said — or `0` once `ensureGCRForUser` later materialised the row.

## Repro

- Address `0xd17624…d98a` listed in `data/genesis.json.balances` with non-zero balance
- Chain accepts the resulting block-0 hash
- `getAddressInfo` reports `balance: "0"`
- Same for 3 independent identities — all "funded in genesis on paper", all 0 on chain
- Disk diverged from what the hash committed to

## Fix

`mergeGenesisBalances()` runs after `restoreSnapshot` **inside the same transaction**. `genesisData.balances` wins on conflict — operator intent is "snapshot is yesterday's state, genesis.balances is today's top-up". Only the `balance` column is overwritten; `identities`, `points`, `referralInfo`, flags are preserved. Missing pubkeys get a fresh row with the same defaults `HandleGCR.createAccount` would assign.

## Consensus impact

**None.** Block-0 hash is computed from `serializeBlockContent` whose `extra.genesisData` already includes the `balances` array. Every honest node parsing the same `genesis.json` now derives the same `gcr_main` state, which is what the hash already committed to. The fix closes the gap between hash and on-disk state; it does not change the hash.

## Validation

Balances parsed to `bigint` OS up front; rejects negative / fractional / NaN / wrong-shaped entries. Silent `BigInt(0)` on a typo would re-introduce the same class of "operator wrote it but chain ignored it" bug.

## Test plan

- [x] 18 unit cases in `testing/genesis/mergeGenesisBalances.test.ts`:
  - no-op paths (undefined/null/empty)
  - validation rejects (non-array, malformed tuple, empty pubkey, negative, fractional, NaN, wrong type)
  - coercion (string / number / bigint)
  - dedup last-wins on duplicate pubkey
  - UPDATE preserves snapshot identity columns
  - INSERT writes defaults (identities, referralCode, points, flags, dates)
  - mixed batch counts (`total` / `updated` / `inserted`)
  - zero balance still applied (operator intent)
- [ ] Manual: wipe `data_*` PG volume, boot with `data/snapshot/` + `data/genesis.json.balances` containing extra addresses, verify `getAddressInfo` returns the genesis-declared balance for those addresses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Genesis account restoration now properly aligns account balances with committed genesis data during snapshot recovery, ensuring consistency between snapshot-derived accounts and on-chain genesis records.

* **Tests**
  * Added comprehensive test suite for genesis balance validation and overlay operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kynesyslabs/node/pull/858?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->