### PR TITLE
fix(deps): pin @kynesyslabs/demosdk via overrides to collapse nested 2.12.2 install

### DIFF
--- a/package.json
+++ b/package.json
@@ -175,6 +175,7 @@
         "socket.io-parser": ">=4.2.6",
         "valibot": ">=1.2.0",
         "fast-xml-parser": ">=5.3.4",
-        "validator": ">=13.15.20"
+        "validator": ">=13.15.20",
+        "@kynesyslabs/demosdk": "4.0.0"
     }
 }


### PR DESCRIPTION
## Repro

SDK 4.0.0 ships with a self-dep on `@kynesyslabs/demosdk@^2.8.22`. bun obediently installs a SECOND copy nested:

```
node_modules/@kynesyslabs/demosdk/                              ← 4.0.0
node_modules/@kynesyslabs/demosdk/node_modules/
                                  @kynesyslabs/demosdk/         ← 2.12.2
```

Any module resolution that lands on the nested copy sees the OLD API surface. The 2.12.2 post-fork serializer does NOT walk `gcr_edits[].amount`, which produces a different canonical hash than the SDK that signed the tx — surfaces on the node as `GCREdit mismatch` on every post-fork transfer.

## Fix

`overrides["@kynesyslabs/demosdk"]: "4.0.0"` forces single-version install across the whole tree. Nested copy collapses.

Verified by `rm -rf node_modules/@kynesyslabs && bun install`: a single `@kynesyslabs/demosdk/package.json` at 4.0.0, no nested copy.

## Companion

sdks PR https://github.com/kynesyslabs/sdks/pull/88 drops the self-dep and bumps SDK to 4.0.1. Once that's published, this override can bump to `4.0.1` too. Until then, 4.0.0 + override is the safe combination.

## Test plan

- [x] `bun install` from clean tree: single SDK installed
- [ ] Rebuild dev.node2 with this PR + retry `bun transfer_10pct.mjs`: expect `valid: true` confirm