### PR TITLE
feat(mempool): mempool-aware nonce lookahead in assignNonce (batch C PR 2)

### DIFF
--- a/docs/specs/audit-sweep-batch-c-nonce.md
+++ b/docs/specs/audit-sweep-batch-c-nonce.md
@@ -2,8 +2,12 @@
 type: spec
 title: Audit-Sweep Batch C — Nonce-based Replay Protection
 date: 2026-05-30
-status: draft
+status: in-progress
 related: docs/specs/active-feature-test-addition-proposal.md, .ccb/bug-hunt-2026-05-28/FINAL_REPORT.md
+prs:
+  - "#884 (PR 1: fork registration + assignNonce infra — merged)"
+  - "#TBD (PR 2: mempool-aware lookahead)"
+  - "#TBD (PR 3: consensus rule + caller wire-up, after SDK publish)"
 ---
 
 # Audit-Sweep Batch C — Nonce-based Replay Protection

--- a/docs/specs/audit-sweep-batch-c-nonce.md
+++ b/docs/specs/audit-sweep-batch-c-nonce.md
@@ -6,7 +6,7 @@ status: in-progress
 related: docs/specs/active-feature-test-addition-proposal.md, .ccb/bug-hunt-2026-05-28/FINAL_REPORT.md
 prs:
   - "#884 (PR 1: fork registration + assignNonce infra — merged)"
-  - "#TBD (PR 2: mempool-aware lookahead)"
+  - "#885 (PR 2: mempool-aware lookahead)"
   - "#TBD (PR 3: consensus rule + caller wire-up, after SDK publish)"
 ---
 
@@ -152,6 +152,8 @@ the existing demosdk pinning pattern in `package.json`).
 |------|------------|
 | In-flight txs with stale nonces after fork activation | SDK already reads nonce live per tx; only stuck txs in custom integrations are at risk. Document in fork-activation runbook. |
 | Mempool count diverges from on-chain state (race) | Single-writer mempool; `countPendingByAddress` reads the same Postgres txn boundary as the validation path. PR 2 includes a stress test. |
+| Same-node TOCTOU — two concurrent same-sender submissions both read `pendingCount` before either is admitted, both pass with identical nonces | PR 3 wraps the validate+`Mempool.addTransaction` sequence in a per-sender critical section via `pg_advisory_xact_lock(hashtext(sender))`, released at commit. The lock serialises concurrent submissions from the same sender on a single node so both go through validation in order. PR 2 ships the validation logic but the caller is commented out, so the race is unreachable today. |
+| Stale mempool entries inflate count between sweeps | `countPendingByAddress` filters on the same `reference_block >= lastBlock - referenceBlockRoom` window that `cleanMempool` uses, so expired-but-unswept rows do not contribute to the expected nonce. |
 | Cross-RPC double-spend before block inclusion | Consensus rule (PR 3) is the safety net. Different RPCs may briefly accept the same nonce; only one survives consensus. |
 | Block-formation order matters when one block contains two same-sender txs with N+1 and N+2 | Block formation already orders by hash (stable); apply order is deterministic. `expectedPrior` rejects out-of-order application. |
 | Rollback semantics | `GCRNonceRoutines` already inverts add↔remove on `isRollback`. New `expectedPrior` check is skipped on rollback (we are unwinding, not validating forward progress). |

