### PR TITLE
feat(consensus): nonceEnforcement consensus rule + caller wire-up (batch C PR 3) [DRAFT - review needed]

### DIFF
--- a/docs/specs/audit-sweep-batch-c-nonce.md
+++ b/docs/specs/audit-sweep-batch-c-nonce.md
@@ -152,8 +152,8 @@ set by governance before deployment.
 The original design called for SDK-side emission of `expectedPrior`,
 which would have required either coordinated rollout (B) or
 SDK-side fork introspection (C). Both were rejected during PR 3
-implementation in favour of **Path A — node populates at apply
-time, SDK ships type-only**:
+implementation in favour of **Path A — node populates at
+validation time, SDK ships type-only**:
 
 - **Zero breaking change**: old SDK clients continue to work
   post-fork without re-publishing. New SDK clients also do not need
@@ -161,13 +161,23 @@ time, SDK ships type-only**:
 - **Signature-safe**: `expectedPrior` is stripped from both
   SDK-shipped and node-regen edits before the hash compare in
   `endpointValidation`. The signed tx hash never includes it; nodes
-  populate it post-validation from local state.
+  populate it inside `assignNonce` from `account.nonce +
+  pendingMempoolCount` and the mutation flows downstream into the
+  apply pipeline.
 - **Single SDK publish stays minimal**: `expectedPrior?: number`
   added to the type union only. No runtime change, no fork-status
   RPC needed in the SDK.
 
-See `endpointValidation.ts` for the strip + the symmetric blanking
-pattern (mirrors the existing `txhash` blanking).
+Initial draft of PR 3 wrote the populate inside
+`HandleGCR.applyTransaction`'s per-edit loop, reading the live
+account nonce from `entities.accounts`. That site is wrong: it
+re-reads state already advanced by prior in-block applies, so a
+replay tx bundled into the same block sees its own freshly-
+incremented value and passes the check. Locking the value at
+validation time (before any apply) is what makes the safety net
+actually work. See `endpointValidation.ts` for the strip + the
+symmetric blanking pattern (mirrors the existing `txhash`
+blanking).
 
 ### PR breakdown
 
@@ -175,7 +185,7 @@ pattern (mirrors the existing `txhash` blanking).
 |----|-------|-------|------|
 | 1 | Fork registration + validation infra (caller still commented) | `forkConfig.ts`, `loadForkConfig.ts`, `validateTransaction.ts`, `testing/devnet/genesis.devnet.json` | Med — registers the fork (default `activationHeight: null`) + ships the fork-gated `assignNonce` implementation. Caller remains commented so live behaviour is unchanged on pre-fork chains; devnet boots post-fork from block 0. |
 | 2 | Mempool-aware lookahead | `mempool.ts` (new `countPendingByAddress`), `assignNonce` consumer in `validateTransaction.ts`, tests | Med — touches mempool query API. |
-| 3 | Consensus rule + caller wire-up (Path A) | `GCRNonceRoutines.ts` (apply-time `expectedPrior` reject), `validateTransaction.ts` (uncomment caller + validation-time `expectedPrior` populate from `account.nonce + pendingCount`), `endpointValidation.ts` (symmetric strip on both sides of hash compare), `package.json` (demosdk 4.0.3 → 4.0.5), e2e test | High — consensus rule change; rollout coordination across validators. The fork is already registered (PR 1) and validation infra is live (PR 2). This PR adds the apply-time rejection + validation-time populate, uncomments the validation caller, and bumps the SDK pin to 4.0.5 (which carries the type-only `expectedPrior?: number` field). |
+| 3 | Consensus rule + caller wire-up (Path A) | `GCRNonceRoutines.ts` (fork-gated `expectedPrior` mismatch reject at apply time), `validateTransaction.ts` (uncomment caller + validation-time `expectedPrior` populate from `account.nonce + pendingCount`), `endpointValidation.ts` (symmetric strip on both sides of hash compare), `package.json` (demosdk 4.0.3 → 4.0.5) | High — consensus rule change; rollout coordination across validators. The fork is already registered (PR 1) and validation infra is live (PR 2). This PR adds the consensus-side rejection + validation-time populate, uncomments the validation caller, and bumps the SDK pin to 4.0.5 (which carries the type-only `expectedPrior?: number` field). Cross-RPC e2e test against the devnet fixture is tracked as a follow-up PR; the strip + populate + reject pipeline is testable today via direct mempool injection. |
 
 ### SDK change
 

--- a/docs/specs/audit-sweep-batch-c-nonce.md
+++ b/docs/specs/audit-sweep-batch-c-nonce.md
@@ -6,8 +6,10 @@ status: in-progress
 related: docs/specs/active-feature-test-addition-proposal.md, .ccb/bug-hunt-2026-05-28/FINAL_REPORT.md
 prs:
   - "#884 (PR 1: fork registration + assignNonce infra — merged)"
