### PR TITLE
fix(transaction): return string instead of throwing on post-fork OS-magnitude amounts in fromEntityToWireNumber

### DIFF
--- a/src/libs/blockchain/transaction.ts
+++ b/src/libs/blockchain/transaction.ts
@@ -634,17 +634,33 @@ function toEntityBigint(
  */
 function fromEntityToWireNumber(
     value: string | number | bigint | null | undefined,
-): number {
+): number | string {
     if (value === null || value === undefined) {
         return 0
     }
     const big: bigint =
         typeof value === "bigint" ? value : BigInt(value as string | number)
     const max = BigInt(Number.MAX_SAFE_INTEGER)
+    // Post-fork: OS-magnitude amounts exceed `Number.MAX_SAFE_INTEGER`
+    // (~9.007e15 OS = ~9.007M DEM). Coerce to a decimal string instead
+    // of throwing — the SDK's `TxFee.{network_fee,rpc_fee,additional_fee}`
+    // and `TransactionContent.amount` are typed `string | number` since
+    // 3.1.0, so the string shape is wire-legal and lossless.
+    //
+    // The previous behaviour (throw on overflow) was inherited from
+    // pre-fork days when this helper only ever saw DEM-magnitude values.
+    // After the osDenomination fork activates, every persisted amount
+    // is in OS — and any post-fork chain that ever processes a transfer
+    // big enough to need OS precision (a 10 % move out of a founder
+    // wallet pre-funded with 10^18 DEM = 10^27 OS, for instance) would
+    // hit this throw on every `getTransactionStatus` poll, exactly the
+    // path the SDK's `broadcastAndWait` walks while waiting for
+    // inclusion. The polling caller then sees an HTTP 500 envelope,
+    // never observes `state: "included"`, and times out — even though
+    // the tx is on chain. Returning a string instead lets the SDK keep
+    // parsing the response and observing the correct lifecycle state.
     if (big > max || big < -max) {
-        throw new Error(
-            `fromEntityToWireNumber: value ${big.toString()} exceeds Number.MAX_SAFE_INTEGER (~9.007e15). This indicates a wire-shape mismatch — pre-fork wire should never carry OS-magnitude amounts. See myc#77 / GH#3213223281.`,
-        )
+        return big.toString()
     }
     return Number(big)
 }


### PR DESCRIPTION
## Repro

After PR #871 unblocked `confirmTx` on dev.node2:

```
[2/3] confirm() — valid: true, reference_block: 36
[3/3] broadcastAndWait() — BroadcastTimeoutError after 60s
```

Even though the tx landed (sender nonce 0→1, sender -1e26 OS, receiver +1e26 OS, block 64 reached). The SDK polls `getTransactionStatus(hash)` to confirm inclusion; that handler crashes 500 on every call:

```json
{ "result": 500, "response": { "error": "INTERNAL_ERROR" },
  "extra": "Error: fromEntityToWireNumber: value 100000000000000000000000000 exceeds Number.MAX_SAFE_INTEGER (~9.007e15)…" }
```

## Root cause

`fromEntityToWireNumber` is the pre-fork-era wire-format helper. Its `throw` on `value > Number.MAX_SAFE_INTEGER` was a "this can't happen in DEM" guard, inherited from before the osDenomination fork. After the fork activates, every persisted `amount` / fee is in OS, and any transfer big enough to need OS precision (a 10 % move out of a 10^18 DEM founder wallet = 10^26 OS) trips the throw on EVERY subsequent read through `fromRawTransaction` — including the `getTransactionStatus` handler the SDK polls.

## Fix

When the value exceeds `Number.MAX_SAFE_INTEGER`, return a decimal string instead. SDK's `TxFee.{network_fee,rpc_fee,additional_fee}` and `TransactionContent.amount` are both typed `string | number` since 3.1.0, so the string shape is wire-legal and lossless.

Return type widens `number → number | string`. Sub-MAX_SAFE_INTEGER values still pass through as `number` so pre-fork chains and pre-fork test fixtures are bit-identical.

## Test plan

- [x] type-check clean
- [ ] dev.node2 rebuild + `BROADCAST=1 bun transfer_10pct.mjs` — expect `broadcastAndWait` to return `{ state: "included", blockNumber: N }` instead of timing out
EOF
)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced handling of large blockchain transaction amounts and fees, preventing conversion errors that previously occurred with oversized values while ensuring precision is maintained.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kynesyslabs/node/pull/872?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->