### PR TITLE
debug(validation): emit raw gcr_edits dump on mismatch + version canary (DEBUG-ONLY)

### DIFF
--- a/src/libs/network/endpointValidation.ts
+++ b/src/libs/network/endpointValidation.ts
@@ -123,8 +123,39 @@ export async function handleValidateTransaction(
         log.debug(
             "[handleValidateTransaction] txGcrEditsHash: " + txGcrEditsHash,
         )
+        // CANARY: distinctive log line that proves the running binary
+        // includes the symmetric-normalisation branch (PR #867+). If you
+        // grep node logs for this string and see nothing, the runtime is
+        // executing pre-PR-#867 bytes despite the source file on disk
+        // appearing up-to-date.
+        log.debug(
+            "[handleValidateTransaction] SYMMETRIC-NORMALISE-V2 active",
+        )
         const comparison = txGcrEditsHash === gcrEditsHash
         if (!comparison) {
+            // DEBUG: on mismatch, dump the raw JSON shape both sides see
+            // so we can identify the specific field that diverges between
+            // SDK ship and node regen. Hex-encoded so multi-line JSON
+            // doesn't break log parsing.
+            try {
+                log.error(
+                    "[handleValidateTransaction] mismatch dump.tx: " +
+                        JSON.stringify(normalisedTxEdits),
+                )
+                log.error(
+                    "[handleValidateTransaction] mismatch dump.regen: " +
+                        JSON.stringify(normalisedRegen),
+                )
+                log.error(
+                    "[handleValidateTransaction] mismatch dump.rawTx: " +
+                        JSON.stringify(tx.content.gcr_edits ?? []),
+                )
+            } catch (dumpErr) {
+                log.error(
+                    "[handleValidateTransaction] mismatch dump failed: " +
+                        (dumpErr instanceof Error ? dumpErr.message : String(dumpErr)),
+                )
+            }
             log.error(
                 "[handleValidateTransaction] GCREdit mismatch: " +
                     txGcrEditsHash +


### PR DESCRIPTION
Diagnostic-only logging to chase the dev.node2 mystery (source has the fix, container reports the right SHA, mismatch still happens). Two log lines added:

1. **SYMMETRIC-NORMALISE-V2 canary** — distinctive marker that proves the running binary executed the post-#867 branch. If grep finds nothing on the host, the runtime is using stale bytes despite the SHA.
2. **Mismatch dump** — on hash compare fail, emit three JSON blobs (normalised tx-side, normalised regen, raw tx.content.gcr_edits) so we can eyeball-diff the exact field that diverges.

Pure logging. No consensus / validation behaviour change. Will revert as soon as root cause is found.