-  - "#885 (PR 2: mempool-aware lookahead)"
-  - "#TBD (PR 3: consensus rule + caller wire-up, after SDK publish)"
+  - "#885 (PR 2: mempool-aware lookahead — merged)"
+  - "#TBD (PR 3: consensus rule + caller wire-up)"
+sdk_publish:
+  - "@kynesyslabs/demosdk 4.0.5 — adds `expectedPrior?: number` to GCREditNonce (type-only, runtime unchanged)"
 ---
 
 # Audit-Sweep Batch C — Nonce-based Replay Protection
@@ -111,19 +113,46 @@ type NonceGCREdit = {
 Introduce a new fork: `nonceEnforcement`, gated by genesis
 `forks.nonceEnforcement.activationHeight`. Behaviour:
 
-- **Pre-fork (legacy)**: `assignNonce` accepts any nonce.
-  `HandleNativeOperations` does not emit a `nonce` edit.
-  `GCRNonceRoutines` ignores `expectedPrior`. Bit-identical to today
-  for re-sync.
-- **Post-fork**: `assignNonce` enforces sequential semantics.
-  `HandleNativeOperations` emits a `+1` `nonce` edit with
-  `expectedPrior = account.nonce` populated by reading GCR at
-  emit-time. `GCRNonceRoutines` rejects the edit when
-  `expectedPrior !== undefined && account.nonce !== expectedPrior`.
+- **Pre-fork (legacy)**: `assignNonce` accepts any nonce. SDK
+  `GCRGeneration.createNonceEdit` ships the legacy shape (no
+  `expectedPrior`). `GCRNonceRoutines` ignores any `expectedPrior`
+  on legacy edits. Bit-identical to today for re-sync.
+- **Post-fork**: `assignNonce` enforces sequential semantics with
+  mempool lookahead (PR 2). The SDK still ships nonce edits without
+  `expectedPrior` — the **node populates it at apply time** in
+  `HandleGCR.applyTransaction` from the live in-memory account
+  state (`entities.accounts.get(pubkey).nonce`). Both sides of the
+  hash compare in `endpointValidation` strip the field before
+  hashing so the signature contract is unaffected.
+  `GCRNonceRoutines` rejects the edit when
+  `accountGCR.nonce !== expectedPrior` — the cross-RPC double-spend
+  safety net.
 
 Devnet sets `activationHeight: 0` like other forks so local testing
 exercises the post-fork path from genesis. Production fork height is
 set by governance before deployment.
+
+#### Emission-site rationale (Path A vs B)
+
+The original design called for SDK-side emission of `expectedPrior`,
+which would have required either coordinated rollout (B) or
+SDK-side fork introspection (C). Both were rejected during PR 3
+implementation in favour of **Path A — node populates at apply
+time, SDK ships type-only**:
+
+- **Zero breaking change**: old SDK clients continue to work
+  post-fork without re-publishing. New SDK clients also do not need
+  to know about the field at runtime.
+- **Signature-safe**: `expectedPrior` is stripped from both
+  SDK-shipped and node-regen edits before the hash compare in
+  `endpointValidation`. The signed tx hash never includes it; nodes
+  populate it post-validation from local state.
+- **Single SDK publish stays minimal**: `expectedPrior?: number`
+  added to the type union only. No runtime change, no fork-status
+  RPC needed in the SDK.
+
+See `endpointValidation.ts` for the strip + the symmetric blanking
+pattern (mirrors the existing `txhash` blanking).
 
 ### PR breakdown
 
@@ -131,7 +160,7 @@ set by governance before deployment.
 |----|-------|-------|------|
 | 1 | Fork registration + validation infra (caller still commented) | `forkConfig.ts`, `loadForkConfig.ts`, `validateTransaction.ts`, `testing/devnet/genesis.devnet.json` | Med — registers the fork (default `activationHeight: null`) + ships the fork-gated `assignNonce` implementation. Caller remains commented so live behaviour is unchanged on pre-fork chains; devnet boots post-fork from block 0. |
 | 2 | Mempool-aware lookahead | `mempool.ts` (new `countPendingByAddress`), `assignNonce` consumer in `validateTransaction.ts`, tests | Med — touches mempool query API. |
-| 3 | Consensus rule + caller wire-up | `GCRNonceRoutines.ts`, `HandleNativeOperations.ts` emit-side, `validateTransaction.ts` uncomment caller, e2e test | High — consensus rule change; rollout coordination across validators. The fork itself is already registered in PR 1; this PR ships the apply-time rejection and emits the increment edit. |
+| 3 | Consensus rule + caller wire-up (Path A) | `GCRNonceRoutines.ts` (apply-time `expectedPrior` reject), `handleGCR.ts` (apply-time `expectedPrior` populate from in-memory account), `endpointValidation.ts` (symmetric strip on both sides of hash compare), `validateTransaction.ts` (uncomment caller), `package.json` (demosdk 4.0.3 → 4.0.5), e2e test | High — consensus rule change; rollout coordination across validators. The fork is already registered (PR 1) and validation infra is live (PR 2). This PR adds the apply-time rejection + populate, uncomments the validation caller, and bumps the SDK pin to 4.0.5 (which carries the type-only `expectedPrior?: number` field). |
 
 ### SDK change
 

--- a/docs/specs/audit-sweep-batch-c-nonce.md
+++ b/docs/specs/audit-sweep-batch-c-nonce.md
@@ -119,14 +119,29 @@ Introduce a new fork: `nonceEnforcement`, gated by genesis
   on legacy edits. Bit-identical to today for re-sync.
 - **Post-fork**: `assignNonce` enforces sequential semantics with
   mempool lookahead (PR 2). The SDK still ships nonce edits without
-  `expectedPrior` — the **node populates it at apply time** in
-  `HandleGCR.applyTransaction` from the live in-memory account
-  state (`entities.accounts.get(pubkey).nonce`). Both sides of the
-  hash compare in `endpointValidation` strip the field before
-  hashing so the signature contract is unaffected.
-  `GCRNonceRoutines` rejects the edit when
+  `expectedPrior` — the **node populates it at validation time**
+  inside `assignNonce` itself, using the same account row +
+  pending-mempool-count it already loaded for the equality check:
+  `expectedPrior = account.nonce + pendingCount`. The populate
+  happens BEFORE the snapshot in `endpointValidation` is taken… no,
+  actually after — the snapshot is captured at line 48 (deep-clone
+  of `tx.content.gcr_edits`) **before** `confirmTransaction` runs.
+  When `assignNonce` mutates the real `tx.content.gcr_edits` array,
+  the snapshot is the unmodified pre-confirmTransaction shape.
+  Hash compare uses snapshot vs regen (both stripped of
+  `expectedPrior` symmetrically), so signature integrity is
+  preserved. The mutated array flows downstream into
+  `HandleGCR.applyTransaction`, which feeds the populated
+  `expectedPrior` into `GCRNonceRoutines`. Rejection fires when
   `accountGCR.nonce !== expectedPrior` — the cross-RPC double-spend
   safety net.
+
+  Why NOT populate at apply time: re-reading account state inside
+  the apply loop would see prior in-block applies, so a replay tx
+  bundled into the same block would see its own freshly-incremented
+  value and pass the check. Locking the value to validation-time
+  state (before any apply) is what makes the safety net actually
+  work.
 
 Devnet sets `activationHeight: 0` like other forks so local testing
 exercises the post-fork path from genesis. Production fork height is
@@ -160,7 +175,7 @@ pattern (mirrors the existing `txhash` blanking).
 |----|-------|-------|------|
 | 1 | Fork registration + validation infra (caller still commented) | `forkConfig.ts`, `loadForkConfig.ts`, `validateTransaction.ts`, `testing/devnet/genesis.devnet.json` | Med — registers the fork (default `activationHeight: null`) + ships the fork-gated `assignNonce` implementation. Caller remains commented so live behaviour is unchanged on pre-fork chains; devnet boots post-fork from block 0. |
 | 2 | Mempool-aware lookahead | `mempool.ts` (new `countPendingByAddress`), `assignNonce` consumer in `validateTransaction.ts`, tests | Med — touches mempool query API. |
-| 3 | Consensus rule + caller wire-up (Path A) | `GCRNonceRoutines.ts` (apply-time `expectedPrior` reject), `handleGCR.ts` (apply-time `expectedPrior` populate from in-memory account), `endpointValidation.ts` (symmetric strip on both sides of hash compare), `validateTransaction.ts` (uncomment caller), `package.json` (demosdk 4.0.3 → 4.0.5), e2e test | High — consensus rule change; rollout coordination across validators. The fork is already registered (PR 1) and validation infra is live (PR 2). This PR adds the apply-time rejection + populate, uncomments the validation caller, and bumps the SDK pin to 4.0.5 (which carries the type-only `expectedPrior?: number` field). |
+| 3 | Consensus rule + caller wire-up (Path A) | `GCRNonceRoutines.ts` (apply-time `expectedPrior` reject), `validateTransaction.ts` (uncomment caller + validation-time `expectedPrior` populate from `account.nonce + pendingCount`), `endpointValidation.ts` (symmetric strip on both sides of hash compare), `package.json` (demosdk 4.0.3 → 4.0.5), e2e test | High — consensus rule change; rollout coordination across validators. The fork is already registered (PR 1) and validation infra is live (PR 2). This PR adds the apply-time rejection + validation-time populate, uncomments the validation caller, and bumps the SDK pin to 4.0.5 (which carries the type-only `expectedPrior?: number` field). |
 
 ### SDK change
 

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
         "@fastify/cors": "^9.0.1",
         "@fastify/swagger": "^8.15.0",
         "@fastify/swagger-ui": "^4.1.0",
-        "@kynesyslabs/demosdk": "4.0.3",
+        "@kynesyslabs/demosdk": "4.0.5",
         "@metaplex-foundation/js": "^0.20.1",
         "@modelcontextprotocol/sdk": "^1.13.3",
         "@noble/ed25519": "^3.0.0",
@@ -177,6 +177,6 @@
         "valibot": ">=1.2.0",
         "fast-xml-parser": ">=5.3.4",
         "validator": ">=13.15.20",
-        "@kynesyslabs/demosdk": "4.0.3"
+        "@kynesyslabs/demosdk": "4.0.5"
     }
 }

