### PR TITLE
fix(transactions): widen amount + fee cols to numeric(38,0) so post-fork OS values cannot overflow

### DIFF
--- a/src/migrations/1779834000000-WidenTransactionsMoneyColsToNumeric.ts
+++ b/src/migrations/1779834000000-WidenTransactionsMoneyColsToNumeric.ts
@@ -1,0 +1,118 @@
+/* LICENSE
+
+© 2026 by KyneSys Labs, licensed under CC BY-NC-ND 4.0
+
+Full license text: https://creativecommons.org/licenses/by-nc-nd/4.0/legalcode
+Human readable license: https://creativecommons.org/licenses/by-nc-nd/4.0/
+
+KyneSys Labs: https://www.kynesys.xyz/
+
+*/
+
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+/**
+ * Widen the four money-shaped columns on `transactions` from PG `bigint`
+ * (int8, max ≈ 9.22 × 10^18) to `numeric(38, 0)` so post-fork OS values
+ * cannot overflow at INSERT time.
+ *
+ * Concretely: a 10 % transfer out of a 10^18 DEM genesis-funded account
+ * is 10^17 DEM × 10^9 OS/DEM = 10^26 OS — three orders of magnitude past
+ * `int8`'s ceiling. Pre-this-migration, `validateTransaction` accepted
+ * the tx (`getAccountBalance` is already `numeric(38, 0)` via
+ * `gcr_main.balance`) but `insertBlock` crashed the consensus loop with:
+ *
+ *     QueryFailedError: value "100000000000000000000000000" is out of
+ *                       range for type bigint
+ *
+ * Postgres allows `ALTER COLUMN … TYPE numeric(38, 0)` against an
+ * existing `bigint` column with an implicit USING cast — every existing
+ * `bigint` value is representable as a `numeric(38, 0)`, so no data
+ * loss is possible.
+ *
+ * Defaults are restored explicitly because `ALTER COLUMN … TYPE` drops
+ * the previous default when the underlying type changes. The
+ * application-layer entity reads these as `bigint` via the
+ * `bigintNumericTransformer` (same transformer used by `gcr_main.balance`).
+ */
+export class WidenTransactionsMoneyColsToNumeric1779834000000
+    implements MigrationInterface
+{
+    name = "WidenTransactionsMoneyColsToNumeric1779834000000"
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        // `amount` is nullable with no default.
+        await queryRunner.query(
+            `ALTER TABLE "transactions" ALTER COLUMN "amount" TYPE numeric(38, 0)`,
+        )
+        // Fee columns are nullable with default 0.
+        await queryRunner.query(
+            `ALTER TABLE "transactions" ALTER COLUMN "networkFee" DROP DEFAULT`,
+        )
+        await queryRunner.query(
+            `ALTER TABLE "transactions" ALTER COLUMN "networkFee" TYPE numeric(38, 0)`,
+        )
+        await queryRunner.query(
+            `ALTER TABLE "transactions" ALTER COLUMN "networkFee" SET DEFAULT 0`,
+        )
+        await queryRunner.query(
+            `ALTER TABLE "transactions" ALTER COLUMN "rpcFee" DROP DEFAULT`,
+        )
+        await queryRunner.query(
+            `ALTER TABLE "transactions" ALTER COLUMN "rpcFee" TYPE numeric(38, 0)`,
+        )
+        await queryRunner.query(
+            `ALTER TABLE "transactions" ALTER COLUMN "rpcFee" SET DEFAULT 0`,
+        )
+        await queryRunner.query(
+            `ALTER TABLE "transactions" ALTER COLUMN "additionalFee" DROP DEFAULT`,
+        )
+        await queryRunner.query(
+            `ALTER TABLE "transactions" ALTER COLUMN "additionalFee" TYPE numeric(38, 0)`,
+        )
+        await queryRunner.query(
+            `ALTER TABLE "transactions" ALTER COLUMN "additionalFee" SET DEFAULT 0`,
+        )
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        // Reverse direction: `numeric(38, 0)` → `bigint`. This narrowing is
+        // LOSSY for any row whose value exceeds 9.22 × 10^18; Postgres will
+        // throw on the offending row rather than silently truncate. That is
+        // the right behaviour — a successful down-migration on a chain
+        // that has already accepted post-fork-magnitude txs would corrupt
+        // the historical ledger. Operators MUST snapshot before running
+        // this down-migration and accept that they cannot reverse without
+        // wiping any post-fork OS magnitudes from `transactions`.
+        await queryRunner.query(
+            `ALTER TABLE "transactions" ALTER COLUMN "additionalFee" DROP DEFAULT`,
+        )
+        await queryRunner.query(
+            `ALTER TABLE "transactions" ALTER COLUMN "additionalFee" TYPE bigint USING "additionalFee"::bigint`,
+        )
+        await queryRunner.query(
+            `ALTER TABLE "transactions" ALTER COLUMN "additionalFee" SET DEFAULT 0`,
+        )
+        await queryRunner.query(
+            `ALTER TABLE "transactions" ALTER COLUMN "rpcFee" DROP DEFAULT`,
+        )
+        await queryRunner.query(
+            `ALTER TABLE "transactions" ALTER COLUMN "rpcFee" TYPE bigint USING "rpcFee"::bigint`,
+        )
+        await queryRunner.query(
+            `ALTER TABLE "transactions" ALTER COLUMN "rpcFee" SET DEFAULT 0`,
+        )
+        await queryRunner.query(
+            `ALTER TABLE "transactions" ALTER COLUMN "networkFee" DROP DEFAULT`,
+        )
+        await queryRunner.query(
+            `ALTER TABLE "transactions" ALTER COLUMN "networkFee" TYPE bigint USING "networkFee"::bigint`,
+        )
+        await queryRunner.query(
+            `ALTER TABLE "transactions" ALTER COLUMN "networkFee" SET DEFAULT 0`,
+        )
+        await queryRunner.query(
+            `ALTER TABLE "transactions" ALTER COLUMN "amount" TYPE bigint USING "amount"::bigint`,
+        )
+    }
+}

