### PR TITLE
Add devnet to chainProviders.egld

### DIFF
--- a/sdk/localsdk/multichain/configs/chainProviders.ts
+++ b/sdk/localsdk/multichain/configs/chainProviders.ts
@@ -11,6 +11,7 @@ export const chainProviders = {
     egld: {
         mainnet: "https://api.multiversx.com",
         testnet: "https://testnet-api.multiversx.com",
+        devnet: "https://devnet-api.multiversx.com",
     },
     solana: {
         mainnet: "https://britta-qyzo1g-fast-mainnet.helius-rpc.com",


### PR DESCRIPTION
Without this, MultiversX contract write transactions targeting devnet fail at the node's executor with "Provider not connected": looking up chainProviders.egld['devnet'] returned undefined, MULTIVERSX.create(undefined) short-circuited (the static create() only initialises the network provider when an rpc_url is truthy), and the subsequent sendTransaction call hit required(this.provider, 'Provider not connected') and threw.

Adds devnet pointing at the official https://devnet-api.multiversx.com. Verified end-to-end with a devnet `increment` call (tx bd9f2317968ad2a71cbcc10c781b8a1a35fa321a703a79a947bce31cc954b4e5).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added devnet RPC endpoint for egld blockchain network configuration alongside existing mainnet and testnet endpoints.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kynesyslabs/node/pull/859?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->