### PR TITLE
fix(l2ps): handle post-fork OS-magnitude amounts losslessly in L2PSTransactions + batch aggregator

### DIFF
--- a/src/libs/l2ps/L2PSBatchAggregator.ts
+++ b/src/libs/l2ps/L2PSBatchAggregator.ts
@@ -501,13 +501,38 @@ export class L2PSBatchAggregator {
             // Convert transactions to ZK-friendly format using the amount from tx content when present.
             // If absent, fallback to 0n to avoid failing the batching loop.
             const zkTransactions = transactions.map((tx) => {
-                // Safely convert amount to BigInt with validation
+                // Safely convert amount to BigInt with validation. The
+                // amount field is `string | number | bigint` across the
+                // SDK wire shapes — pre-fork carries a DEM `number`,
+                // post-fork carries an OS decimal string that exceeds
+                // `Number.MAX_SAFE_INTEGER` for any meaningful supply.
+                // Routing through `Number()` first would silently
+                // round-trip the post-fork string through a lossy
+                // double-precision cast (10^26 OS becomes ~10^26 minus
+                // junk in the low ~70 bits); BigInt() accepts string,
+                // number, and bigint directly, so let it handle the
+                // coercion losslessly.
                 const rawAmount = (tx.encrypted_tx as any)?.content?.amount
                 let amount: bigint
                 try {
-                    amount = rawAmount !== undefined && rawAmount !== null
-                        ? BigInt(Math.floor(Number(rawAmount)))
-                        : 0n
+                    if (rawAmount === undefined || rawAmount === null) {
+                        amount = 0n
+                    } else if (typeof rawAmount === "bigint") {
+                        amount = rawAmount
+                    } else if (typeof rawAmount === "number") {
+                        if (!Number.isFinite(rawAmount)) {
+                            amount = 0n
+                        } else {
+                            amount = BigInt(Math.trunc(rawAmount))
+                        }
+                    } else {
+                        // string path — accept decimal-integer strings as
+                        // BigInt() does natively; reject fractional strings
+                        // by truncating at the decimal point if present.
+                        const s = String(rawAmount).trim()
+                        const i = s.indexOf(".")
+                        amount = BigInt(i >= 0 ? s.slice(0, i) : s)
+                    }
                 } catch {
                     amount = 0n
                 }

--- a/src/migrations/1779834500000-WidenL2PSTransactionsAmountToNumeric.ts
+++ b/src/migrations/1779834500000-WidenL2PSTransactionsAmountToNumeric.ts
@@ -1,0 +1,55 @@
+/* LICENSE
+
+© 2026 by KyneSys Labs, licensed under CC BY-NC-ND 4.0
+
+Full license text: https://creativecommons.org/licenses/by-nc-nd/4.0/legalcode
+Human readable license: https://creativecommons.org/licenses/by-nc-nd/4.0/
+
+KyneSys Labs: https://www.kynesys.xyz/
+
+*/
+
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+/**
+ * Same widening as `WidenTransactionsMoneyColsToNumeric1779834000000`,
+ * applied to `l2ps_transactions.amount`. L2PS replays per-tx amounts
+ * inside aggregated L1 batches, so a post-fork OS amount (e.g. 10^26
+ * for a 10 % move out of a 10^18 DEM wallet) lands here too. Without
+ * the widening, the column would reject any post-fork batch with
+ * `value … is out of range for type bigint`, exactly the consensus-
+ * breaking crash we fixed on the top-level `transactions` table.
+ *
+ * `numeric(38, 0)` lossless-casts from `bigint` (every int8 fits),
+ * so `up` is safe. `down` is narrowing and lossy on any persisted
+ * post-fork-magnitude row — operators must accept that.
+ */
+export class WidenL2PSTransactionsAmountToNumeric1779834500000
+    implements MigrationInterface
+{
+    name = "WidenL2PSTransactionsAmountToNumeric1779834500000"
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `ALTER TABLE "l2ps_transactions" ALTER COLUMN "amount" DROP DEFAULT`,
+        )
+        await queryRunner.query(
+            `ALTER TABLE "l2ps_transactions" ALTER COLUMN "amount" TYPE numeric(38, 0)`,
+        )
+        await queryRunner.query(
+            `ALTER TABLE "l2ps_transactions" ALTER COLUMN "amount" SET DEFAULT 0`,
+        )
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `ALTER TABLE "l2ps_transactions" ALTER COLUMN "amount" DROP DEFAULT`,
+        )
+        await queryRunner.query(
+            `ALTER TABLE "l2ps_transactions" ALTER COLUMN "amount" TYPE bigint USING "amount"::bigint`,
+        )
+        await queryRunner.query(
+            `ALTER TABLE "l2ps_transactions" ALTER COLUMN "amount" SET DEFAULT 0`,
+        )
+    }
+}

--- a/src/model/entities/L2PSTransactions.ts
+++ b/src/model/entities/L2PSTransactions.ts
@@ -15,6 +15,7 @@ import {
     Index,
     CreateDateColumn,
 } from "typeorm"
+import { bigintNumericTransformer } from "./transformers"
 
 /**
  * L2PS Transaction Entity
@@ -96,9 +97,20 @@ export class L2PSTransaction {
     to_address: string
 
     /**
-     * Transaction amount
+     * Transaction amount. Widened from PG `bigint` (int8, max ~9.22 × 10^18)
+     * to `numeric(38, 0)` for the same reason `transactions.amount` was
+     * widened in the iter-5 fork bump: post-fork OS values exceed int8
+     * on any meaningful supply (10 % of a 10^18 DEM founder wallet is
+     * 10^26 OS). Application-level type stays `bigint` via the shared
+     * transformer.
      */
-    @Column("bigint", { default: 0 })
+    @Column({
+        type: "numeric",
+        precision: 38,
+        scale: 0,
+        default: "0",
+        transformer: bigintNumericTransformer,
+    })
     amount: bigint
 
     /**


### PR DESCRIPTION
Companion to #863 (top-level `transactions` widening) + #872 (`fromEntityToWireNumber` post-fork string fallback). Audit found two more post-fork overflow bombs:

## 1. L2PSTransactions.amount widened

`@Column("bigint")` → `@Column("numeric(38, 0)")` with shared transformer. L2PS replays per-tx amounts inside aggregated L1 batches, so a 10 % move out of a 10^18 DEM wallet (10^26 OS) overflows int8 the same way the top-level table did. Migration `1779834500000` mirrors `1779834000000`.

## 2. L2PSBatchAggregator BigInt(Math.floor(Number(rawAmount))) anti-pattern

The wire shape is `string | number | bigint`. Routing the post-fork decimal-string through `Number()` first silently truncates to the nearest double-precision value (10^26 OS becomes 10^26 minus ~70 low bits of junk) before `BigInt()` is even reached. Rewritten to handle each input type directly: bigint/number pass through, decimal-integer strings go straight to `BigInt()`.

## Audit results for remaining MAX_SAFE_INTEGER sites

| Site | Verdict |
|---|---|
| `subOperations.transferNative` | dead code, no live caller |
| `l2ps_hashes.ts:220` | seed value for `reduce()` |
| `omniprotocol/sync.ts:146` | block-number cap |
| `forks/migrations/osDenomination.ts` | legacy GCR, retired |
| `transformers.ts` | unsafe-Number guard in BigInt transformer, correct behaviour |

Both fixed bombs would have fired the first time an L2PS batch carried a real founder-wallet transfer. Same fix shape as #863.