### PR TITLE
fix(mempool): close same-node nonce TOCTOU via per-sender advisory lock (batch C PR 4)

### DIFF
--- a/docs/specs/audit-sweep-batch-c-nonce.md
+++ b/docs/specs/audit-sweep-batch-c-nonce.md
@@ -7,7 +7,8 @@ related: docs/specs/active-feature-test-addition-proposal.md, .ccb/bug-hunt-2026
 prs:
   - "#884 (PR 1: fork registration + assignNonce infra — merged)"
   - "#885 (PR 2: mempool-aware lookahead — merged)"
-  - "#TBD (PR 3: consensus rule + caller wire-up)"
+  - "#886 (PR 3: consensus rule + caller wire-up — merged)"
+  - "#TBD (PR 4: same-node TOCTOU advisory lock)"
 sdk_publish:
   - "@kynesyslabs/demosdk 4.0.5 — adds `expectedPrior?: number` to GCREditNonce (type-only, runtime unchanged)"
 ---
@@ -186,6 +187,7 @@ blanking).
 | 1 | Fork registration + validation infra (caller still commented) | `forkConfig.ts`, `loadForkConfig.ts`, `validateTransaction.ts`, `testing/devnet/genesis.devnet.json` | Med — registers the fork (default `activationHeight: null`) + ships the fork-gated `assignNonce` implementation. Caller remains commented so live behaviour is unchanged on pre-fork chains; devnet boots post-fork from block 0. |
 | 2 | Mempool-aware lookahead | `mempool.ts` (new `countPendingByAddress`), `assignNonce` consumer in `validateTransaction.ts`, tests | Med — touches mempool query API. |
 | 3 | Consensus rule + caller wire-up (Path A) | `GCRNonceRoutines.ts` (fork-gated `expectedPrior` mismatch reject at apply time), `validateTransaction.ts` (uncomment caller + validation-time `expectedPrior` populate from `account.nonce + pendingCount`), `endpointValidation.ts` (symmetric strip on both sides of hash compare), `package.json` (demosdk 4.0.3 → 4.0.5) | High — consensus rule change; rollout coordination across validators. The fork is already registered (PR 1) and validation infra is live (PR 2). This PR adds the consensus-side rejection + validation-time populate, uncomments the validation caller, and bumps the SDK pin to 4.0.5 (which carries the type-only `expectedPrior?: number` field). Cross-RPC e2e test against the devnet fixture is tracked as a follow-up PR; the strip + populate + reject pipeline is testable today via direct mempool injection. |
+| 4 | Same-node TOCTOU advisory lock | `mempool.ts` (per-sender `pg_advisory_xact_lock` + in-lock re-query around `addTransaction`), `validateTransaction.ts` (update assignNonce JSDoc to reflect actual TOCTOU mitigation site) | Low — fork-gated, local to a single function, no cross-node coordination. Closes the validate→addTransaction window that was a known carry-over from PR 2's docstring. Mempool stays clean instead of relying on the PR 3 consensus reject to clear duplicate-nonce admissions later. |
 
 ### SDK change
 
@@ -206,7 +208,7 @@ the existing demosdk pinning pattern in `package.json`).
 |------|------------|
 | In-flight txs with stale nonces after fork activation | SDK already reads nonce live per tx; only stuck txs in custom integrations are at risk. Document in fork-activation runbook. |
 | Mempool count diverges from on-chain state (race) | Single-writer mempool; `countPendingByAddress` reads the same Postgres txn boundary as the validation path. PR 2 includes a stress test. |