--- a/src/model/entities/Transactions.ts
+++ b/src/model/entities/Transactions.ts
@@ -1,5 +1,6 @@
 import type { TransactionContent } from "@kynesyslabs/demosdk/types"
 import { Column, Entity, Index, PrimaryGeneratedColumn } from "typeorm"
+import { bigintNumericTransformer } from "./transformers"
 
 @Entity("transactions")
 @Index("idx_transactions_hash", ["hash"])
@@ -40,7 +41,23 @@ export class Transactions {
     @Column("varchar", { name: "to" })
     to: string
 
-    @Column("bigint", { name: "amount", nullable: true })
+    // Widened from PG `bigint` (int8, max ~9.2e18) to `numeric(38, 0)` so
+    // post-fork OS values fit. A 10% transfer out of the production
+    // genesis-funded 10^18 DEM account is 10^17 DEM × 10^9 OS/DEM = 10^26
+    // OS — three orders of magnitude past `int8`'s ceiling, which manifests
+    // at block-insert time as `value "1e26" is out of range for type bigint`
+    // and crashes the consensus loop. `numeric(38, 0)` matches
+    // `gcr_main.balance` (see PR that introduced bigintNumericTransformer)
+    // and shares its transformer so the application-level type stays
+    // `bigint` end-to-end.
+    @Column({
+        type: "numeric",
+        name: "amount",
+        precision: 38,
+        scale: 0,
+        nullable: true,
+        transformer: bigintNumericTransformer,
+    })
     amount: bigint
 
     @Column("bigint", { name: "nonce", nullable: true, default: 0 })
@@ -49,27 +66,42 @@ export class Transactions {
     @Column("bigint", { name: "timestamp" })
     timestamp: number
 
-    // REVIEW Widened from `integer` (32-bit) to `bigint` so OS-denominated
-    // fees (post-migration) cannot be silently truncated. Pre-migration the
-    // values still fit in 32 bits, so the migration is a pure widening with
-    // no data conversion required. TypeORM returns bigint columns as JS
-    // strings unless a transformer is supplied; callers around
-    // toRawTransaction/fromRawTransaction (the only consumers) coerce via
-    // BigInt() at the boundary.
-    //
-    // `nullable: true, default: 0` — older databases predate the entity
-    // declaration and may have NULL fee rows. With `synchronize: true` an
-    // implicit NOT NULL constraint would fail on startup against such
-    // rows. Allowing NULL + defaulting to 0 lets the node start; readers
-    // already coerce via `Number(rawTx.networkFee ?? 0)` and
-    // `BigInt(... ?? 0)` so a NULL is observed as 0 throughout the stack.
-    @Column("bigint", { name: "networkFee", nullable: true, default: 0 })
+    // Fee columns: same widening rationale as `amount`. `nullable: true,
+    // default: 0` retained — older databases predate the entity
+    // declaration and may have NULL fee rows; readers already coerce
+    // via `BigInt(... ?? 0)` so a NULL is observed as 0 throughout
+    // the stack.
+    @Column({
+        type: "numeric",
+        name: "networkFee",
+        precision: 38,
+        scale: 0,
+        nullable: true,
+        default: "0",
+        transformer: bigintNumericTransformer,
+    })
     networkFee: bigint | null
 
-    @Column("bigint", { name: "rpcFee", nullable: true, default: 0 })
+    @Column({
+        type: "numeric",
+        name: "rpcFee",
+        precision: 38,
+        scale: 0,
+        nullable: true,
+        default: "0",
+        transformer: bigintNumericTransformer,
+    })
     rpcFee: bigint | null
 
-    @Column("bigint", { name: "additionalFee", nullable: true, default: 0 })
+    @Column({
+        type: "numeric",
+        name: "additionalFee",
+        precision: 38,
+        scale: 0,
+        nullable: true,
+        default: "0",
+        transformer: bigintNumericTransformer,
+    })
     additionalFee: bigint | null
 
     // DEM-665: ed25519 public key (lowercase hex, `0x` + 64 hex chars) of


### PR DESCRIPTION
## Summary

A 10% transfer out of a 10^18 DEM genesis-funded account is `10^17 DEM × 10^9 OS/DEM = 10^26 OS` — **three orders of magnitude past PG `bigint`** (int8, max ≈ 9.22 × 10^18).

Pre-fix, `validateTransaction` accepted the tx (`getAccountBalance` reads `gcr_main.balance` as `numeric(38, 0)`) but `insertBlock` crashed the consensus loop:

```
QueryFailedError: value "100000000000000000000000000" is out of range for type bigint
```

## Fix

The four money-shaped columns on `transactions` (`amount`, `networkFee`, `rpcFee`, `additionalFee`) are widened to `numeric(38, 0)` to match `gcr_main.balance`. They share its `bigintNumericTransformer` so the application-level type stays `bigint` end-to-end — readers and writers don't change shape.

### Why this matters

OS-magnitude wire values already land in `amount` post-fork (see `DemosTransactions.pay` where `wireAmount = amountOs.toString()`), and any genesis-funded account big enough to be useful (founder + incentives wallets) trips this on first transfer. Without the fix, validators crash on the first non-trivial transfer.

### Why 9 decimals (not 18)

Demos: 1 DEM = 10^9 OS. The overflow comes from supply magnitude (founder accounts pre-funded at 10^18 DEM), not decimal count. Same structural issue Ethereum-style chains hit with `bigint` — Geth uses byte arrays for the same reason.

## Migration

`1779834000000-WidenTransactionsMoneyColsToNumeric`:
- `ALTER COLUMN … TYPE numeric(38, 0)` — implicit cast from `bigint` is lossless (every `bigint` fits a `numeric(38, 0)`)
- Defaults restored explicitly after the `TYPE` change (Postgres drops them)
- `down()` reverses to `bigint`, but narrowing is **lossy** on any row with a post-fork-magnitude value — operator guidance in the migration log clarifies they must wipe before reverting

## Test plan — devnet repro

Booted local 2-node devnet with funded-genesis fixture (5 identities, 1e18 DEM each, osDenomination active from block 0).

- **Pre-fix**: `confirm()` returns `valid: true`, broadcast lands tx in `reference_block=2`, node-1 crashes at `insertBlock`:
  ```
  value "100000000000000000000000000" is out of range for type bigint
  ```
  Chain stops at block 2, no receiver-side balance update visible.

- **Post-fix**: chain advances to block 9+, receiver balance moves from `1e27` OS (genesis) → `1.1e27` OS (genesis + 1e26 OS transfer). GCREdit hash compare still passes (PR #861 prerequisite).

## Type-check

```bash
bun run type-check-ts
# new code clean; pre-existing duplicate-import errors in chainBlocks.ts + worker-threads-test unchanged
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved numeric precision for transaction monetary fields. Transaction amounts and associated fees (network, RPC, additional) now support larger values with enhanced accuracy for better financial data integrity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kynesyslabs/node/pull/863?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->