### PR TITLE
Port/contract write on stabilisation

### DIFF
--- a/sdk/localsdk/multichain/configs/chainProviders.ts
+++ b/sdk/localsdk/multichain/configs/chainProviders.ts
@@ -11,6 +11,7 @@ export const chainProviders = {
     egld: {
         mainnet: "https://api.multiversx.com",
         testnet: "https://testnet-api.multiversx.com",
+        devnet: "https://devnet-api.multiversx.com",
     },
     solana: {
         mainnet: "https://britta-qyzo1g-fast-mainnet.helius-rpc.com",

--- a/src/features/multichain/routines/executors/contract_write.ts
+++ b/src/features/multichain/routines/executors/contract_write.ts
@@ -1,5 +1,5 @@
 import type { IOperation } from "@kynesyslabs/demosdk/types"
-import { EVM, MULTIVERSX, SOLANA } from "@kynesyslabs/demosdk/xm-localsdk"
+import { EVM, MULTIVERSX, SOLANA, TON } from "@kynesyslabs/demosdk/xm-localsdk"
 import { evmProviders } from "sdk/localsdk/multichain/configs/evmProviders"
 import log from "@/utilities/logger"
 import handleAptosContractWrite from "./aptos_contract_write"
@@ -42,6 +42,16 @@ async function handleMultiversxContractWrite(operation: IOperation) {
     )
 }
 
+async function handleTonContractWrite(operation: IOperation) {
+    // Signed payload is a hex-encoded BoC of the wallet's external message; the localSDK's
+    // TON.sendTransaction parses it and broadcasts via TonCenter.
+    return await genericJsonRpcPay(
+        TON,
+        chainProviders.ton[operation.subchain],
+        operation,
+    )
+}
+
 export default async function handleContractWrite(
     operation: IOperation,
     chainID: number,
@@ -57,6 +67,8 @@ export default async function handleContractWrite(
             return await handleSolanaContractWrite(operation)
         case "egld":
             return await handleMultiversxContractWrite(operation)
+        case "ton":
+            return await handleTonContractWrite(operation)
         default:
             return {
                 result: "error",

--- a/src/features/multichain/routines/executors/contract_write.ts
+++ b/src/features/multichain/routines/executors/contract_write.ts
@@ -1,5 +1,5 @@
 import type { IOperation } from "@kynesyslabs/demosdk/types"
-import { EVM, SOLANA } from "@kynesyslabs/demosdk/xm-localsdk"
+import { EVM, MULTIVERSX, SOLANA } from "@kynesyslabs/demosdk/xm-localsdk"
 import { evmProviders } from "sdk/localsdk/multichain/configs/evmProviders"
 import log from "@/utilities/logger"
 import handleAptosContractWrite from "./aptos_contract_write"
@@ -32,6 +32,16 @@ async function handleSolanaContractWrite(operation: IOperation) {
     )
 }
 
+async function handleMultiversxContractWrite(operation: IOperation) {
+    // Signed payload is an IPlainTransactionObject; the localSDK's MULTIVERSX.sendTransaction
+    // POSTs it to the MultiversX REST API at /transaction/send.
+    return await genericJsonRpcPay(
+        MULTIVERSX,
+        chainProviders.egld[operation.subchain],
+        operation,
+    )
+}
+
 export default async function handleContractWrite(
     operation: IOperation,
     chainID: number,
@@ -45,6 +55,8 @@ export default async function handleContractWrite(
             return await handleAptosContractWrite(operation)
         case "solana":
             return await handleSolanaContractWrite(operation)
+        case "egld":
+            return await handleMultiversxContractWrite(operation)
         default:
             return {
                 result: "error",

--- a/src/features/multichain/routines/executors/contract_write.ts
+++ b/src/features/multichain/routines/executors/contract_write.ts
@@ -37,7 +37,7 @@ async function handleMultiversxContractWrite(operation: IOperation) {
     // POSTs it to the MultiversX REST API at /transaction/send.
     return await genericJsonRpcPay(
         MULTIVERSX,
-        chainProviders.egld[operation.subchain],
+        operation.rpc || chainProviders.egld[operation.subchain],
         operation,
     )
 }
@@ -47,7 +47,7 @@ async function handleTonContractWrite(operation: IOperation) {
     // TON.sendTransaction parses it and broadcasts via TonCenter.
     return await genericJsonRpcPay(
         TON,
-        chainProviders.ton[operation.subchain],
+        operation.rpc || chainProviders.ton[operation.subchain],
         operation,
     )
 }

--- a/src/libs/blockchain/gcr/gcr_routines/identityManager.ts
+++ b/src/libs/blockchain/gcr/gcr_routines/identityManager.ts
@@ -7,6 +7,7 @@ import {
     InferFromSignaturePayload,
 } from "@kynesyslabs/demosdk/abstraction"
 import {
+    APTOS,
     EVM,
     IBC,
     MULTIVERSX,
@@ -56,6 +57,8 @@ const chains: { [key: string]: typeof DefaultChain } = {
     near: NEAR,
     // @ts-expect-error - BTC module contains more fields than the DefaultChain type
     btc: BTC,
+    // @ts-expect-error - APTOS module contains more fields than the DefaultChain type
+    aptos: APTOS,
 }
 
 export default class IdentityManager {
@@ -217,7 +220,8 @@ export default class IdentityManager {
                 chainId === "ton" ||
                 chainId === "ibc" ||
                 chainId === "atom" ||
-                chainId === "near"
+                chainId === "near" ||
+                chainId === "aptos"
             ) {
                 messageVerified = await sdk.verifyMessage(
                     signedData,


### PR DESCRIPTION
Ports the contract-write changes already merged into `testnet` onto `stabilisation` (the branch the running network actually runs on).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended contract write capabilities to support MultiversX and TON blockchains, enabling additional non-EVM chain operations.
  * Added identity verification support for the APTOS blockchain through chain SDK integration.
  * Expanded MultiversX network configuration with a new devnet RPC endpoint, complementing existing mainnet and testnet environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kynesyslabs/node/pull/860?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->