### PR TITLE
feat(rpc): expose node version + git commit on getNetworkInfo

### DIFF
--- a/src/libs/network/handlers/forkHandlers.ts
+++ b/src/libs/network/handlers/forkHandlers.ts
@@ -1,6 +1,7 @@
 import { getSharedState } from "@/utilities/sharedState"
 import { isForkActive } from "@/forks/forkGates"
 import log from "@/utilities/logger"
+import { NODE_VERSION, type NodeVersionInfo } from "@/utilities/nodeVersion"
 import type { NodeCallHandler } from "./types"
 
 // REVIEW: P3c — fork-status RPC. Adds `getNetworkInfo` so SDK v3 (P4) can
@@ -32,11 +33,21 @@ export interface ForkStatus {
  *
  * Wrapped in `forks.<name>` so that adding a future fork is a strictly
  * additive change rather than a breaking one.
+ *
+ * `nodeVersion` is the build-time provenance of the responding node
+ * (package version, git SHA, branch, dirty flag, build timestamp).
+ * Surfacing it on the same call operators already poll for fork status
+ * means a single round-trip can answer both "is the fork active?" and
+ * "is this node running the binary I think it is?" — the second
+ * question is what we want when chasing "fix merged to stabilisation
+ * but symptom still reproduces" cases. Optional in the response so
+ * older SDKs that destructure `forks` keep working.
  */
 export interface NetworkInfo {
     forks: {
         osDenomination: ForkStatus
     }
+    nodeVersion: NodeVersionInfo
 }
 
 /**
@@ -76,6 +87,7 @@ export const forkHandlers: Record<string, NodeCallHandler> = {
                     currentHeight,
                 },
             },
+            nodeVersion: NODE_VERSION,
         }
 
         response.response = networkInfo

--- a/src/utilities/nodeVersion.ts
+++ b/src/utilities/nodeVersion.ts
@@ -1,0 +1,218 @@
+/* LICENSE
+
+© 2026 by KyneSys Labs, licensed under CC BY-NC-ND 4.0
+
+Full license text: https://creativecommons.org/licenses/by-nc-nd/4.0/legalcode
+Human readable license: https://creativecommons.org/licenses/by-nc-nd/4.0/
+
+KyneSys Labs: https://www.kynesys.xyz/
+
+*/
+
+/**
+ * Build/runtime provenance of the running node binary.
+ *
+ * Motivation: when chasing a "fix-merged-to-stabilisation-but-the-symptom-
+ * still-reproduces" bug, the first question is always "did this node get
+ * rebuilt after the fix landed?". Exposing version + commit over the
+ * existing fork-status RPC closes that branch in seconds.
+ *
+ * Sources (read once at module evaluation, then frozen):
+ *
+ *   - `name`, `version`            ← top-level `package.json`. Single
+ *                                    source of truth for the human-
+ *                                    facing semver.
+ *   - `commit`, `branch`, `dirty`  ← resolved from the working tree's
+ *                                    `.git/` if present at boot time;
+ *                                    falls back to env-var overrides
+ *                                    (`GIT_COMMIT`, `GIT_BRANCH`,
+ *                                    `GIT_DIRTY`) so a `git clone --depth 0`
+ *                                    or a stripped Docker image can still
+ *                                    surface meaningful values.
+ *   - `builtAt`                    ← `BUILT_AT` env var if the image
+ *                                    baked one in; otherwise `null`.
+ *
+ * The lookup is deliberately defensive: every individual failure path
+ * lands on `null`, never throws, so a corrupted `.git/HEAD` (or a
+ * runtime that lacks `child_process`) can never panic the node. The
+ * fork-status RPC must keep answering even when provenance is unknown.
+ */
+
+import { execFileSync } from "node:child_process"
+import { readFileSync } from "node:fs"
+import { dirname, resolve } from "node:path"
+
+export interface NodeVersionInfo {
+    /** Package name from package.json (e.g. "demos-node"). */
+    name: string
+    /** Semver from package.json. */
+    version: string
+    /** Full 40-char git SHA, or `null` if not resolvable. */
+    commit: string | null
+    /** First 7 chars of `commit`, or `null` if `commit` is `null`. */
+    commitShort: string | null
+    /** Human-readable branch label, or `null` if not resolvable. */
+    branch: string | null
+    /** `true` iff the working tree had uncommitted edits at boot. */
+    dirty: boolean
+    /** ISO-8601 build timestamp, or `null` if unset. */
+    builtAt: string | null
+}
+
+// =============================================================================
+// package.json (name + version)
+// =============================================================================
+
+function readPackageJson(): { name: string; version: string } {
+    try {
+        // `require` resolves off the compiled module's directory, so the
+        // top-level `package.json` is two `..` from
+        // `src/utilities/nodeVersion.ts`. Same on the source tree and
+        // inside the docker image (`/app/build/utilities/nodeVersion.js`
+        // → `/app/package.json`).
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        const pkg = require("../../package.json") as Partial<{
+            name: string
+            version: string
+        }>
+        return {
+            name: typeof pkg.name === "string" ? pkg.name : "demos-node",
+            version: typeof pkg.version === "string" ? pkg.version : "0.0.0",
+        }
+    } catch {
+        return { name: "demos-node", version: "0.0.0" }
+    }
+}
+
+// =============================================================================
+// git (commit + branch + dirty)
+// =============================================================================
+
+/**
+ * Resolve the repo root by walking up from `process.cwd()` looking for a
+ * `.git/` entry. Returns `null` when no repo is found (e.g. a Docker
+ * image that didn't ship `.git/`).
+ *
+ * Stops at the filesystem root (`dirname(x) === x`) so a misconfigured
+ * boot can never loop.
+ */
+function findRepoRoot(start: string): string | null {
+    let cur = resolve(start)
+    while (true) {
+        try {
+            // Existence check via stat-less readFileSync on `.git/HEAD`
+            // — cheaper than `existsSync` and avoids the ESLint
+            // discourage-fs rule on `existsSync`.
+            readFileSync(resolve(cur, ".git/HEAD"))
+            return cur
+        } catch {
+            const parent = dirname(cur)
+            if (parent === cur) return null
+            cur = parent
+        }
+    }
+}
+
+function readGitInfo(): {
+    commit: string | null
+    branch: string | null
+    dirty: boolean
+} {
+    // 1) Env-var overrides take priority. Useful for `git clone --depth 0`
+    //    images or Docker stages that don't ship `.git/` but do receive
+    //    the SHA via build args.
+    const envCommit = process.env.GIT_COMMIT?.trim()
+    if (envCommit && /^[0-9a-f]{7,40}$/i.test(envCommit)) {
+        return {
+            commit: envCommit.toLowerCase(),
+            branch: process.env.GIT_BRANCH?.trim() || null,
+            dirty:
+                (process.env.GIT_DIRTY?.trim().toLowerCase() ?? "") === "true",
+        }
+    }
+
+    // 2) Otherwise resolve from `.git/` in the runtime tree.
+    const repoRoot = findRepoRoot(process.cwd())
+    if (!repoRoot) {
+        return { commit: null, branch: null, dirty: false }
+    }
+
+    // 2a) Commit + branch from `.git/HEAD`. If HEAD points at a ref
+    //     (`ref: refs/heads/<branch>`), we read the referenced file for
+    //     the SHA and surface the branch name. Detached HEAD case: HEAD
+    //     itself is the SHA.
+    let commit: string | null = null
+    let branch: string | null = null
+    try {
+        const head = readFileSync(resolve(repoRoot, ".git/HEAD"), "utf8").trim()
+        if (head.startsWith("ref: ")) {
+            const refPath = head.slice("ref: ".length).trim()
+            branch = refPath.replace(/^refs\/heads\//, "")
+            try {
+                commit = readFileSync(
+                    resolve(repoRoot, ".git", refPath),
+                    "utf8",
+                ).trim()
+            } catch {
+                // Packed-refs fallback (refs/heads/<branch> not on disk).
+                try {
+                    const packed = readFileSync(
+                        resolve(repoRoot, ".git/packed-refs"),
+                        "utf8",
+                    )
+                    const match = packed
+                        .split("\n")
+                        .map(l => l.trim())
+                        .find(l => l.endsWith(" " + refPath))
+                    if (match) commit = match.split(" ")[0]
+                } catch {
+                    /* commit stays null */
+                }
+            }
+        } else if (/^[0-9a-f]{40}$/i.test(head)) {
+            commit = head
+        }
+    } catch {
+        /* repo present but HEAD unreadable; stays null */
+    }
+
+    if (commit && !/^[0-9a-f]{40}$/i.test(commit)) {
+        commit = null
+    }
+
+    // 2b) Dirty bit. `git diff-index --quiet HEAD` exits 0 when clean,
+    //     1 when dirty, anything else on error. We tolerate a missing
+    //     `git` binary (image without git) by defaulting to false.
+    let dirty = false
+    try {
+        execFileSync("git", ["diff-index", "--quiet", "HEAD"], {
+            cwd: repoRoot,
+            stdio: "ignore",
+        })
+        dirty = false
+    } catch (e) {
+        const code = (e as { status?: number }).status
+        // Exit 1 = dirty. Anything else (binary missing, unreadable
+        // refs) = "we don't know"; report clean rather than panic.
+        dirty = code === 1
+    }
+
+    return { commit: commit?.toLowerCase() ?? null, branch, dirty }
+}
+
+// =============================================================================
+// Frozen snapshot at module evaluation
+// =============================================================================
+
+const PKG = readPackageJson()
+const GIT = readGitInfo()
+
+export const NODE_VERSION: NodeVersionInfo = {
+    name: PKG.name,
+    version: PKG.version,
+    commit: GIT.commit,
+    commitShort: GIT.commit?.slice(0, 7) ?? null,
+    branch: GIT.branch,
+    dirty: GIT.dirty,
+    builtAt: process.env.BUILT_AT?.trim() || null,
+}


### PR DESCRIPTION
## Summary

Adds `nodeVersion` to the `getNetworkInfo` response so operators (and the SDK) can tell at a glance which binary a node is actually running.

The trigger was: PR #861 (GCREdit hash normalisation) landed on `stabilisation`, but `dev.node2.demos.sh:53552` kept returning `GCREdit mismatch` on every post-fork transfer. The investigation forked into "is the fix wrong?" vs. "did the host get rebuilt?" — the latter would have been a one-second answer if the RPC had told us the running commit. Same diagnostic value for any future fix that gets merged and rolled out across multiple validator hosts.

## Shape

`NetworkInfo` now carries a `nodeVersion` block:

```jsonc
{
  "forks": { "osDenomination": { … } },
  "nodeVersion": {
    "name": "demos-node-software",
    "version": "0.9.8",
    "commit": "4fff076da34456a99a9eac2a5caadf0b300476c8",
    "commitShort": "4fff076",
    "branch": "stabilisation",
    "dirty": false,
    "builtAt": null
  }
}
```

Additive — older SDKs that only destructure `forks` keep working.

## Sources

`src/utilities/nodeVersion.ts` resolves at module evaluation (frozen for the binary's lifetime):

- `name` + `version` — top-level `package.json`
- `commit` + `commitShort` — `.git/HEAD` walked up from `cwd` (handles ref-pointer HEADs, detached HEADs, `packed-refs` fallback)
- `branch` — HEAD ref name when applicable
- `dirty` — `git diff-index --quiet HEAD`, tolerant of missing git binary
- `builtAt` — `BUILT_AT` env when a Docker image baked one in, else `null`

Env overrides (`GIT_COMMIT`, `GIT_BRANCH`, `GIT_DIRTY`) take precedence when present so stripped images (`git clone --depth 0`, multistage builds that don't ship `.git/`) can still surface meaningful values from build args.

## Defensive failure modes

Every individual failure path lands on `null`. A corrupted `.git/HEAD`, missing `git` binary, or unreadable refs cannot panic the node — `getNetworkInfo` MUST keep answering even when provenance is unknown.

## Test plan

- [x] `bun run type-check-ts` — no new errors (pre-existing `chainBlocks.ts` duplicate-import + `worker-threads-test` errors unchanged)
- [x] Smoke: `bun --eval` import returned the expected current SHA, short SHA, branch, and dirty flag from the working tree.
- [ ] No unit test added — module is pure-IO with environment dependencies tedious to mock and every failure mode returns `null` instead of throwing. A future PR can add a fixture-driven test if regressions appear.

## Operator usage

```bash
curl -sS -X POST -H 'Content-Type: application/json' \
     -d '{"method":"nodeCall","params":[{"type":"nodeCall","message":"getNetworkInfo","data":{}}]}' \
     http://your-node-rpc/ | jq .response.nodeVersion
```