--- a/src/libs/blockchain/gcr/gcr_routines/GCRNonceRoutines.ts
+++ b/src/libs/blockchain/gcr/gcr_routines/GCRNonceRoutines.ts
@@ -38,6 +38,44 @@ export default class GCRNonceRoutines {
         // Getting the actual nonce to apply the operation
         const actualNonce = accountGCR.nonce
 
+        // Audit-sweep batch C PR 3 — cross-RPC replay safety net.
+        //
+        // When `expectedPrior` is present on the edit, reject the
+        // application if the on-chain account nonce does not match.
+        // This catches the case where two competing same-nonce txs
+        // from different RPCs both pass per-node validation but get
+        // bundled into the same block: the first applies, the second
+        // sees `accountGCR.nonce !== expectedPrior` and is rejected.
+        //
+        // `expectedPrior` is populated by the node at apply time (see
+        // `endpointValidation.ts` apply-pipeline integration) from
+        // local GCR state — the field is stripped from both incoming
+        // and SDK-regen edits before the hash comparison, so the
+        // signature contract is unaffected.
+        //
+        // Rollback path: skip the check. Rollbacks unwind a prior
+        // apply; the recorded `expectedPrior` is the value BEFORE the
+        // original apply, not after. Re-checking would always fail
+        // because `accountGCR.nonce` has already advanced.
+        if (
+            !editOperation.isRollback &&
+            typeof editOperation.expectedPrior === "number"
+        ) {
+            if (actualNonce !== editOperation.expectedPrior) {
+                log.error(
+                    `[GCRNonceRoutines] expectedPrior mismatch for ${editOperationAccount}: ` +
+                        `accountGCR.nonce=${actualNonce}, expectedPrior=${editOperation.expectedPrior} — ` +
+                        "rejecting nonce edit (cross-RPC replay or out-of-order apply)",
+                )
+                return {
+                    success: false,
+                    message:
+                        `Nonce expectedPrior mismatch: account.nonce=${actualNonce}, ` +
+                        `expectedPrior=${editOperation.expectedPrior}`,
+                }
+            }
+        }
+
         if (editOperation.operation === "add") {
             accountGCR.nonce += editOperation.amount
         } else if (editOperation.operation === "remove") {

--- a/src/libs/blockchain/gcr/gcr_routines/GCRNonceRoutines.ts
+++ b/src/libs/blockchain/gcr/gcr_routines/GCRNonceRoutines.ts
@@ -4,6 +4,8 @@ import { GCRMain } from "@/model/entities/GCRv2/GCR_Main"
 import HandleGCR, { GCRResult } from "src/libs/blockchain/gcr/handleGCR"
 import { forgeToHex } from "@/libs/crypto/forgeUtils"
 import log from "src/utilities/logger"
+import { isForkActive } from "@/forks"
+import { getSharedState } from "@/utilities/sharedState"
 
 export default class GCRNonceRoutines {
     static async apply(
@@ -40,38 +42,59 @@ export default class GCRNonceRoutines {
 
         // Audit-sweep batch C PR 3 — cross-RPC replay safety net.
         //
-        // When `expectedPrior` is present on the edit, reject the
-        // application if the on-chain account nonce does not match.
-        // This catches the case where two competing same-nonce txs
-        // from different RPCs both pass per-node validation but get
-        // bundled into the same block: the first applies, the second
-        // sees `accountGCR.nonce !== expectedPrior` and is rejected.
+        // Fork-gated on `nonceEnforcement`. Pre-fork: ignore the
+        // field entirely so a client shipping `expectedPrior` on a
+        // pre-fork node cannot induce rejections that newer-binary
+        // nodes would also enforce (consensus split risk before
+        // activation). Hash-strip in `endpointValidation` means
+        // `expectedPrior` is not signed, so pre-fork clients could
+        // attach it without breaking signature validation — that is
+        // exactly the validator-split footgun this gate avoids
+        // (PR #886 review: CodeRabbit Critical).
         //
-        // `expectedPrior` is populated by the node at apply time (see
-        // `endpointValidation.ts` apply-pipeline integration) from
-        // local GCR state — the field is stripped from both incoming
-        // and SDK-regen edits before the hash comparison, so the
+        // Post-fork: when `expectedPrior` is present on the edit,
+        // reject the application if the on-chain account nonce does
+        // not match. This catches the case where two competing
+        // same-nonce txs from different RPCs both pass per-node
+        // validation but get bundled into the same block: the first
+        // applies, the second sees `accountGCR.nonce !==
+        // expectedPrior` and is rejected.
+        //
+        // `expectedPrior` is populated at validation time by
+        // `assignNonce` (see `validateTransaction.ts`) from
+        // `account.nonce + pendingMempoolCount`. The field is stripped
+        // from both incoming and SDK-regen edits in
+        // `endpointValidation` before the hash comparison, so the
         // signature contract is unaffected.
         //
         // Rollback path: skip the check. Rollbacks unwind a prior
         // apply; the recorded `expectedPrior` is the value BEFORE the
         // original apply, not after. Re-checking would always fail
         // because `accountGCR.nonce` has already advanced.
+        //
+        // Block-height source for the fork gate: prefer
+        // `accountGCR.blockNumber` when set by the apply pipeline;
+        // fall back to `getSharedState.lastBlockNumber`. Apply paths
+        // run inside block processing so the shared-state tip is
+        // accurate.
         if (
             !editOperation.isRollback &&
             typeof editOperation.expectedPrior === "number"
         ) {
-            if (actualNonce !== editOperation.expectedPrior) {
-                log.error(
-                    `[GCRNonceRoutines] expectedPrior mismatch for ${editOperationAccount}: ` +
-                        `accountGCR.nonce=${actualNonce}, expectedPrior=${editOperation.expectedPrior} — ` +
-                        "rejecting nonce edit (cross-RPC replay or out-of-order apply)",
-                )
-                return {
-                    success: false,
-                    message:
-                        `Nonce expectedPrior mismatch: account.nonce=${actualNonce}, ` +
-                        `expectedPrior=${editOperation.expectedPrior}`,
+            const blockHeight = getSharedState.lastBlockNumber ?? 0
+            if (isForkActive("nonceEnforcement", blockHeight)) {
+                if (actualNonce !== editOperation.expectedPrior) {
+                    log.error(
+                        `[GCRNonceRoutines] expectedPrior mismatch for ${editOperationAccount}: ` +
+                            `accountGCR.nonce=${actualNonce}, expectedPrior=${editOperation.expectedPrior} — ` +
+                            "rejecting nonce edit (cross-RPC replay or out-of-order apply)",
+                    )
+                    return {
+                        success: false,
+                        message:
+                            `Nonce expectedPrior mismatch: account.nonce=${actualNonce}, ` +
+                            `expectedPrior=${editOperation.expectedPrior}`,
+                    }
                 }
             }
         }

--- a/src/libs/blockchain/gcr/handleGCR.ts
+++ b/src/libs/blockchain/gcr/handleGCR.ts
@@ -43,8 +43,6 @@ import GCRValidatorStakeRoutines from "./gcr_routines/GCRValidatorStakeRoutines"
 
 import { In } from "typeorm"
 import { Mutex } from "async-mutex"
-import { isForkActive } from "@/forks"
-import { getSharedState } from "@/utilities/sharedState"
 import GCRIdentityRoutines from "./gcr_routines/GCRIdentityRoutines"
 import { GCRTLSNotaryRoutines } from "./gcr_routines/GCRTLSNotaryRoutines"
 import { GCRTLSNotary } from "@/model/entities/GCRv2/GCR_TLSNotary"
@@ -384,44 +382,6 @@ export default class HandleGCR {
         for (const edit of gcrEdits) {
             if (!simulate && tx.hash) {
                 edit.txhash = tx.hash
-            }
-
-            // Audit-sweep batch C PR 3 — populate `expectedPrior` on
-            // every `nonce` edit when the `nonceEnforcement` fork is
-            // active at the block this tx is being applied in. The
-            // SDK never writes the field (and `endpointValidation`
-            // stripped it from both sides before hashing), so this is
-            // the canonical fill site on the apply path.
-            //
-            // Read the account nonce LIVE from `entities.accounts` —
-            // not a per-tx snapshot — so a hypothetical second
-            // `nonce` edit in the same tx (e.g. consolidation tx with
-            // two operations) sees the post-first-apply value. For
-            // the common single-nonce-edit tx, this equals the
-            // on-chain account nonce at block-start.
-            //
-            // Block-height source: `tx.blockNumber` when known,
-            // falling back to `getSharedState.lastBlockNumber`. Block
-            // application paths set `tx.blockNumber` on inclusion;
-            // simulation / mempool replay use the chain tip.
-            //
-            // Rollback skips this entirely — see `GCRNonceRoutines`.
-            if (
-                !isRollback &&
-                edit.type === "nonce" &&
-                isGCRMainEdit(edit) &&
-                typeof (edit as GCREditNonce).expectedPrior !== "number"
-            ) {
-                const blockHeight =
-                    tx.blockNumber ?? getSharedState.lastBlockNumber ?? 0
-                if (isForkActive("nonceEnforcement", blockHeight)) {
-                    const pubkey = normalizePubkey(edit.account)
-                    const liveAccount = entities.accounts.get(pubkey)
-                    if (liveAccount) {
-                        ;(edit as GCREditNonce).expectedPrior =
-                            liveAccount.nonce
-                    }
-                }
             }
 
             let result: GCRResult

--- a/src/libs/blockchain/gcr/handleGCR.ts
+++ b/src/libs/blockchain/gcr/handleGCR.ts
@@ -43,6 +43,8 @@ import GCRValidatorStakeRoutines from "./gcr_routines/GCRValidatorStakeRoutines"
 
 import { In } from "typeorm"
 import { Mutex } from "async-mutex"
+import { isForkActive } from "@/forks"
+import { getSharedState } from "@/utilities/sharedState"
 import GCRIdentityRoutines from "./gcr_routines/GCRIdentityRoutines"
 import { GCRTLSNotaryRoutines } from "./gcr_routines/GCRTLSNotaryRoutines"
 import { GCRTLSNotary } from "@/model/entities/GCRv2/GCR_TLSNotary"
@@ -382,6 +384,44 @@ export default class HandleGCR {
         for (const edit of gcrEdits) {
             if (!simulate && tx.hash) {
                 edit.txhash = tx.hash
+            }
+
+            // Audit-sweep batch C PR 3 — populate `expectedPrior` on
+            // every `nonce` edit when the `nonceEnforcement` fork is
+            // active at the block this tx is being applied in. The
+            // SDK never writes the field (and `endpointValidation`
+            // stripped it from both sides before hashing), so this is
+            // the canonical fill site on the apply path.
+            //
+            // Read the account nonce LIVE from `entities.accounts` —
+            // not a per-tx snapshot — so a hypothetical second
+            // `nonce` edit in the same tx (e.g. consolidation tx with
+            // two operations) sees the post-first-apply value. For
+            // the common single-nonce-edit tx, this equals the
+            // on-chain account nonce at block-start.
+            //
+            // Block-height source: `tx.blockNumber` when known,
+            // falling back to `getSharedState.lastBlockNumber`. Block
+            // application paths set `tx.blockNumber` on inclusion;
+            // simulation / mempool replay use the chain tip.
+            //
+            // Rollback skips this entirely — see `GCRNonceRoutines`.
+            if (
+                !isRollback &&
+                edit.type === "nonce" &&
+                isGCRMainEdit(edit) &&
+                typeof (edit as GCREditNonce).expectedPrior !== "number"
+            ) {
+                const blockHeight =
+                    tx.blockNumber ?? getSharedState.lastBlockNumber ?? 0
+                if (isForkActive("nonceEnforcement", blockHeight)) {
+                    const pubkey = normalizePubkey(edit.account)
+                    const liveAccount = entities.accounts.get(pubkey)
+                    if (liveAccount) {
+                        ;(edit as GCREditNonce).expectedPrior =
+                            liveAccount.nonce
+                    }
+                }
             }
 
             let result: GCRResult

--- a/src/libs/blockchain/routines/validateTransaction.ts
+++ b/src/libs/blockchain/routines/validateTransaction.ts
@@ -526,5 +526,47 @@ export async function assignNonce(tx: Transaction): Promise<boolean> {
         return false
     }
 
+    // Audit-sweep batch C PR 3 — populate `expectedPrior` on this
+    // tx's `nonce` GCREdit (if present) at validation time, NOT at
+    // apply time.
+    //
+    // Why validation time: the value must be a snapshot of the
+    // sender's nonce taken BEFORE this tx is bundled into a block.
+    // Populating at apply time would re-read `entities.accounts` —
+    // which already reflects prior in-block applies — so the
+    // expected value would track the apply-time state, defeating
+    // the cross-RPC safety net entirely (the second replay would
+    // see its own freshly-incremented value and pass the check).
+    //
+    // Formula: `expectedPrior = account.nonce + pendingCount`. This
+    // is the value the sender's nonce will be at the moment this tx
+    // applies, assuming all queued mempool txs from the same sender
+    // (which are ordered before this one) land first. For a single
+    // tx: `pendingCount === 0`, so `expectedPrior === account.nonce`.
+    // For the k-th of N back-to-back submissions:
+    // `expectedPrior === account.nonce + (k-1)`.
+    //
+    // The field is stripped from both sides of the hash compare in
+    // `endpointValidation`, so the signed tx hash is invariant under
+    // whether or not this populate ran. Pre-fork blocks re-sync
+    // bit-identically because the fork-gate above short-circuits.
+    //
+    // We mutate `tx.content.gcr_edits` in place. The hash strip
+    // means downstream serialisation / signing is unaffected.
+    if (Array.isArray(tx.content.gcr_edits)) {
+        const expectedPrior = account.nonce + pendingCount
+        for (const edit of tx.content.gcr_edits) {
+            if (edit.type === "nonce") {
+                const editAccount =
+                    typeof edit.account === "string"
+                        ? edit.account.toLowerCase()
+                        : edit.account
+                if (editAccount === senderAddress) {
+                    edit.expectedPrior = expectedPrior
+                }
+            }
+        }
+    }
+
     return true
 }

--- a/src/libs/blockchain/routines/validateTransaction.ts
+++ b/src/libs/blockchain/routines/validateTransaction.ts
@@ -77,8 +77,13 @@ export async function confirmTransaction(
     }
     */
 
-    /* NOTE Nonce assignment is done in the GCR too
-    let hasNonce = await assignNonce(tx)
+    // Audit-sweep batch C PR 3 — wire `assignNonce` into the live
+    // validation path. Pre-fork: `assignNonce` short-circuits to
+    // `true` (PR 1), so this is a noop. Post-fork: enforces strict
+    // sequential nonce semantics with mempool lookahead (PRs 1+2),
+    // and the matching consensus-side `expectedPrior` check on
+    // `GCRNonceRoutines` (this PR) is the cross-RPC safety net.
+    const hasNonce = await assignNonce(tx)
     if (!hasNonce) {
         validityData.data.message =
             "[Native Tx Validation] [NONCE ERROR] Nonce not assigned\n"
@@ -86,7 +91,7 @@ export async function confirmTransaction(
         validityData = await signValidityData(validityData)
         return validityData
     }
-    */
+
     // Verify tx validity
 
     const {

--- a/src/libs/blockchain/routines/validateTransaction.ts
+++ b/src/libs/blockchain/routines/validateTransaction.ts
@@ -557,10 +557,19 @@ export async function assignNonce(tx: Transaction): Promise<boolean> {
         const expectedPrior = account.nonce + pendingCount
         for (const edit of tx.content.gcr_edits) {
             if (edit.type === "nonce") {
-                const editAccount =
+                // Normalise non-string forge-key accounts to lowercase
+                // hex before comparing, mirroring the same coercion in
+                // `GCRNonceRoutines.apply`. Direct `===` between an
+                // object and a string is always false, which would
+                // silently skip the populate and disable the cross-RPC
+                // safety net for any client shipping forge-format
+                // accounts (PR #886 review: CodeRabbit Major /
+                // Greptile P1).
+                const editAccount = (
                     typeof edit.account === "string"
-                        ? edit.account.toLowerCase()
-                        : edit.account
+                        ? edit.account
+                        : forgeToHex(edit.account)
+                ).toLowerCase()
                 if (editAccount === senderAddress) {
                     edit.expectedPrior = expectedPrior
                 }

--- a/src/libs/network/endpointValidation.ts
+++ b/src/libs/network/endpointValidation.ts
@@ -64,6 +64,15 @@ export async function handleValidateTransaction(
         )
         gcrEdits.forEach((gcredit: GCREdit) => {
             gcredit.txhash = ""
+            // Audit-sweep batch C PR 3 — strip the node-only
+            // `expectedPrior` field from the regen side before
+            // hashing. The SDK never populates it; the node fills it
+            // in at apply time from local GCR state. Leaving it on
+            // the regen side would diverge from the SDK-shipped edit
+            // and surface as a spurious GCREdit mismatch.
+            if (gcredit.type === "nonce" && "expectedPrior" in gcredit) {
+                delete (gcredit as { expectedPrior?: number }).expectedPrior
+            }
         })
 
         // Normalise the regenerated gcrEdits through the SAME serializer
@@ -134,9 +143,19 @@ export async function handleValidateTransaction(
         // Use the PRE-confirmTransaction snapshot, not tx.content.gcr_edits,
         // which `applyGasFeeSeparation` may have mutated by prepending
         // node-computed fee edits.
-        const txEditsBlanked = txShippedGcrEdits.map(
-            (e: GCREdit) => ({ ...e, txhash: "" }),
-        )
+        const txEditsBlanked = txShippedGcrEdits.map((e: GCREdit) => {
+            const blanked = { ...e, txhash: "" }
+            // Audit-sweep batch C PR 3 — symmetric strip of
+            // `expectedPrior` on the tx-side input. The SDK 4.0.5+
+            // type allows the field but the SDK runtime never writes
+            // it; an old or non-conformant client could nonetheless
+            // ship it. Drop it here so the hash is invariant under
+            // that choice, matching the regen-side strip above.
+            if (blanked.type === "nonce" && "expectedPrior" in blanked) {
+                delete (blanked as { expectedPrior?: number }).expectedPrior
+            }
+            return blanked
+        })
         const normalisedTxEdits = normaliseGcrEditsForHash(txEditsBlanked)
         const txGcrEditsHash = Hashing.sha256(
             JSON.stringify(normalisedTxEdits),

--- a/src/libs/network/endpointValidation.ts
+++ b/src/libs/network/endpointValidation.ts
@@ -67,7 +67,9 @@ export async function handleValidateTransaction(
             // Audit-sweep batch C PR 3 — strip the node-only
             // `expectedPrior` field from the regen side before
             // hashing. The SDK never populates it; the node fills it
-            // in at apply time from local GCR state. Leaving it on
+            // in at validation time inside `assignNonce` (see
+            // `validateTransaction.ts`) from
+            // `account.nonce + pendingMempoolCount`. Leaving it on
             // the regen side would diverge from the SDK-shipped edit
             // and surface as a spurious GCREdit mismatch.
             if (gcredit.type === "nonce" && "expectedPrior" in gcredit) {


### PR DESCRIPTION
**DRAFT — design review needed before merge.**

PR 3 of the 3-PR batch C nonce-replay-protection sequence specified in [`docs/specs/audit-sweep-batch-c-nonce.md`](../blob/bugfix/audit-sweep-batch-c-consensus-rule-2026-05-31/docs/specs/audit-sweep-batch-c-nonce.md).

## Concern flagged during review

The current implementation populates `expectedPrior` in `handleGCR.applyTransaction` at apply time, reading the live account nonce from `entities.accounts`. This is **not correct** for the cross-RPC double-spend scenario:

1. Tx A: account.nonce = N. Edit populates `expectedPrior = N`. Applies → N+1. ✓
2. Tx B (replay in same block): account.nonce is now N+1 in `entities.accounts`. Edit populates `expectedPrior = N+1`. Reject check: `accountGCR.nonce(N+1) === expectedPrior(N+1)` → **passes** (BUG).

The populate must happen at **validation time** (during `confirmTransaction`), capturing the pre-block account state, so each tx's `expectedPrior` reflects what the sender's nonce *should* be. Re-reading at apply time defeats the safety net.

Filed as draft so we don't merge the broken populate logic. Need to:
1. Move populate from `handleGCR.applyTransaction` to a per-tx pass during validation OR at block-formation time before `applyTransaction` runs.
2. Confirm symmetric strip in `endpointValidation` is still correct given the new populate site.
3. Add the actual cross-RPC e2e test that would have caught this.

The other changes are sound: `GCRNonceRoutines` rejection logic, validateTransaction caller uncomment, SDK pin bump, doc updates.

## Files

- `src/libs/blockchain/gcr/gcr_routines/GCRNonceRoutines.ts` — apply-time rejection on `expectedPrior` mismatch (✓ correct)
- `src/libs/blockchain/gcr/handleGCR.ts` — apply-time `expectedPrior` populate (**⚠ needs to move**)
- `src/libs/network/endpointValidation.ts` — symmetric strip both sides (✓ correct under either populate site)
- `src/libs/blockchain/routines/validateTransaction.ts` — `assignNonce` caller uncommented (✓ correct)
- `package.json` — demosdk 4.0.3 → 4.0.5 (✓)
- `docs/specs/audit-sweep-batch-c-nonce.md` — Path A rationale + PR list updates (✓)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sequential nonce enforcement with mempool-aware lookahead to improve transaction ordering.

* **Bug Fixes**
  * Stricter nonce guards: validation rejects nonce edits that don't match expected prior values and surfaces clear mismatch errors.
  * Node-side population and symmetric stripping of a node-only nonce hint to preserve transaction hashes/signatures.

* **Documentation**
  * Spec updated with pre-fork vs post-fork nonce behavior and validation details.

* **Chores**
  * Pinned demosdk dependency to 4.0.5.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->