### PR TITLE
fix(forks,validation): post-fork by default on fresh chains + GCREdit hash mismatch

### DIFF
--- a/data/genesis.json
+++ b/data/genesis.json
@@ -9,7 +9,7 @@
   },
   "forks": {
       "osDenomination": {
-          "activationHeight": null
+          "activationHeight": 0
       },
       "gasFeeSeparation": {
           "activationHeight": null,

--- a/src/forks/forkConfig.ts
+++ b/src/forks/forkConfig.ts
@@ -109,14 +109,30 @@ export const PLACEHOLDER_TREASURY_ADDRESS =
     "0x" + "0".repeat(64)
 
 /**
- * Default fork configuration. Every fork starts inactive (`null`) so that a
- * node booting without a `forks` section in genesis is bit-identical to a
- * pre-fork node. Genesis can override individual entries via
- * `genesisData.forks`.
+ * Default fork configuration.
+ *
+ * `osDenomination` defaults to `activationHeight: 0` — fresh chains
+ * boot post-fork by default. Rationale: every Demos chain shipped via
+ * `./run -b true` / `wipe_and_reboot.sh` / docker --clean is a brand-new
+ * chain with no pre-fork peers to maintain wire compatibility with. The
+ * previous default (`null`) was a backwards-compatibility hedge for the
+ * incentives-campaign testnet that crossed the fork mid-flight; that
+ * window has closed. Operators upgrading an existing pre-fork chain
+ * MUST still pin `activationHeight: <future block>` explicitly in
+ * `data/genesis.json.forks.osDenomination` and roll the upgrade in
+ * lock-step with their peers — overriding the default to `null` is
+ * supported and remains the safe path for a live cross-fork upgrade.
+ *
+ * `gasFeeSeparation` stays inactive by default because its activation
+ * also requires a real treasury address — the placeholder zero address
+ * is rejected by the loader when `activationHeight !== null`. Operators
+ * who want this fork active on a fresh chain set both fields explicitly.
+ *
+ * Genesis can override any entry via `genesisData.forks`.
  */
 export const DEFAULT_FORK_CONFIG: ForkConfigByName = {
     osDenomination: {
-        activationHeight: null,
+        activationHeight: 0,
         description:
             "DEM→OS denomination change. amount field becomes OS string.",
     },

--- a/src/libs/network/endpointValidation.ts
+++ b/src/libs/network/endpointValidation.ts
@@ -12,11 +12,13 @@ import log from "src/utilities/logger"
 import { GCRMain } from "@/model/entities/GCRv2/GCR_Main"
 import Datasource from "@/model/datasource"
 import { GCRGeneration } from "@kynesyslabs/demosdk/websdk"
+import { denomination } from "@kynesyslabs/demosdk"
 import {
     hexToUint8Array,
     ucrypto,
     uint8ArrayToHex,
 } from "@kynesyslabs/demosdk/encryption"
+import { isForkActive } from "@/forks/forkGates"
 import TxValidatorPool from "../blockchain/validation/txValidatorPool"
 import GCR from "../blockchain/gcr/gcr"
 
@@ -45,13 +47,63 @@ export async function handleValidateTransaction(
         gcrEdits.forEach((gcredit: GCREdit) => {
             gcredit.txhash = ""
         })
+
+        // Normalise the regenerated gcrEdits through the SAME serializer
+        // the SDK ran on its side before broadcast. Without this, the
+        // post-fork SDK ships `gcr_edits[i].amount` as a canonical OS
+        // decimal string (e.g. `"1000000000"` for the 1-DEM gas edit)
+        // while `GCRGeneration.generate` returns the raw author shape
+        // (`amount: 1` as a JS `number` in DEM for the gas edit). Hashing
+        // those two shapes diverges, surfacing here as a spurious
+        // `GCREdit mismatch` even though the edit set is otherwise
+        // identical (subtract + add + gas + nonce, same accounts, same
+        // base amount).
+        //
+        // We piggyback on `serializeTransactionContent` (SDK), which is
+        // the canonical wire-shape transform — it already walks
+        // `gcr_edits[]` and rewrites embedded `amount` fields on
+        // `balance` / `escrow` / `validatorStake` entries per
+        // `transformEditPostFork` (or `…PreFork` when the fork is
+        // inactive). Wrapping the regenerated edits into a throwaway
+        // content envelope is the cheapest way to reuse that walker
+        // without exporting the private helper.
+        //
+        // Block-height source: `Chain.getLastBlockNumber()` mirrors what
+        // the SDK uses on the client side (its `_isPostForkCached`
+        // ultimately resolves against the same gate via the
+        // `getNetworkInfo` RPC). Pending-tx hashing always references the
+        // current chain tip — block-0 / mempool entries are caught by
+        // `isForkActive` returning `false` on a null/future activation.
+        const blockHeight = await Chain.getLastBlockNumber()
+        const postFork = isForkActive("osDenomination", blockHeight)
+
+        const normaliseGcrEditsForHash = (edits: GCREdit[]): GCREdit[] => {
+            // Build a minimal `TransactionContent`-shaped envelope so
+            // `serializeTransactionContent` can do its `gcr_edits[]`
+            // walk; the other fields are passed through unchanged.
+            const envelope = {
+                ...tx.content,
+                gcr_edits: edits,
+            }
+            const serialised = denomination.serializeTransactionContent(
+                envelope as any,
+                postFork,
+            )
+            const parsed = JSON.parse(serialised) as { gcr_edits: GCREdit[] }
+            return parsed.gcr_edits ?? []
+        }
+
         const handleGcrEditsHashStart = Date.now()
-        const gcrEditsHash = Hashing.sha256(JSON.stringify(gcrEdits))
+        const normalisedRegen = normaliseGcrEditsForHash(gcrEdits)
+        const gcrEditsHash = Hashing.sha256(JSON.stringify(normalisedRegen))
         const handleGcrEditsHashEnd = Date.now()
         log.only(
             `[handleValidateTransaction] GCR edits hash generated in ${handleGcrEditsHashEnd - handleGcrEditsHashStart}ms`,
         )
         log.debug("[handleValidateTransaction] gcrEditsHash: " + gcrEditsHash)
+        // tx.content.gcr_edits is already on the SDK-normalised wire shape
+        // (the SDK serialised before signing); hash it directly to compare
+        // against the freshly-normalised regen above.
         const txGcrEditsHash = Hashing.sha256(
             JSON.stringify(tx.content.gcr_edits),
         )

--- a/testing/forks/disableForkMachineryFlag.test.ts
+++ b/testing/forks/disableForkMachineryFlag.test.ts
@@ -82,13 +82,18 @@ describe("DEMOS_DISABLE_FORK_MACHINERY (rehearsal flag)", () => {
     })
 
     it("loadForkConfigFromGenesis ignores `forks` when flag is set", () => {
+        // Pin to null first so we can prove the loader was a no-op when
+        // the flag is set; without the explicit pin we'd be measuring
+        // against the new post-fork default and the test would pass even
+        // if the flag silently let activation through.
+        getSharedState.forkConfig.osDenomination.activationHeight = null
         process.env.DEMOS_DISABLE_FORK_MACHINERY = "true"
         loadForkConfigFromGenesis({
             forks: {
                 osDenomination: { activationHeight: 5 },
             },
         })
-        // Default config retained: activation stays null (inactive).
+        // Pre-pinned null retained — proving the loader is a no-op.
         expect(
             getSharedState.forkConfig.osDenomination.activationHeight,
         ).toBeNull()

--- a/testing/forks/forkGates.test.ts
+++ b/testing/forks/forkGates.test.ts
@@ -31,7 +31,10 @@ describe("isForkActive — truth table", () => {
     })
 
     it("returns false when activationHeight is null (default)", () => {
-        // All P2 defaults: activationHeight === null.
+        // Legacy pre-fork mode — operator pins null in genesis for live
+        // cross-fork upgrades. Library default flipped to 0 for fresh
+        // chains, so pin null explicitly here.
+        getSharedState.forkConfig.osDenomination.activationHeight = null
         expect(isForkActive("osDenomination", 0)).toBe(false)
         expect(isForkActive("osDenomination", 1)).toBe(false)
         expect(isForkActive("osDenomination", 1_000_000)).toBe(false)

--- a/testing/forks/getNetworkInfo.test.ts
+++ b/testing/forks/getNetworkInfo.test.ts
@@ -76,8 +76,12 @@ describe("getNetworkInfo RPC handler", () => {
     })
 
     it("default state — activationHeight null, fork inactive", async () => {
-        // Fresh defaults: activationHeight === null. currentHeight can be
-        // anything; assert only that the response surfaces it faithfully.
+        // Pin activationHeight to null explicitly to test the legacy
+        // pre-fork path. The library default flipped to `0` (post-fork)
+        // for fresh-chain ergonomics; this scenario covers operators who
+        // still pin null in their genesis.json for live cross-fork
+        // upgrades.
+        getSharedState.forkConfig.osDenomination.activationHeight = null
         getSharedState.lastBlockNumber = 0
 
         const response = await getNetworkInfo(
@@ -92,7 +96,9 @@ describe("getNetworkInfo RPC handler", () => {
     })
 
     it("default state — surfaces non-zero currentHeight while inactive", async () => {
-        // Mid-life node, fork still unconfigured.
+        // Mid-life node, fork still unconfigured. Pin null explicitly —
+        // see comment in the previous test for why.
+        getSharedState.forkConfig.osDenomination.activationHeight = null
         getSharedState.lastBlockNumber = 12_345
 
         const response = await getNetworkInfo(

--- a/testing/forks/loadForkConfig.test.ts
+++ b/testing/forks/loadForkConfig.test.ts
@@ -40,6 +40,10 @@ describe("loadForkConfigFromGenesis", () => {
     })
 
     it("is a no-op for genesis with no `forks` field", () => {
+        // Pin to a known sentinel so we can prove no-op: any value
+        // other than the library default would be overwritten if the
+        // loader were active.
+        getSharedState.forkConfig.osDenomination.activationHeight = null
         const before = JSON.stringify(getSharedState.forkConfig)
         loadForkConfigFromGenesis({
             properties: { id: 1, name: "DEMOS", currency: "DEM" },
@@ -239,6 +243,9 @@ describe("loadForkConfigFromGenesis", () => {
     })
 
     it("handles null/undefined/non-object input gracefully", () => {
+        // Pin to null so the assertion below proves the loader was a
+        // pure no-op (rather than matching the new post-fork default).
+        getSharedState.forkConfig.osDenomination.activationHeight = null
         expect(() => loadForkConfigFromGenesis(null)).not.toThrow()
         expect(() => loadForkConfigFromGenesis(undefined)).not.toThrow()
         expect(() => loadForkConfigFromGenesis("not-an-object")).not.toThrow()

--- a/testing/forks/serializerGate.test.ts
+++ b/testing/forks/serializerGate.test.ts
@@ -84,14 +84,18 @@ describe("serializerGate — bit-identical to JSON.stringify with default config
     })
 
     it("transaction content: same bytes as JSON.stringify at any height (default config)", () => {
+        // Legacy pre-fork mode pinned explicitly — library default is
+        // now post-fork (0), this test still covers the cross-fork
+        // upgrade path where operators pin null in genesis.
+        getSharedState.forkConfig.osDenomination.activationHeight = null
         const content = makeSampleTransactionContent()
         const direct = JSON.stringify(content)
 
         expect(serializeTransactionContent(content, 0)).toBe(direct)
         expect(serializeTransactionContent(content, 1)).toBe(direct)
         expect(serializeTransactionContent(content, 1_000_000)).toBe(direct)
-        // Default: activationHeight === null → fork never active even at
-        // absurdly high heights.
+        // activationHeight === null → fork never active even at absurdly
+        // high heights.
         expect(serializeTransactionContent(content, 999_999_999)).toBe(direct)
     })
 


### PR DESCRIPTION
## Summary

Two coupled fixes surfaced while debugging why a freshly-booted node refused every transfer with `GCREdit mismatch` on a chain whose `genesis.balances` had loaded correctly (PR #858 prerequisite applied).

## Change 1 — `osDenomination.activationHeight` default: `null` → `0`

Every chain shipped via `./run -b true` / `wipe_and_reboot.sh` / `docker --clean` is a brand-new chain with **no pre-fork peers** to maintain wire compatibility with. The previous default (`null`) was a back-compat hedge for the incentives-campaign testnet that crossed the fork mid-flight; that window has closed.

With the old default, operators on a clean docker boot silently ended up **pre-fork** — only whole-DEM transfers accepted, `SubDemPrecisionError` on every "10% of a non-round balance" op.

`gasFeeSeparation` stays at `null` because its activation requires a real treasury address (the placeholder zero is loader-rejected when `activationHeight !== null`). Operators who want it on a fresh chain set both fields explicitly.

**Cross-fork upgrade path preserved.** Operators upgrading an existing pre-fork chain MUST still pin `activationHeight: <future block>` explicitly — overriding to `null` remains the safe path for a live cross-fork upgrade.

`data/genesis.json` in this repo updated to match: `osDenomination.activationHeight: 0`.

## Change 2 — `endpointValidation` normalises regenerated `gcr_edits` before hashing

Root cause of the `GCREdit mismatch` errors:

- SDK serializer rewrites every `gcr_edits[].amount` for balance/escrow/validatorStake entries to a canonical OS decimal string when the fork is active. The 1-DEM gas edit becomes `amount: "1000000000"`.
- Node then runs `GCRGeneration.generate(tx)` to recompute the expected edits. That helper is a pure author producing the raw author shape (`amount: 1` as a JS number in DEM for the gas edit).
- Hashing the two shapes diverges → `GCREdit mismatch` on every post-fork transfer even though the edit set is structurally identical (subtract + add + gas + nonce, same accounts, same base amounts).

Fix: wrap the regenerated edits into a throwaway `{ ...tx.content, gcr_edits }` envelope and run `denomination.serializeTransactionContent` on it, then pull `.gcr_edits` back out. That reuses the SDK's canonical wire-shape transform (per `transformEditPostFork` / `…PreFork`) without us having to mirror the per-edit-type rewrite logic node-side.

Block-height source is `Chain.getLastBlockNumber()`; `postFork` is decided by `isForkActive("osDenomination", blockHeight)`, the same gate the SDK ultimately consults via `getNetworkInfo`.

## Change 3 — Forks unit-test setup hardened

Pre-existing forks unit tests that asserted "default is null" now pin `activationHeight = null` explicitly so they continue exercising the legacy pre-fork path while the library default is post-fork. No assertion changes — just an explicit setup line per test.

## Manual repro on `dev.node2.demos.sh:53552`

- Pre-fix: `bun transfer_10pct.mjs` failed at `confirm()` with `"GCREdit mismatch"`.
- With this fix + `wipe_and_reboot.sh` applied: confirm + broadcast land, receiver balance updates within one block (verified via repeated `getAddressInfo` polls).

## Diagnosis artefacts

Side-by-side dump of SDK-shipped `tx.content.gcr_edits` vs `GCRGeneration.generate(tx)` regen (see `debug_gcr_edits.mjs` — kept out of this PR; sanity script):

```
[2] DIFF
    sdk : {"type":"balance","operation":"remove",…,"amount":"1000000000",…}  ← OS string
    node: {"type":"balance","operation":"remove",…,"amount":1,…}              ← DEM number
```

## Test plan

- [x] `bun test testing/forks/` — 156 pass / 9 skip (Postgres-gated)
- [x] `bun run type-check-ts` — no new errors introduced (pre-existing `l2ps-messaging` + `worker-threads-test` errors unchanged)
- [x] Manual: dry-run + broadcast on `dev.node2` returns "broadcast OK" + receiver balance increment
- [ ] Manual on `dev.node3`: requires `wipe_and_reboot.sh` first (chain isn't yet on a build with PR #858)

## Pre-existing failures NOT introduced by this PR

`bun test testing/forks/` shows 6 failures that reproduce on `stabilisation` baseline:
- `forks integration (P3d) > scenario 1: snapshot replay across fork height …`
- `osDenomination migration > Test 3 / 4 / 6 / 9 / 10`

Verified by stashing this diff and re-running — same failures. Out of scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Changes**
  * osDenomination fork configuration now activates immediately by default on all fresh chains instead of remaining inactive by default.

* **Bug Fixes**
  * Transaction hash validation now normalizes transaction amounts to the SDK wire format before computing comparison hashes to ensure accurate validation.

* **Tests**
  * Test fixtures and scenarios updated with explicit fork activation height configurations for improved test isolation and clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kynesyslabs/node/pull/861?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->