### PR TITLE
fix(validation): snapshot tx.content.gcr_edits BEFORE confirmTransaction so applyGasFeeSeparation prepends don't break hash compare

### DIFF
--- a/src/libs/network/endpointValidation.ts
+++ b/src/libs/network/endpointValidation.ts
@@ -31,6 +31,25 @@ export async function handleValidateTransaction(
     log.info("SERVER", fname + "Handling transaction...")
     let validationData: ValidityData
     try {
+        // SNAPSHOT the SDK-shipped gcr_edits BEFORE confirmTransaction
+        // mutates the array. `confirmTransaction` calls
+        // `applyGasFeeSeparation` when the gasFeeSeparation fork is
+        // active, which PREPENDS node-computed fee edits onto
+        // `tx.content.gcr_edits`. Without this snapshot, the hash
+        // comparison below would be comparing
+        //   tx.content.gcr_edits (mutated: [fee...,subtract,add,gas,nonce])
+        // against
+        //   GCRGeneration.generate(tx) (regen: [subtract,add,gas,nonce])
+        // and diverge by exactly the prepended fee edits — a structural
+        // mismatch the SDK has no way to predict because the fee
+        // distribution is the validator's computation, not the
+        // signer's. Hashing the snapshot keeps the compare meaningful:
+        // "did the SDK ship the same edits GCRGeneration would
+        // regenerate?", which is the actual invariant we want.
+        const txShippedGcrEdits: GCREdit[] = JSON.parse(
+            JSON.stringify(tx.content.gcr_edits ?? []),
+        )
+
         const handleConfirmTransactionStart = Date.now()
         validationData = await confirmTransaction(tx, sender)
         const handleConfirmTransactionEnd = Date.now()
@@ -113,7 +132,10 @@ export async function handleValidateTransaction(
         //      handled by `normaliseGcrEditsForHash`; we mirror that
         //      walker on the tx-side input by feeding it through the
         //      same envelope.
-        const txEditsBlanked = (tx.content.gcr_edits ?? []).map(
+        // Use the PRE-confirmTransaction snapshot, not tx.content.gcr_edits,
+        // which `applyGasFeeSeparation` may have mutated by prepending
+        // node-computed fee edits.
+        const txEditsBlanked = txShippedGcrEdits.map(
             (e: GCREdit) => ({ ...e, txhash: "" }),
         )
         const normalisedTxEdits = normaliseGcrEditsForHash(txEditsBlanked)


### PR DESCRIPTION
## Root cause

`confirmTransaction` runs `applyGasFeeSeparation` when the `gasFeeSeparation` fork is active, which **PREPENDS** node-computed fee edits onto `tx.content.gcr_edits` in place. The hash comparison ran AFTER that mutation:

```
tx.content.gcr_edits (mutated):  [fee_a, fee_b, ..., subtract, add, gas, nonce]
GCRGeneration.generate(tx):                          [subtract, add, gas, nonce]
```

Divergence by EXACTLY the prepended fee edits — a structural mismatch the SDK has no way to predict because the fee distribution is the validator's computation, not the signer's.

**dev.node2** reproduced; **local devnet** did NOT because the devnet boots with `gasFeeSeparation.activationHeight: null` → `applyGasFeeSeparation` gated off → no prepend → #861+#867 normalisation was sufficient.

## Fix

Snapshot `tx.content.gcr_edits` via structured clone BEFORE calling `confirmTransaction`, then hash against the snapshot instead of the mutated array. The invariant we want to verify is "did the SDK ship the same edits GCRGeneration would regenerate?" — exactly what the snapshot captures.

Fee edits live downstream of this check and become part of the signed validity data via the existing `signValidityData` flow — no consensus impact.

## Trace

- `applyGasFeeSeparation.ts:187` mutates `tx.content.gcr_edits` in place
- `validateTransaction.ts:133` calls it inside `confirmTransaction`
- `endpointValidation.ts:35` calls `confirmTransaction`, then was reading the already-mutated `tx.content.gcr_edits`

## Test plan

- [x] Local devnet: still passes (regression test for the gasFeeSeparation-inactive path)
- [ ] dev.node2: rebuild + retry `BROADCAST=1 bun transfer_10pct.mjs` — expect `valid: true`

## Companion PRs in the saga

- #858 genesis.balances overlay
- #861 / #867 gcr_edits hash normalisation
- #863 numeric(38,0) widening
- #869 SDK override pin
- #870 (DEBUG-only) canary log + dump on mismatch — kept; can be reverted after this PR is verified

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed transaction validation to ensure accurate hash computations and comparisons throughout the confirmation process, improving transaction integrity check reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kynesyslabs/node/pull/871?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->