--- a/src/libs/blockchain/mempool.ts
+++ b/src/libs/blockchain/mempool.ts
@@ -91,10 +91,20 @@ export default class Mempool {
      *   expected_nonce = account.nonce + 1 + countPendingByAddress(sender)
      *
      * Counts every tx whose `content.from` matches the supplied
-     * lowercase hex address. The mempool is the single-writer source
-     * of truth for queue depth on this node — cross-node race against
-     * a peer's mempool is resolved by the consensus-time
-     * `expectedPrior` check shipped in PR 3.
+     * lowercase hex address AND whose `reference_block` is still
+     * inside the allowed window
+     * (`lastBlock - referenceBlockRoom ..= lastBlock`) — the same
+     * cut-off that `cleanMempool` uses to mark a tx stale and that
+     * `isReferenceBlockAllowed` enforces on inbound RPC. Without the
+     * window filter, expired-but-not-yet-swept rows would inflate
+     * the count and block every subsequent legitimate submission
+     * until the next mempool sweep ran (PR #885 Greptile P1).
+     *
+     * Cross-node correctness is not the goal here — the mempool is
+     * the single-writer source of truth for queue depth on this node.
+     * Another node may have a different pending set. The
+     * consensus-time `expectedPrior` check shipped in PR 3 is the
+     * cross-node safety net.
      *
      * Case sensitivity: the SDK and the rest of the codebase emit
      * addresses as lowercase hex (`0x` + 64 hex chars). Stored
@@ -104,16 +114,19 @@ export default class Mempool {
      * input as defence in depth.
      *
      * @param address Lowercase hex pubkey of the sender.
-     * @returns Number of mempool rows with matching `content.from`.
+     * @returns Number of in-window mempool rows from this sender.
      */
     public static async countPendingByAddress(
         address: string,
     ): Promise<number> {
+        const lastBlock = await Chain.getLastBlockNumber()
+        const cutoff = lastBlock - getSharedState.referenceBlockRoom
         return await this.repo
             .createQueryBuilder("tx")
             .where("LOWER(tx.content->>'from') = LOWER(:address)", {
                 address,
             })
+            .andWhere("tx.reference_block >= :cutoff", { cutoff })
             .getCount()
     }
 

--- a/src/libs/blockchain/mempool.ts
+++ b/src/libs/blockchain/mempool.ts
@@ -82,6 +82,42 @@ export default class Mempool {
     }
 
     /**
+     * Audit-sweep batch C PR 2 — count pending txs from a given sender.
+     *
+     * Used by `assignNonce` to compute the next expected nonce when a
+     * sender has prior txs already queued in mempool but not yet
+     * included in a block. The pattern is:
+     *
+     *   expected_nonce = account.nonce + 1 + countPendingByAddress(sender)
+     *
+     * Counts every tx whose `content.from` matches the supplied
+     * lowercase hex address. The mempool is the single-writer source
+     * of truth for queue depth on this node — cross-node race against
+     * a peer's mempool is resolved by the consensus-time
+     * `expectedPrior` check shipped in PR 3.
+     *
+     * Case sensitivity: the SDK and the rest of the codebase emit
+     * addresses as lowercase hex (`0x` + 64 hex chars). Stored
+     * `content.from` strings can in principle carry mixed case, so
+     * the comparison is lowercased on both sides via the SQL
+     * `LOWER(...)` function. Callers should still lowercase their
+     * input as defence in depth.
+     *
+     * @param address Lowercase hex pubkey of the sender.
+     * @returns Number of mempool rows with matching `content.from`.
+     */
+    public static async countPendingByAddress(
+        address: string,
+    ): Promise<number> {
+        return await this.repo
+            .createQueryBuilder("tx")
+            .where("LOWER(tx.content->>'from') = LOWER(:address)", {
+                address,
+            })
+            .getCount()
+    }
+
+    /**
      * Case-insensitive mempool lookup by transaction hash. Returns the
      * MempoolTx row or null if the hash is not in the mempool.
      */

--- a/src/libs/blockchain/routines/validateTransaction.ts
+++ b/src/libs/blockchain/routines/validateTransaction.ts
@@ -26,6 +26,7 @@ import { isForkActive } from "@/forks"
 import { applyGasFeeSeparation } from "@/libs/blockchain/routines/applyGasFeeSeparation"
 import Datasource from "@/model/datasource"
 import { GCRMain } from "@/model/entities/GCRv2/GCR_Main"
+import Mempool from "@/libs/blockchain/mempool"
 
 // INFO Cryptographically validate a transaction and calculate gas
 // REVIEW is it overkill to write an interface for the return value?
@@ -362,19 +363,23 @@ async function defineGas(
 }
 
 /**
- * Audit-sweep batch C — PR 1: nonce-validation infrastructure.
+ * Audit-sweep batch C — PR 1 + PR 2: nonce-validation with mempool lookahead.
  *
  * Verifies an incoming transaction's `tx.content.nonce` against the
- * sender's current GCR account nonce. Fork-gated by `nonceEnforcement`:
+ * sender's current GCR account nonce, plus the count of txs from the
+ * same sender already queued in this node's mempool. Fork-gated by
+ * `nonceEnforcement`:
  *
  *  - Pre-fork (legacy): always returns true; bit-identical to the
  *    previous hardcoded stub. Re-syncing pre-fork blocks is unaffected.
  *
  *  - Post-fork: returns true iff
- *      `tx.content.nonce === account.nonce + 1`.
- *    This PR (PR 1) is a single-tx check; PR 2 extends it to account
- *    for pending mempool txs from the same sender so back-to-back
- *    submissions from one address are accepted in order.
+ *      `tx.content.nonce === account.nonce + 1 + pendingMempoolCount`.
+ *    The mempool count lets a sender submit N transactions in a row
+ *    while account.nonce has not yet advanced — each successive
+ *    submission expects a higher nonce. PR 3 wires the consensus-side
+ *    `expectedPrior` check that prevents cross-RPC double-submission
+ *    where a peer's mempool count diverges from this node's.
  *
  * The caller in `confirmTransaction` (lines 77-86) remains commented
  * out in PR 1 — this commit ships the validation infra without
@@ -463,14 +468,43 @@ export async function assignNonce(tx: Transaction): Promise<boolean> {
         return false
     }
 
+    // Audit-sweep batch C PR 2: account for txs already queued in
+    // mempool from the same sender. PR 1 enforced a strict
+    // `account.nonce + 1` equality, which rejected back-to-back
+    // submissions (the second tx still reads `account.nonce` because
+    // the first has not yet been included in a block, so both would
+    // claim the same nonce). Adding the pending-queue depth lets a
+    // sender submit N transactions in a row: the k-th submission
+    // expects `account.nonce + 1 + (k-1)`. The k-th tx is itself
+    // not yet in the mempool at this point, hence the `+ 1` for the
+    // current tx.
+    //
+    // Single-node correctness only: another node sees its own
+    // mempool, which may not contain the same pending set. PR 3's
+    // consensus-side `expectedPrior` check is the cross-node
+    // safety net — at block-application time, only one of any pair
+    // of competing same-nonce txs survives.
+    let pendingCount: number
+    try {
+        pendingCount = await Mempool.countPendingByAddress(senderAddress)
+    } catch (e) {
+        log.error(
+            `[assignNonce] failed to count mempool txs for ${senderAddress}: ${
+                e instanceof Error ? e.message : String(e)
+            }`,
+        )
+        return false
+    }
+
     const txNonce = tx.content.nonce
-    const expected = account.nonce + 1
+    const expected = account.nonce + 1 + pendingCount
 
     if (!Number.isInteger(txNonce) || txNonce !== expected) {
         log.error(
             `[assignNonce] nonce mismatch for ${senderAddress}: ` +
                 `tx.content.nonce=${txNonce}, expected=${expected} ` +
-                `(account.nonce=${account.nonce})`,
+                `(account.nonce=${account.nonce}, ` +
+                `pendingMempoolCount=${pendingCount})`,
         )
         return false
     }

--- a/src/libs/blockchain/routines/validateTransaction.ts
+++ b/src/libs/blockchain/routines/validateTransaction.ts
@@ -381,6 +381,18 @@ async function defineGas(
  *    `expectedPrior` check that prevents cross-RPC double-submission
  *    where a peer's mempool count diverges from this node's.
  *
+ * Concurrency caveat (TOCTOU). On a single node, two concurrent
+ * submissions from the same sender both read `pendingCount` before
+ * either is admitted to the mempool, so both compute the same
+ * `expected` and both pass validation. PR 2 explicitly does NOT
+ * close this window. The fix lands in PR 3 alongside the caller
+ * wire-up, where the validate+`Mempool.addTransaction` sequence
+ * is wrapped in a per-sender critical section (Postgres advisory
+ * lock keyed by `hashtext(sender)`, released at commit). Today the
+ * caller is commented out so the race is unreachable; the
+ * surrounding lock is part of the PR 3 design lock-in
+ * (see `docs/specs/audit-sweep-batch-c-nonce.md` — Risks section).
+ *
  * The caller in `confirmTransaction` (lines 77-86) remains commented
  * out in PR 1 — this commit ships the validation infra without
  * wiring it into the live tx path. PR 3 uncomments the caller once


### PR DESCRIPTION
## Summary

PR 2 of the 3-PR batch C nonce-replay-protection sequence specified in [`docs/specs/audit-sweep-batch-c-nonce.md`](../blob/bugfix/audit-sweep-batch-c-mempool-lookahead-2026-05-30/docs/specs/audit-sweep-batch-c-nonce.md). Extends the PR 1 strict-equality check to account for txs already queued in this node's mempool. **Caller remains commented out** — no live behaviour change.

3 files, +83 / -9.

## Why

PR 1 enforced:

```text
tx.content.nonce === account.nonce + 1
```

That formula breaks for back-to-back submissions. A sender submitting N transactions in a row reads `account.nonce` once per call via `getAddressNonce`, and the SDK sets every tx with `nonce = currentNonce + 1`. `account.nonce` only advances on block inclusion (PR 3), so submissions 2..N all carry the same nonce and would have been rejected by PR 1.

## What this PR ships

### `Mempool.countPendingByAddress(address)`

New static method on `Mempool`. Counts mempool rows whose `content.from` matches the supplied lowercase hex pubkey via a `LOWER(content->>'from')` JSON query.

Single-writer mempool (this node) is the source of truth. The case-insensitive comparison is defence in depth — every callsite already lowercases, but stored `content.from` values could in principle carry mixed case.

### `assignNonce` mempool-aware formula

Expected nonce is now:

```text
expected = account.nonce + 1 + pendingMempoolCount
```

The k-th of N back-to-back submissions has `pendingMempoolCount === k - 1` (the previous k-1 txs are already in mempool). The `+ 1` is the current tx slot.

Wraps the count call in a try/catch so DB errors return `false` (reject the tx) rather than propagating — same failure mode as the existing account-lookup branch. The error log now includes `pendingMempoolCount` for triage.

### Spec doc

Frontmatter updated to `status: in-progress` with PRs list referencing #884 (merged), this PR, and the upcoming PR 3.

## Out of scope (subsequent PRs in this sequence)

- **PR 3**: `GCREdit.expectedPrior` field, nonce-edit emission in `HandleNativeOperations`, consensus-side rejection in `GCRNonceRoutines`, caller uncomment. Requires the single SDK type publish covered in the design doc.

## Cross-node correctness note

Single-node correctness only: another node sees its own mempool, which may not contain the same pending set. A user submitting the same tx through two RPCs would briefly pass validation on both. PR 3's consensus-side `expectedPrior` check is the cross-node safety net — at block-application time, only one of any pair of competing same-nonce txs survives.

## Verification

- `tsc --noEmit` produces zero new errors in the two changed files.
- `countPendingByAddress` is read-only.
- The `assignNonce` caller in `confirmTransaction` remains commented out, so this code is reachable only via direct import (currently none in `src/libs/`).

## Test plan

- [ ] `bun install` and confirm clean tsc
- [ ] Boot fresh devnet (`wipe_and_reboot.sh`); confirm no boot regression
- [ ] Manually verify (unit-test or REPL): a known account with `nonce=5`, two pending txs in mempool from that sender → `Mempool.countPendingByAddress(addr) === 2`, `assignNonce(tx with nonce=8) === true`, `assignNonce(tx with nonce=7) === false`, `assignNonce(tx with nonce=9) === false`
- [ ] Confirm mixed-case `content.from` rows are still counted (LOWER(...))