-| Same-node TOCTOU — two concurrent same-sender submissions both read `pendingCount` before either is admitted, both pass with identical nonces | PR 3 wraps the validate+`Mempool.addTransaction` sequence in a per-sender critical section via `pg_advisory_xact_lock(hashtext(sender))`, released at commit. The lock serialises concurrent submissions from the same sender on a single node so both go through validation in order. PR 2 ships the validation logic but the caller is commented out, so the race is unreachable today. |
+| Same-node TOCTOU — two concurrent same-sender submissions both read `pendingCount` before either is admitted, both pass with identical nonces | **PR 4** wraps the per-sender re-check + insert inside `Mempool.addTransaction` in a Postgres transaction with `pg_advisory_xact_lock(hashtext('nonce:' || sender))`. The lock serialises concurrent same-sender admissions on a single node. Inside the lock, the routine re-queries `account.nonce` + `countPendingByAddress` (so it sees any concurrent winner that beat it through validate) and rejects the second tx before it occupies a mempool slot. The lock is fork-gated on `nonceEnforcement`; pre-fork chains are bit-identical. The lock alone does not cover cross-node replay — that's the consensus-side `expectedPrior` apply-time reject in PR 3. |
 | Stale mempool entries inflate count between sweeps | `countPendingByAddress` filters on the same `reference_block >= lastBlock - referenceBlockRoom` window that `cleanMempool` uses, so expired-but-unswept rows do not contribute to the expected nonce. |
 | Cross-RPC double-spend before block inclusion | Consensus rule (PR 3) is the safety net. Different RPCs may briefly accept the same nonce; only one survives consensus. |
 | Block-formation order matters when one block contains two same-sender txs with N+1 and N+2 | Block formation already orders by hash (stable); apply order is deterministic. `expectedPrior` rejects out-of-order application. |

--- a/src/libs/blockchain/mempool.ts
+++ b/src/libs/blockchain/mempool.ts
@@ -267,8 +267,24 @@ export default class Mempool {
                             }
                         }
 
+                        // PR #887 Greptile P1 (iter 2): live re-query
+                        // of the block tip inside the lock.
+                        // `blockHeight` outside the lock is the
+                        // `getSharedState.lastBlockNumber` snapshot
+                        // captured before any await; a block produced
+                        // between `confirmTransaction` and
+                        // `addTransaction` would diverge from the
+                        // cutoff `assignNonce` used (which goes
+                        // through `Chain.getLastBlockNumber()` —
+                        // `countPendingByAddress`). Mirror that path
+                        // so both windows align on the same
+                        // block tip and a still-valid tx is never
+                        // rejected for a stale-cutoff mismatch.
+                        const liveBlockHeight =
+                            await Chain.getLastBlockNumber()
                         const cutoff =
