### PR TITLE
fix(validation): symmetric gcr_edits normalisation on both sides of the hash compare

### DIFF
--- a/src/libs/network/endpointValidation.ts
+++ b/src/libs/network/endpointValidation.ts
@@ -101,11 +101,24 @@ export async function handleValidateTransaction(
             `[handleValidateTransaction] GCR edits hash generated in ${handleGcrEditsHashEnd - handleGcrEditsHashStart}ms`,
         )
         log.debug("[handleValidateTransaction] gcrEditsHash: " + gcrEditsHash)
-        // tx.content.gcr_edits is already on the SDK-normalised wire shape
-        // (the SDK serialised before signing); hash it directly to compare
-        // against the freshly-normalised regen above.
+        // SYMMETRY: tx.content.gcr_edits must be hashed in the EXACT same
+        // shape as `normalisedRegen` above, otherwise any field the SDK
+        // populates that the regen path blanks (or vice-versa) shows up as
+        // a spurious "GCREdit mismatch". Two specific gotchas:
+        //   1. `txhash`. The SDK currently ships gcr_edits with `txhash`
+        //      empty, but some flows (and older nodes) propagate the
+        //      parent tx hash into every edit. Force-blank on both sides
+        //      to make the hash invariant under that choice.
+        //   2. Embedded amount shape (number vs OS string). Already
+        //      handled by `normaliseGcrEditsForHash`; we mirror that
+        //      walker on the tx-side input by feeding it through the
+        //      same envelope.
+        const txEditsBlanked = (tx.content.gcr_edits ?? []).map(
+            (e: GCREdit) => ({ ...e, txhash: "" }),
+        )
+        const normalisedTxEdits = normaliseGcrEditsForHash(txEditsBlanked)
         const txGcrEditsHash = Hashing.sha256(
-            JSON.stringify(tx.content.gcr_edits),
+            JSON.stringify(normalisedTxEdits),
         )
         log.debug(
             "[handleValidateTransaction] txGcrEditsHash: " + txGcrEditsHash,


### PR DESCRIPTION
## Production repro

dev.node2 (rebuilt from `0f8ead5d`, which already includes PR #861) keeps logging:

```
gcrEditsHash:   16f9495100b98...   ← constant across runs (regen, normalised)
txGcrEditsHash: 6dabe23e82ad...    ← varies per run (raw tx.content.gcr_edits)
→ GCREdit mismatch
```

The regen path was normalised by #861 (txhash blanked + serializer-walk via the envelope) but the tx-side input was hashed straight from `tx.content.gcr_edits` without the same treatment. Whatever field varies in the wire payload — most likely a populated `txhash` on inbound edits some SDK flow ships, plus the post-fork OS-string vs pre-fork DEM-number ambiguity on `amount` — ended up in the hash and diverged from the blanked-regen value.

## Fix

Symmetric normalisation on both sides:
- `txhash` forced empty on regen *and* tx-side edits before hash
- both sides walk through the same `normaliseGcrEditsForHash` envelope so the serializer's per-edit-type rewrite applies uniformly

The compare is now truly asking "did the SDK generate the same logical edit set as `GCRGeneration.generate`?" instead of "does the SDK happen to produce byte-identical JSON to `GCRGeneration.generate`?".

## Test plan

- [x] `bun run type-check-ts` — no new errors
- [ ] Verify on dev.node2 after rebuild: `BROADCAST=1 bun transfer_10pct.mjs` returns `valid: true` instead of `GCREdit mismatch`