### PR TITLE
chore(scripts): upgrade_sdk + check_sdk shell helpers, drop "latest" override

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
         "start:clean": "rm -rf data/chain.db && tsx -r tsconfig-paths/register src/index.ts",
         "start:purge": "rm -rf .demos_identity && rm -rf data/chain.db && tsx -r tsconfig-paths/register src/index.ts",
         "dev": "ts-node-dev --import tsx --respawn --transpile-only src/index.ts",
-        "upgrade_sdk": "bun update @kynesyslabs/demosdk --latest",
+        "upgrade_sdk": "scripts/upgrade-sdk.sh",
+        "check_sdk": "scripts/check-sdk.sh",
         "upgrade_deps": "bun update-interactive --latest",
         "upgrade_deps:force": "ncu -u && bun install",
         "keygen": "tsx -r tsconfig-paths/register src/libs/utils/keyMaker.ts",
@@ -104,7 +105,7 @@
         "@fastify/cors": "^9.0.1",
         "@fastify/swagger": "^8.15.0",
         "@fastify/swagger-ui": "^4.1.0",
-        "@kynesyslabs/demosdk": "4.0.2",
+        "@kynesyslabs/demosdk": "4.0.3",
         "@metaplex-foundation/js": "^0.20.1",
         "@modelcontextprotocol/sdk": "^1.13.3",
         "@noble/ed25519": "^3.0.0",
@@ -176,6 +177,6 @@
         "valibot": ">=1.2.0",
         "fast-xml-parser": ">=5.3.4",
         "validator": ">=13.15.20",
-        "@kynesyslabs/demosdk": "latest"
+        "@kynesyslabs/demosdk": "4.0.3"
     }
 }

--- a/scripts/check-sdk.sh
+++ b/scripts/check-sdk.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# check-sdk.sh — print the currently-installed @kynesyslabs/demosdk
+# version alongside what package.json declares, so operators can
+# verify at a glance whether their tree matches expectations.
+#
+# Surfaces three things:
+#   1. dependencies pin in package.json
+#   2. overrides pin in package.json (single-version guarantee)
+#   3. actual version installed under node_modules/@kynesyslabs/demosdk
+#      AND any nested copies (which would indicate the override didn't
+#      take — should never happen on a clean install but useful to
+#      catch lockfile drift early).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+PKG="@kynesyslabs/demosdk"
+cd "${REPO_ROOT}"
+
+DEP="$(bun pm pkg get "dependencies.${PKG}" 2>/dev/null | tr -d '"' || echo "(not declared)")"
+OVR="$(bun pm pkg get "overrides.${PKG}" 2>/dev/null | tr -d '"' || echo "(not declared)")"
+
+echo "package.json:"
+echo "  dependencies.${PKG} = ${DEP}"
+echo "  overrides.${PKG}    = ${OVR}"
+echo
+
+INSTALLED_COUNT=0
+echo "installed copies under node_modules/:"
+# Walk every package.json under any node_modules tree and pull versions
+# of @kynesyslabs/demosdk. Multiple lines = the override pin failed and
+# bun materialised more than one version.
+while IFS= read -r pjson; do
+    if grep -q "\"name\": *\"${PKG}\"" "${pjson}"; then
+        v="$(grep -oE '"version" *: *"[^"]+"' "${pjson}" | head -1 | sed 's/.*"\([^"]*\)"/\1/')"
+        echo "  ${pjson} → ${v}"
+        INSTALLED_COUNT=$((INSTALLED_COUNT + 1))
+    fi
+done < <(find node_modules -path '*/@kynesyslabs/demosdk/package.json' 2>/dev/null)
+
+if [[ "${INSTALLED_COUNT}" -eq 0 ]]; then
+    echo "  (none installed — run \`bun install\`)"
+elif [[ "${INSTALLED_COUNT}" -gt 1 ]]; then
+    echo
+    echo "WARN: ${INSTALLED_COUNT} copies of ${PKG} installed."
+    echo "      The overrides pin should collapse them to one — run"
+    echo "      \`bun run upgrade_sdk\` or check overrides in package.json."
+fi

--- a/scripts/upgrade-sdk.sh
+++ b/scripts/upgrade-sdk.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# upgrade-sdk.sh — upgrade @kynesyslabs/demosdk to latest, then pin the
+# resolved version in BOTH `dependencies` and `overrides` so the next
+# `bun install` (and every CI build) gets the exact same version back.
+#
+# Why pin both:
+#   - `dependencies` controls what THIS package requests.
+#   - `overrides` flattens the install tree so no transitive dep
+#     (including the self-dep loop the SDK shipped pre-4.0.1) can
+#     sneak a different version in alongside ours.
+#
+# Why not leave `overrides` at `"latest"`:
+#   "latest" is non-deterministic — two operators running `bun install`
+#   an hour apart could end up on different SDK versions while the
+#   lockfile silently absorbs the drift. Pinning the exact version makes
+#   the build bit-reproducible; upgrading becomes an explicit
+#   `bun run upgrade_sdk` operator action.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+PKG="@kynesyslabs/demosdk"
+cd "${REPO_ROOT}"
+
+echo "[upgrade-sdk] upgrading ${PKG} to latest…"
+bun update "${PKG}" --latest
+
+# Read whatever resolved range bun wrote into package.json and strip
+# the `^` / `~` prefix. bun pm pkg get returns a JSON-encoded string,
+# so trim the surrounding quotes too.
+RESOLVED="$(bun pm pkg get "dependencies.${PKG}" | tr -d '"')"
+EXACT="${RESOLVED#[\^~]}"
+
+if [[ ! "${EXACT}" =~ ^[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+    echo "[upgrade-sdk] dependency range '${RESOLVED}' is not a plain version; refusing to pin a non-semver value." >&2
+    exit 1
+fi
+
+echo "[upgrade-sdk] pinning ${PKG}=${EXACT} in dependencies + overrides…"
+bun pm pkg set "dependencies.${PKG}=${EXACT}"
+bun pm pkg set "overrides.${PKG}=${EXACT}"
+
+echo "[upgrade-sdk] re-installing so the lockfile reflects the override…"
+bun install
+
+echo "[upgrade-sdk] done — ${PKG} pinned at ${EXACT}."


### PR DESCRIPTION
## Summary

`overrides["@kynesyslabs/demosdk"]: "latest"` was wrong — "latest" is non-deterministic so two operators running `bun install` an hour apart can pick up different SDK versions while the lockfile silently absorbs the drift.

## Changes

- **scripts/upgrade-sdk.sh** — `bun update --latest` → read resolved range → pin EXACT version in both `dependencies` and `overrides` → `bun install`. Upgrading is now an explicit operator action, build stays bit-reproducible.
- **scripts/check-sdk.sh** — prints declared pins + every installed copy under `node_modules/`. >1 copy emits a warning so we catch lockfile drift before it becomes a ghost "GCREdit mismatch" bug (we already lost a day to nested 2.12.2 alongside top-level 4.0.0).
- **package.json** — both registered as `bun run upgrade_sdk` / `bun run check_sdk`.

Smoke verified locally:
```
$ bun run check_sdk
package.json:
  dependencies.@kynesyslabs/demosdk = 4.0.3
  overrides.@kynesyslabs/demosdk    = 4.0.3
installed copies under node_modules/:
  node_modules/@kynesyslabs/demosdk/package.json → 4.0.3
```