-                            blockHeight - getSharedState.referenceBlockRoom
+                            liveBlockHeight -
+                            getSharedState.referenceBlockRoom
                         const pendingCount = await mempoolRepo
                             .createQueryBuilder("tx")
                             .where(

--- a/src/libs/blockchain/mempool.ts
+++ b/src/libs/blockchain/mempool.ts
@@ -206,70 +206,108 @@ export default class Mempool {
             isForkActive("nonceEnforcement", blockHeight)
         ) {
             try {
-                return await this.repo.manager.transaction(async em => {
-                    // Postgres advisory locks operate on signed bigint
-                    // keys. `hashtext()` returns a 32-bit signed int —
-                    // ample collision space for distinct senders, no
-                    // false-positive interference with other lock
-                    // keyspaces in the project (none exist yet).
-                    await em.query(
-                        "SELECT pg_advisory_xact_lock(hashtext($1))",
-                        [`nonce:${senderFrom}`],
-                    )
-
-                    // Re-check inside the lock. The account row may have
-                    // advanced (a concurrent submission committed); the
-                    // mempool count likely changed.
-                    const gcrRepo = em.getRepository(GCRMain)
-                    const account = await gcrRepo.findOne({
-                        where: { pubkey: senderFrom },
-                    })
-                    if (!account) {
-                        return {
-                            confirmationBlock: null,
-                            error: "Nonce TOCTOU recheck: sender account missing",
-                        }
-                    }
-
-                    const cutoff =
-                        blockHeight - getSharedState.referenceBlockRoom
-                    const mempoolRepo = em.getRepository(MempoolTx)
-                    const pendingCount = await mempoolRepo
-                        .createQueryBuilder("tx")
-                        .where(
-                            "LOWER(tx.content->>'from') = LOWER(:address)",
-                            { address: senderFrom },
+                // PR #887 Greptile P1: explicit `READ COMMITTED`. The
+                // default Postgres txn isolation can be flipped by
+                // server / connection-pool config, and under
+                // `REPEATABLE READ` or `SERIALIZABLE` the txn
+                // snapshot is taken at `BEGIN` — BEFORE the advisory
+                // lock fires — so the in-lock re-query of
+                // `pendingCount` would see stale data and the entire
+                // TOCTOU guarantee silently collapses. Pinning the
+                // level here makes the lock + recheck semantics
+                // independent of operator configuration.
+                return await this.repo.manager.transaction(
+                    "READ COMMITTED",
+                    async em => {
+                        // Postgres advisory locks operate on signed
+                        // bigint keys. `hashtext()` returns a 32-bit
+                        // signed int — ample collision space for
+                        // distinct senders, no false-positive
+                        // interference with other lock keyspaces in
+                        // the project (none exist yet).
+                        await em.query(
+                            "SELECT pg_advisory_xact_lock(hashtext($1))",
+                            [`nonce:${senderFrom}`],
                         )
-                        .andWhere("tx.reference_block >= :cutoff", { cutoff })
-                        .getCount()
 
-                    const expected = account.nonce + 1 + pendingCount
-                    if (txNonce !== expected) {
-                        log.error(
-                            `[Mempool.addTransaction] Nonce TOCTOU recheck mismatch for ${senderFrom}: ` +
-                                `tx.content.nonce=${txNonce}, expected=${expected} ` +
-                                `(account.nonce=${account.nonce}, pendingMempoolCount=${pendingCount})`,
-                        )
-                        return {
-                            confirmationBlock: null,
-                            error:
-                                "Nonce TOCTOU recheck failed: " +
-                                `tx.content.nonce=${txNonce}, expected=${expected}`,
+                        // PR #887 Greptile P2: re-check the hash
+                        // INSIDE the lock so a second concurrent
+                        // submission of the identical tx (same
+                        // hash) gets a clear "already in mempool"
+                        // error instead of falling through to the
+                        // nonce-mismatch message. The outer
+                        // `checkTransactionByHash` runs before the
+                        // lock and lets both racers past, so the
+                        // in-lock check is the only place where
+                        // duplicate-hash concurrency is
+                        // distinguishable from nonce reuse.
+                        const mempoolRepo = em.getRepository(MempoolTx)
+                        const hashExists = await mempoolRepo.exists({
+                            where: { hash: transaction.hash },
+                        })
+                        if (hashExists) {
+                            return {
+                                confirmationBlock: null,
+                                error: "Transaction already in mempool",
+                            }
                         }
-                    }
 
-                    const saved = await mempoolRepo.save({
-                        ...transaction,
-                        timestamp: BigInt(transaction.content.timestamp),
-                        nonce: transaction.content.nonce,
-                        blockNumber: blockRef,
-                    })
+                        // Re-check inside the lock. The account row
+                        // may have advanced (a concurrent submission
+                        // committed); the mempool count likely
+                        // changed.
+                        const gcrRepo = em.getRepository(GCRMain)
+                        const account = await gcrRepo.findOne({
+                            where: { pubkey: senderFrom },
+                        })
+                        if (!account) {
+                            return {
+                                confirmationBlock: null,
+                                error: "Nonce TOCTOU recheck: sender account missing",
+                            }
+                        }
 
-                    return {
-                        confirmationBlock: saved.blockNumber,
-                        error: "",
-                    }
-                })
+                        const cutoff =
+                            blockHeight - getSharedState.referenceBlockRoom
+                        const pendingCount = await mempoolRepo
+                            .createQueryBuilder("tx")
+                            .where(
+                                "LOWER(tx.content->>'from') = LOWER(:address)",
+                                { address: senderFrom },
+                            )
+                            .andWhere("tx.reference_block >= :cutoff", {
+                                cutoff,
+                            })
+                            .getCount()
+
+                        const expected = account.nonce + 1 + pendingCount
+                        if (txNonce !== expected) {
+                            log.error(
+                                `[Mempool.addTransaction] Nonce TOCTOU recheck mismatch for ${senderFrom}: ` +
+                                    `tx.content.nonce=${txNonce}, expected=${expected} ` +
+                                    `(account.nonce=${account.nonce}, pendingMempoolCount=${pendingCount})`,
+                            )
+                            return {
+                                confirmationBlock: null,
+                                error:
+                                    "Nonce TOCTOU recheck failed: " +
+                                    `tx.content.nonce=${txNonce}, expected=${expected}`,
+                            }
+                        }
+
+                        const saved = await mempoolRepo.save({
+                            ...transaction,
+                            timestamp: BigInt(transaction.content.timestamp),
+                            nonce: transaction.content.nonce,
+                            blockNumber: blockRef,
+                        })
+
+                        return {
+                            confirmationBlock: saved.blockNumber,
+                            error: "",
+                        }
+                    },
+                )
             } catch (error) {
                 let message = "Error: Failed to add transaction to mempool"
                 if (error instanceof QueryFailedError) {

--- a/src/libs/blockchain/mempool.ts
+++ b/src/libs/blockchain/mempool.ts
@@ -17,6 +17,8 @@ import Chain from "./chain"
 import { getSharedState } from "@/utilities/sharedState"
 import TxValidatorPool from "./validation/txValidatorPool"
 import { CHUNK_MEMPOOL_TX, chunkedInsert } from "./chainDb"
+import { isForkActive } from "@/forks"
+import { GCRMain } from "@/model/entities/GCRv2/GCR_Main"
 
 export default class Mempool {
     public static repo: Repository<MempoolTx> = null
@@ -163,6 +165,122 @@ export default class Mempool {
 
             if (getSharedState.inConsensusLoop) {
                 blockRef = SecretaryManager.lastBlockRef + 1
+            }
+        }
+
+        // Audit-sweep batch C PR 4 — close the validate→addTransaction
+        // TOCTOU window for `nonceEnforcement`.
+        //
+        // `assignNonce` ran during the earlier `confirmTransaction`
+        // call, but that's a separate RPC round-trip from this
+        // execute-side insert. Between the two, two concurrent
+        // ingress paths for the same sender can both pass validation
+        // (each sees stale `account.nonce + pendingCount`) and reach
+        // here with duplicate nonces. The consensus-side
+        // `expectedPrior` check in `GCRNonceRoutines` (PR 3) catches
+        // them at block-apply time, but only after they both occupy
+        // mempool slots. Closing the gap at the insert point keeps
+        // the mempool clean and rejects the duplicate immediately.
+        //
+        // Design: wrap re-check + insert in a Postgres txn with a
+        // per-sender `pg_advisory_xact_lock`. Lock released at
+        // commit/rollback. Re-query account nonce + mempool count
+        // INSIDE the locked section so the values reflect any
+        // concurrent winner that beat us into the lock. If the
+        // re-check fails, return error without inserting.
+        //
+        // Skip when not native, when no sender (genesis path), when
+        // fork inactive, or when the tx doesn't carry a nonce —
+        // those paths preserve the legacy behaviour bit-identically.
+        const senderFromRaw = transaction.content?.from
+        const senderFrom =
+            typeof senderFromRaw === "string"
+                ? senderFromRaw.toLowerCase()
+                : null
+        const txNonce = transaction.content?.nonce
+        const blockHeight = getSharedState.lastBlockNumber ?? 0
+
+        if (
+            senderFrom &&
+            typeof txNonce === "number" &&
+            isForkActive("nonceEnforcement", blockHeight)
+        ) {
+            try {
+                return await this.repo.manager.transaction(async em => {
+                    // Postgres advisory locks operate on signed bigint
+                    // keys. `hashtext()` returns a 32-bit signed int —
+                    // ample collision space for distinct senders, no
+                    // false-positive interference with other lock
+                    // keyspaces in the project (none exist yet).
+                    await em.query(
+                        "SELECT pg_advisory_xact_lock(hashtext($1))",
+                        [`nonce:${senderFrom}`],
+                    )
+
+                    // Re-check inside the lock. The account row may have
+                    // advanced (a concurrent submission committed); the
+                    // mempool count likely changed.
+                    const gcrRepo = em.getRepository(GCRMain)
+                    const account = await gcrRepo.findOne({
+                        where: { pubkey: senderFrom },
+                    })
+                    if (!account) {
+                        return {
+                            confirmationBlock: null,
+                            error: "Nonce TOCTOU recheck: sender account missing",
+                        }
+                    }
+
+                    const cutoff =
+                        blockHeight - getSharedState.referenceBlockRoom
+                    const mempoolRepo = em.getRepository(MempoolTx)
+                    const pendingCount = await mempoolRepo
+                        .createQueryBuilder("tx")
+                        .where(
+                            "LOWER(tx.content->>'from') = LOWER(:address)",
+                            { address: senderFrom },
+                        )
+                        .andWhere("tx.reference_block >= :cutoff", { cutoff })
+                        .getCount()
+
+                    const expected = account.nonce + 1 + pendingCount
+                    if (txNonce !== expected) {
+                        log.error(
+                            `[Mempool.addTransaction] Nonce TOCTOU recheck mismatch for ${senderFrom}: ` +
+                                `tx.content.nonce=${txNonce}, expected=${expected} ` +
+                                `(account.nonce=${account.nonce}, pendingMempoolCount=${pendingCount})`,
+                        )
+                        return {
+                            confirmationBlock: null,
+                            error:
+                                "Nonce TOCTOU recheck failed: " +
+                                `tx.content.nonce=${txNonce}, expected=${expected}`,
+                        }
+                    }
+
+                    const saved = await mempoolRepo.save({
+                        ...transaction,
+                        timestamp: BigInt(transaction.content.timestamp),
+                        nonce: transaction.content.nonce,
+                        blockNumber: blockRef,
+                    })
+
+                    return {
+                        confirmationBlock: saved.blockNumber,
+                        error: "",
+                    }
+                })
+            } catch (error) {
+                let message = "Error: Failed to add transaction to mempool"
+                if (error instanceof QueryFailedError) {
+                    log.error(`Error saving tx: ${transaction.hash}`)
+                    log.error(error.message)
+                    message = "Error: Transaction already in mempool"
+                }
+                return {
+                    confirmationBlock: null,
+                    error: message,
+                }
             }
         }
 

--- a/src/libs/blockchain/routines/validateTransaction.ts
+++ b/src/libs/blockchain/routines/validateTransaction.ts
@@ -389,14 +389,17 @@ async function defineGas(
  * Concurrency caveat (TOCTOU). On a single node, two concurrent
  * submissions from the same sender both read `pendingCount` before
  * either is admitted to the mempool, so both compute the same
- * `expected` and both pass validation. PR 2 explicitly does NOT
- * close this window. The fix lands in PR 3 alongside the caller
- * wire-up, where the validate+`Mempool.addTransaction` sequence
- * is wrapped in a per-sender critical section (Postgres advisory
- * lock keyed by `hashtext(sender)`, released at commit). Today the
- * caller is commented out so the race is unreachable; the
- * surrounding lock is part of the PR 3 design lock-in
- * (see `docs/specs/audit-sweep-batch-c-nonce.md` — Risks section).
+ * `expected` and both pass validation here. Closed at the insert
+ * boundary by PR 4: `Mempool.addTransaction` wraps the per-sender
+ * `pg_advisory_xact_lock`-protected re-check + insert. The lock
+ * serialises concurrent same-sender ingress and the in-lock
+ * re-query of `account.nonce + pendingMempoolCount` catches the
+ * duplicate-nonce second submission before it occupies a mempool
+ * slot. See `docs/specs/audit-sweep-batch-c-nonce.md` Risks section
+ * for the cross-RPC safety net (PR 3's `expectedPrior` apply-time
+ * reject in `GCRNonceRoutines`) — that remains the only line of
+ * defence against cross-node replay since this node's mempool lock
+ * cannot serialise across peers.
  *
  * The caller in `confirmTransaction` (lines 77-86) remains commented
  * out in PR 1 — this commit ships the validation infra without


### PR DESCRIPTION
## Summary

PR 4 of the batch C nonce-replay-protection sequence specified in [`docs/specs/audit-sweep-batch-c-nonce.md`](../blob/bugfix/audit-sweep-batch-c-toctou-lock-2026-05-31/docs/specs/audit-sweep-batch-c-nonce.md). Closes the same-node TOCTOU window that was flagged on PR #886 and originally promised in PR #885's `assignNonce` docstring (but never landed).

3 files, +133 / -10.

## The window

`assignNonce` runs during `confirmTransaction` (validate RPC). `Mempool.addTransaction` runs during a separate execute RPC. Between the two, two concurrent ingress paths for the same sender can both pass validation (each sees the same stale `account.nonce + pendingCount`) and reach `addTransaction` with duplicate nonces.

PR #886's consensus-side `expectedPrior` reject catches them at block-apply time, but only after both occupy mempool slots and burn cleanup churn.

## What this PR ships

### `Mempool.addTransaction`

Wrap the per-sender re-check + insert in a Postgres transaction:

```ts
await em.query(
    "SELECT pg_advisory_xact_lock(hashtext($1))",
    [`nonce:${senderFrom}`],
)
// re-query account.nonce + countPendingByAddress INSIDE the lock
// re-check tx.content.nonce === expected
// insert (or reject)
```

Lock key namespaced as `nonce:${sender_lowercase_hex}` so future advisory-lock callers in the project can't collide. Released at commit/rollback.

### Fork-gated

Only runs when `nonceEnforcement` is active **and** the tx carries a string `content.from` **and** a numeric `content.nonce`. Pre-fork chains stay bit-identical via the legacy insert path below the gate. Genesis-tx / awardPoints / L2PS internal paths that don't carry a native sender skip the gate.

### `assignNonce` JSDoc

Rewritten to point at `Mempool.addTransaction` as the actual TOCTOU mitigation site. PR 2's original wording promised PR 3 would land the lock; PR 3 shipped without it and Greptile flagged the discrepancy. Now matches shipped reality.

### Spec doc

- PRs frontmatter: PR 3 marked merged, PR 4 added.
- Risks table TOCTOU row rewritten to describe the actual PR 4 fix shape + cross-node carve-out.
- PR breakdown: new PR 4 row (Low risk, fork-gated, single function).

## Cross-node note

This lock is local to this node's Postgres. **Cross-RPC replay across two different validators is NOT covered.** That remains the consensus-side `expectedPrior` apply-time reject in `GCRNonceRoutines` (PR #886). PR 4 is the same-node companion to that cross-node safety net.

## Verification

- `tsc --noEmit` clean on both changed code files.
- Manual trace of concurrent same-sender submission:
  1. Client A and B both validate with `account.nonce=0`. Both pass (`tx.content.nonce=1` in both).
  2. Both reach `Mempool.addTransaction` concurrently. A acquires advisory lock first.
  3. A re-queries inside lock: `account.nonce=0`, `pending=0`, `expected=1`. Match. Inserts. Releases at commit.
  4. B acquires lock. Re-queries: `account.nonce=0`, `pending=1` (A just inserted), `expected=2`. `tx.content.nonce=1`. Mismatch. Returns error without inserting.
- Pre-fork trace: `senderFrom` set, `txNonce` number, but `isForkActive` returns false → skip the locked branch → legacy insert path runs → bit-identical re-sync.

## Test plan

- [ ] `bun install` and confirm clean tsc.
- [ ] Boot devnet (post-fork from block 0).
- [ ] Concurrent-submission test: fire 2 same-sender `confirmTx + executeTx` round-trips back-to-back with identical `tx.content.nonce`. Expect first to land in mempool, second to fail with `Nonce TOCTOU recheck failed` error.
- [ ] Pre-fork chain (testnet checkout with `nonceEnforcement.activationHeight: null`): confirm legacy `addTransaction` path is taken (no advisory lock, no recheck) — re-sync stays bit-identical.