### PR TITLE
fix(consensus): close vote-race in broadcastBlockHash, restore [pro, con] BFT semantics (batch D) [DRAFT - consensus]

### DIFF
--- a/src/libs/consensus/v2/routines/broadcastBlockHash.ts
+++ b/src/libs/consensus/v2/routines/broadcastBlockHash.ts
@@ -1,174 +1,292 @@
 import { RPCResponse } from "@kynesyslabs/demosdk/types"
-import { ConsensusHashResponse } from "../interfaces"
 import Block from "src/libs/blockchain/block"
 import { Peer } from "src/libs/peer"
 import { getSharedState } from "src/utilities/sharedState"
 import log from "src/utilities/logger"
-import { hexToUint8Array, ucrypto } from "@kynesyslabs/demosdk/encryption"
+import { hexToUint8Array } from "@kynesyslabs/demosdk/encryption"
 import TxValidatorPool from "@/libs/blockchain/validation/txValidatorPool"
 
+/**
+ * Per-peer vote outcome. The `signaturesToMerge` map carries every
+ * signature the peer attached to its response **after** caller-side
+ * verification against the candidate block hash; entries that failed
+ * verification are dropped before this object is constructed so the
+ * aggregator never has to second-guess validity.
+ */
+interface PeerVoteOutcome {
+    peerId: string
+    vote: "pro" | "con"
+    signaturesToMerge: Record<string, string>
+    rejectionReason?: string
+}
+
+/**
+ * Verify every incoming signature in parallel against the candidate
+ * block hash and return only the verified ones. Failures are logged
+ * but do not abort the routine — peers can legitimately ship
+ * signatures from other peers that haven't yet been published, and
+ * the aggregator merges what we can trust.
+ *
+ * Returns the verified subset as `{identity: signature}` so the
+ * caller can hand it to the aggregator without re-verifying.
+ */
+async function verifyIncomingSignatures(
+    incoming: Record<string, string>,
+    candidateBlockHash: string,
+    peerId: string,
+): Promise<Record<string, string>> {
+    const entries = Object.entries(incoming)
+    const checks = await Promise.all(
+        entries.map(async ([identity, signature]) => {
+            try {
+                const isValid =
+                    await TxValidatorPool.getInstance().verify({
+                        algorithm: getSharedState.signingAlgorithm,
+                        message: new TextEncoder().encode(candidateBlockHash),
+                        signature: hexToUint8Array(signature),
+                        publicKey: hexToUint8Array(identity),
+                    })
+                return { identity, signature, isValid }
+            } catch (e) {
+                const msg = e instanceof Error ? e.message : String(e)
+                log.error(
+                    `[broadcastBlockHash] Signature verification threw for ${identity} (relayed by ${peerId}): ${msg}`,
+                )
+                return { identity, signature, isValid: false }
+            }
+        }),
+    )
+
+    const verified: Record<string, string> = {}
+    for (const { identity, signature, isValid } of checks) {
+        if (isValid) {
+            verified[identity] = signature
+        } else {
+            log.error(
+                `[broadcastBlockHash] Invalid signature relayed by ${peerId} for ${identity}; dropping. ` +
+                    `Candidate block hash: ${candidateBlockHash}`,
+            )
+        }
+    }
+    return verified
+}
+
+/**
+ * Per-peer flow: call the peer's `proposeBlockHash`, classify the
+ * response as pro/con, and (on pro) collect the signatures the peer
+ * attached. Never throws — a network failure becomes a `con` vote
+ * with a rejection reason so the aggregator counts votes accurately.
+ */
+async function proposeAndCollect(
+    peer: Peer,
+    block: Block,
+    proposeParams: [string, Block["validation_data"], string],
+): Promise<PeerVoteOutcome> {
+    const peerId = peer.identity
+    let response: RPCResponse
+    try {
+        response = await peer.longCall(
+            {
+                method: "consensus_routine",
+                params: [
+                    {
+                        method: "proposeBlockHash",
+                        params: proposeParams,
+                    },
+                ],
+            },
+            true,
+            {
+                allowedCodes: [401, 404],
+            },
+        )
+    } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e)
+        log.error(
+            `[broadcastBlockHash] longCall to ${peerId} threw (counts as con): ${msg}`,
+        )
+        return {
+            peerId,
+            vote: "con",
+            signaturesToMerge: {},
+            rejectionReason: `longCall threw: ${msg}`,
+        }
+    }
+
+    if (response.result !== 200) {
+        const extraMessage =
+            typeof response.extra === "object" && response.extra !== null
+                ? (response.extra as { message?: string }).message
+                : undefined
+        log.error(
+            "[broadcastBlockHash] Block hash not confirmed by validator " +
+                `${peerId}: result=${response.result} message=${extraMessage}`,
+        )
+
+        // Diagnostic dump preserved from prior implementation — helps
+        // operators investigate why two shard members disagreed on
+        // the candidate block content. The mismatched-block payload
+        // is only present on the 401 branch from
+        // `manageProposeBlockHash`; guard accordingly.
+        const extra = response.extra as
+            | { ourBlock?: { txHashes?: string[]; ordered_transactions?: string[] } }
+            | undefined
+        if (extra?.ourBlock) {
+            const theirTxHashes: string[] =
+                extra.ourBlock.txHashes ??
+                extra.ourBlock.ordered_transactions ??
+                []
+            const ourTxHashes: string[] =
+                getSharedState.candidateBlock.content.ordered_transactions
+            const theirSet = new Set(theirTxHashes)
+            const ourSet = new Set(ourTxHashes)
+            const missingFromUs = theirTxHashes.filter(h => !ourSet.has(h))
+            const missingFromThem = ourTxHashes.filter(
+                h => !theirSet.has(h),
+            )
+            log.error(
+                `[broadcastBlockHash] tx-set diff with ${peerId}: ` +
+                    `missingFromUs=${missingFromUs.length}, ` +
+                    `missingFromThem=${missingFromThem.length}`,
+            )
+            log.debug(
+                `[broadcastBlockHash] Their block: ${JSON.stringify(
+                    extra.ourBlock,
+                    null,
+                    2,
+                )}`,
+            )
+        }
+
+        return {
+            peerId,
+            vote: "con",
+            signaturesToMerge: {},
+            rejectionReason: `HTTP ${response.result}`,
+        }
+    }
+
+    // 200 path — receiver agreed with our block hash. `response.extra`
+    // is its `candidateBlock.validation_data` (see
+    // `manageProposeBlockHash.ts` line 104). `response.response` is
+    // the receiver's pubkey hex; `extra.signatures[response.response]`
+    // is its signature over our block hash.
+    const extra = response.extra as
+        | { signatures?: Record<string, string> }
+        | undefined
+    const incomingSignatures = extra?.signatures ?? {}
+
+    if (Object.keys(incomingSignatures).length === 0) {
+        log.warn(
+            `[broadcastBlockHash] ${peerId} returned 200 but attached no signatures; counting as pro vote with no merge`,
+        )
+        return {
+            peerId,
+            vote: "pro",
+            signaturesToMerge: {},
+        }
+    }
+
+    const verified = await verifyIncomingSignatures(
+        incomingSignatures,
+        block.hash,
+        peerId,
+    )
+
+    return {
+        peerId,
+        vote: "pro",
+        signaturesToMerge: verified,
+    }
+}
+
+/**
+ * Broadcasts our candidate block hash to every shard member,
+ * collects each peer's vote (pro/con), and merges the per-peer
+ * signatures that survive verification into our candidate block's
+ * `validation_data.signatures` map.
+ *
+ * Returns `[pro, con]` — the actual peer vote counts, NOT a
+ * signature count. BFT threshold computation in
+ * {@link isBlockValid} expects vote counts; using signature count
+ * would conflate "this peer attested to our block" with "this peer
+ * relayed a third party's attestation" and inflate the tally past
+ * what 2/3+1 implies.
+ *
+ * Concurrency notes (audit-sweep batch D):
+ *  - Per-peer outbound calls run in parallel via `Promise.all`.
+ *    Each one is wrapped in a try/catch so a single peer's network
+ *    failure becomes a `con` vote with a rejection reason, not a
+ *    routine-level abort. `Promise.allSettled` semantics achieved
+ *    by always resolving (never rejecting) from inside the map.
+ *  - Per-peer signature verification runs in parallel inside the
+ *    per-peer flow (`verifyIncomingSignatures`).
+ *  - Signature merge into `block.validation_data.signatures` is
+ *    serialised AFTER all peer outcomes settle — single sequential
+ *    pass over the aggregated outcomes. This eliminates the
+ *    fire-and-forget race the previous implementation had where
+ *    `.then` callbacks mutated `signatures` after the routine
+ *    returned, leaving the caller (`voteOnBlock`) to consume a
+ *    half-populated map.
+ *
+ * The previous implementation also commented out the
+ * `[pro, con]` return and instead returned
+ * `[signatureCount, shard.length - signatureCount]`. That broke BFT
+ * semantics — concurrent inbound `manageProposeBlockHash` calls
+ * write into the same `signatures` map (because `block` IS
+ * `getSharedState.candidateBlock`), so `signatureCount` reflected
+ * not just our outbound peer votes but every signature any shard
+ * member happened to relay during our broadcast window. This PR
+ * restores vote-count semantics.
+ */
 export async function broadcastBlockHash(
     block: Block,
     shard: Peer[],
 ): Promise<[number, number]> {
+    const ourId = getSharedState.publicKeyHex
+    const proposeParams: [string, Block["validation_data"], string] = [
+        block.hash,
+        block.validation_data,
+        ourId,
+    ]
+
+    const outcomes = await Promise.all(
+        shard.map(peer => proposeAndCollect(peer, block, proposeParams)),
+    )
+
     let pro = 0
     let con = 0
-    const promises = []
-    const ourId = getSharedState.publicKeyHex
-    const proposeParams = [block.hash, block.validation_data, ourId]
-    for (const peer of shard) {
-        promises.push(
-            peer.longCall(
-                {
-                    method: "consensus_routine",
-                    params: [
-                        {
-                            method: "proposeBlockHash",
-                            params: proposeParams,
-                        },
-                    ],
-                },
-                true,
-                {
-                    allowedCodes: [401],
-                },
-            ), // REVIEW  We should wait a little if the call returns false as the node is not in the consensus loop yet and in general for all consensus_routine calls
-        )
-    }
 
-    // See manageConsensusRoutine.ts for more details on the response format and mechanism
-    for (const promise of promises) {
-        // Work asynchronously
-        promise.then(async (response: RPCResponse) => {
-            if (response.result === 200) {
-                // Add the validation data to the block
-                // ? Should we check if the peer is in the shard? Theoretically we checked before
-                const peerValidationData =
-                    response.extra.signatures[response.response]
-                block.validation_data.signatures[response.response] =
-                    peerValidationData
-
-                const incomingSignatures: { [key: string]: string } =
-                    response.extra["signatures"]
-
-                const signatureVerificationPromises = Object.entries(
-                    incomingSignatures,
-                ).map(async ([identity, signature]) => {
-                    const isValid = await TxValidatorPool.getInstance().verify({
-                        algorithm: getSharedState.signingAlgorithm,
-                        message: new TextEncoder().encode(block.hash),
-                        signature: hexToUint8Array(signature),
-                        publicKey: hexToUint8Array(identity),
-                    })
-
-                    if (isValid) {
-                        block.validation_data.signatures[identity] = signature
-                        log.debug(
-                            `Signature ${signature} from ${identity} added to the candidate block`,
-                        )
-                        return { identity, signature, isValid: true }
-                    }
-
-                    log.error(
-                        `Found invalid incoming signature by: ${identity}`,
-                    )
-                    log.error(`Proposed signature: ${signature}`)
-                    log.error("Candidate block hash: " + block.hash)
-                    log.error(
-                        "Signature verification failed. Signature not added.",
-                    )
-                    return { identity, signature, isValid: false }
-                })
-
-                await Promise.all(signatureVerificationPromises)
-                pro++
-            } else {
-                log.error("Failed for validator: " + response.response)
-                log.error(
-                    "[broadcastBlockHash] Block hash not confirmed from the validator: " +
-                        response.response,
-                )
-                log.error("Message: " + response.extra.message)
-                // ! We have:
-                /* [WARNING] [2024-08-27T21:31:41.139Z] [RPC Call] [consensus_routine] [2024-08-27T21:31:41.100Z] Response not OK: Consensus mode is not active - 400
-                [broadcastBlockHash] response from a validator received.
-                [broadcastBlockHash] Block hash not confirmed from the validator: Consensus mode is not active
-                // ! With the timestamp being 41 on the second node running and 37 on the first (the time interval taken to run the second node is indeed 3 seconds)
-                */
-                log.error(
-                    "[broadcastBlockHash] Block hash proposed: " + block.hash,
-                )
-                log.error(
-                    "[broadcastBlockHash] Response received (with error): " +
-                        JSON.stringify(response.extra),
-                )
-
-                if (response.extra.ourBlock) {
-                    const theirTxHashes: string[] =
-                        response.extra.ourBlock.txHashes ??
-                        response.extra.ourBlock.ordered_transactions ??
-                        []
-                    const ourTxHashes: string[] =
-                        getSharedState.candidateBlock.content
-                            .ordered_transactions
-
-                    const theirSet = new Set(theirTxHashes)
-                    const ourSet = new Set(ourTxHashes)
-
-                    const missingFromUs = theirTxHashes.filter(
-                        h => !ourSet.has(h),
-                    )
-                    const missingFromThem = ourTxHashes.filter(
-                        h => !theirSet.has(h),
-                    )
-
-                    log.error(
-                        "Their block: " +
-                            JSON.stringify(response.extra.ourBlock, null, 2),
-                    )
-                    log.error(
-                        "Our block: " +
-                            JSON.stringify(
-                                {
-                                    hash: getSharedState.candidateBlock.hash,
-                                    number: getSharedState.candidateBlock
-                                        .number,
-                                    timestamp:
-                                        getSharedState.candidateBlock.content
-                                            .timestamp,
-                                    txCount: ourTxHashes.length,
-                                    txHashes: ourTxHashes,
-                                },
-                                null,
-                                2,
-                            ),
-                    )
-                    log.error(
-                        `[broadcastBlockHash] Missing from us (${missingFromUs.length}): ${JSON.stringify(missingFromUs)}`,
-                    )
-                    log.error(
-                        `[broadcastBlockHash] Missing from them (${missingFromThem.length}): ${JSON.stringify(missingFromThem)}`,
-                    )
-                }
-                con++
+    // Serial merge: each `Object.assign` operation against the
+    // shared `signatures` map is atomic, but we want a single
+    // deterministic order so log lines reflect what landed and
+    // operators can replay the merge if needed.
+    for (const outcome of outcomes) {
+        if (outcome.vote === "pro") {
+            pro++
+            const added = Object.entries(outcome.signaturesToMerge)
+            for (const [identity, signature] of added) {
+                block.validation_data.signatures[identity] = signature
             }
-        })
+            if (added.length > 0) {
+                log.debug(
+                    `[broadcastBlockHash] Merged ${added.length} verified ` +
+                        `signatures relayed by ${outcome.peerId}`,
+                )
+            }
+        } else {
+            con++
+        }
     }
 
-    // TODO: Transmit received votes to the other nodes
-    // to help with failures
-    await Promise.all(promises)
     log.info(
-        "[broadcastBlockHash] Block hash broadcasted to the shard: votes: " +
-            pro +
-            " rejections: " +
-            con,
+        `[broadcastBlockHash] Vote tally for block ${block.hash}: ` +
+            `pro=${pro}, con=${con} (shard size=${shard.length})`,
     )
-    // return [pro, con]
 
-    const signatureCount = Object.keys(
-        getSharedState.candidateBlock.validation_data.signatures,
-    ).length
-    // INFO: Return the candidate block signature count
-    return [signatureCount, shard.length - signatureCount]
+    // TODO: Transmit received votes to the other nodes to help with
+    // failures (pre-existing follow-up, unrelated to the vote-race
+    // fix).
+
+    return [pro, con]
 }

--- a/src/libs/consensus/v2/routines/broadcastBlockHash.ts
+++ b/src/libs/consensus/v2/routines/broadcastBlockHash.ts
@@ -46,22 +46,37 @@ async function verifyIncomingSignatures(
                         signature: hexToUint8Array(signature),
                         publicKey: hexToUint8Array(identity),
                     })
-                return { identity, signature, isValid }
+                // `loggedFailure` marks whether the inner catch path
+                // already emitted an error for this entry — so the
+                // outer aggregator can skip its own "Invalid
+                // signature" log and avoid double-noise (PR #888
+                // Greptile P2).
+                return {
+                    identity,
+                    signature,
+                    isValid,
+                    loggedFailure: false,
+                }
             } catch (e) {
                 const msg = e instanceof Error ? e.message : String(e)
                 log.error(
                     `[broadcastBlockHash] Signature verification threw for ${identity} (relayed by ${peerId}): ${msg}`,
                 )
-                return { identity, signature, isValid: false }
+                return {
+                    identity,
+                    signature,
+                    isValid: false,
+                    loggedFailure: true,
+                }
             }
         }),
     )
 
     const verified: Record<string, string> = {}
-    for (const { identity, signature, isValid } of checks) {
+    for (const { identity, signature, isValid, loggedFailure } of checks) {
         if (isValid) {
             verified[identity] = signature
-        } else {
+        } else if (!loggedFailure) {
             log.error(
                 `[broadcastBlockHash] Invalid signature relayed by ${peerId} for ${identity}; dropping. ` +
                     `Candidate block hash: ${candidateBlockHash}`,
@@ -176,14 +191,24 @@ async function proposeAndCollect(
         | undefined
     const incomingSignatures = extra?.signatures ?? {}
 
+    // PR #888 Greptile P1: a `pro` vote must carry cryptographic
+    // proof of agreement, not just an HTTP 200. A peer returning
+    // 200 with no signatures, or a signatures bundle that fails
+    // verification entirely, contributes no auditable evidence to
+    // `block.validation_data.signatures` — counting such a vote
+    // would mean BFT quorum can be reached on responses no one can
+    // later prove came from the claimed validators. Treat as `con`
+    // with an explicit rejectionReason so the operator can
+    // distinguish "peer attacked us" from "peer disagreed".
     if (Object.keys(incomingSignatures).length === 0) {
-        log.warn(
-            `[broadcastBlockHash] ${peerId} returned 200 but attached no signatures; counting as pro vote with no merge`,
+        log.error(
+            `[broadcastBlockHash] ${peerId} returned 200 but attached no signatures; treating as con`,
         )
         return {
             peerId,
-            vote: "pro",
+            vote: "con",
             signaturesToMerge: {},
+            rejectionReason: "200 with empty signatures map",
         }
     }
 
@@ -192,6 +217,26 @@ async function proposeAndCollect(
         block.hash,
         peerId,
     )
+
+    // PR #888 Greptile P1 (continued): a peer's signature on our
+    // block hash is the canonical attestation that this peer voted
+    // pro. We require it to be present AND verified before counting
+    // the vote. If the peer only relayed third-party signatures
+    // (e.g. malformed bundle dropped on verify, or 200 with only
+    // OTHER validators' signatures), that's a `con` — relayed
+    // signatures alone are not a vote.
+    if (!Object.prototype.hasOwnProperty.call(verified, peerId)) {
+        log.error(
+            `[broadcastBlockHash] ${peerId} returned 200 but its own signature is missing or failed verification; treating as con`,
+        )
+        return {
+            peerId,
+            vote: "con",
+            signaturesToMerge: {},
+            rejectionReason:
+                "200 without verifiable own signature on block hash",
+        }
+    }
 
     return {
         peerId,
@@ -244,9 +289,23 @@ export async function broadcastBlockHash(
     shard: Peer[],
 ): Promise<[number, number]> {
     const ourId = getSharedState.publicKeyHex
+
+    // PR #888 Greptile P2: snapshot `validation_data` once before
+    // fan-out. The receiver-side `manageProposeBlockHash` runs
+    // concurrently with our outbound broadcast (every shard member
+    // is calling every other simultaneously), and any inbound call
+    // mutates `getSharedState.candidateBlock.validation_data.
+    // signatures` — which is the SAME object as
+    // `block.validation_data`. Passing that live reference to every
+    // peer means each outbound call serialises a slightly different
+    // payload depending on what landed first. A `structuredClone`
+    // freezes the payload at fan-out time so every peer sees the
+    // same `validation_data` snapshot. Receivers still verify and
+    // merge what they get; the freeze only affects what we ship.
+    const validationDataSnapshot = structuredClone(block.validation_data)
     const proposeParams: [string, Block["validation_data"], string] = [
         block.hash,
-        block.validation_data,
+        validationDataSnapshot,
         ourId,
     ]
 


### PR DESCRIPTION
## Plain-English summary

**What your code does** (the consensus voting handshake)

When a node thinks it has a candidate block ready, it asks every other node in the shard: *"do you agree the block's hash should be X?"* by calling each peer's `proposeBlockHash` endpoint.

Each peer answers with either:
- **200 = yes** + a signature attesting to that hash, plus any other signatures it's already collected from other peers
- **401/404 = no** (you're not in the shard / I haven't formed a candidate yet)

The sender tallies the yes/no votes. If more than 2/3 voted yes → the block is valid → it gets finalised onto the chain.

**What was broken** (three things at once, all amplifying each other)

1. **Half-counted votes** — the tally code (`pro++`/`con++`) ran inside a `.then(...)` callback that wasn't being waited for. Outer code returned **before** the votes finished counting. Result: routine sometimes returned `pro=0` even though every peer agreed.

2. **Wrong number returned** — instead of returning the vote count, the routine returned the **signature count** — a totally different number. Signatures pile up from multiple sources (peer's own attestation, signatures the peer relayed from other peers, signatures other peers were concurrently writing into the same shared object because everyone calls everyone). The BFT "2/3 majority" check was comparing this inflated number against the threshold → blocks were getting approved on fewer real votes than required.

3. **Shared mutable map race** — because all five shard members call each other in parallel, they were all writing signatures into the same JavaScript object at the same time. JS is single-threaded so individual writes don't tear, but the read-verify-write pattern interleaves badly across paths.

**What the fix does**

- Replace fire-and-forget callbacks with awaited promises. Vote tally now finishes before the function returns.
- Each per-peer call returns a small typed object: `{vote: "pro" | "con", signaturesToMerge: ...}`. All outcomes are collected first, then a single serial loop counts votes and merges verified signatures. No more racing writes.
- Return `[pro, con]` (real vote counts), not signature count. BFT check now compares apples to apples.
- Network failures count as `con` votes with an explicit reason, not silent aborts.

**Why this matters**

The combination of bug 2 + bug 3 was the dangerous one: blocks could pass BFT without enough validators actually agreeing. With the fix, the math under `isBlockValid` finally matches the protocol's intent (2/3 + 1 of shard size).

---

## Technical detail

Closes audit-sweep CRITICAL #2 from the 2026-05-28 bug hunt: \`broadcastBlockHash.ts\` vote race.

### Three interacting bugs in the pre-existing implementation

#### 1. Fire-and-forget \`.then\` chains
\`peer.longCall(...).then(async response => { ... pro++; signatures[...] = ... })\` — the \`.then\` is discarded. Outer \`await Promise.all(promises)\` waits for the original longCall promises only. \`pro/con\` increments and signature writes complete AFTER the routine returns. Caller (\`voteOnBlock\`) consumes a half-populated tally.

#### 2. Return value contradicts BFT semantics
Last line returned \`[signatureCount, shard.length - signatureCount]\` instead of \`[pro, con]\`. Signature count includes:
- our own pre-existing signature
- signatures peer-merged via \`response.extra\`
- signatures relayed by other shard peers concurrently calling our \`manageProposeBlockHash\` handler (because \`block\` IS \`getSharedState.candidateBlock\` — same object reference)

BFT \`isBlockValid(pro, totalVotes)\` was being passed signature count vs threshold computed from \`shard.length\`. **Blocks could pass BFT on fewer actual peer-agreement votes than 2/3+1 requires. Consensus safety violation.**

#### 3. Concurrent writes to shared signatures map
\`block.validation_data.signatures\` IS \`getSharedState.candidateBlock.validation_data.signatures\` (same object — verified at \`createBlock.ts:67\`). Outbound \`.then\` callbacks AND inbound \`manageProposeBlockHash\` handler invocations race to write into it.

### Fix shape (Path C — full rewrite with explicit aggregation)

1. **\`proposeAndCollect\`** per-peer flow — try/catch around \`longCall\` so network failures become \`con\` votes with reason, not aborts. Matches the \`Promise.allSettled\` discipline batch A applied elsewhere.
2. **\`verifyIncomingSignatures\`** parallel sig verify, returns verified subset.
3. **Outer routine** — \`await Promise.all(shard.map(...))\`. Aggregates outcomes before counting. Single deterministic serial merge loop.
4. **Return** — \`[pro, con]\` actual vote counts.
5. **Allowed codes** — added 404 (candidate not formed) alongside 401, was being treated as retry-worthy before.

### Why not Bun workers (asked during implementation)
Race wasn't CPU-bound. Workers fix CPU, not promise misuse. \`TxValidatorPool\` already uses \`worker_threads\` for crypto.

### Manual verification traces

**Race scenario** (4 peers, all agree):
- Old: \`Promise.all(promises)\` resolves on HTTP completion. \`pro=0\`, returns \`[0, shard.length]\`. Block rejected.
- New: \`Promise.all(map(proposeAndCollect))\` waits on full per-peer flow. Returns \`[4, 0]\`. Block passes.

**Signature-inflation scenario** (5-node shard, A relays C+D, B relays D+E):
- Old: signatureCount = us+A+B+C+D+E = 6. Returns \`[6, -1]\`. Threshold = floor(10/3)+1 = 4. Passes on inflated count.
- New: \`pro=2\` (A, B directly voted); C, D, E never directly called us. Returns \`[2, 3]\`. Correctly rejected. Relayed signatures still merged into map for downstream finalisation.

### Specifically wanted feedback on
- Whether ANY caller of \`broadcastBlockHash\` was implicitly relying on the inflated signature-count return value.
- Whether \`isBlockValid\`'s 2/3+1 threshold was tuned with the inflated count in mind (it should be — but want explicit confirmation).
- Whether the 404 allowed-codes addition is safe (was a 404 \"candidate block not formed\" previously triggering 3× \`longCall\` retry by accident, masking some other behaviour?).

### Out of scope
- Cross-RPC vote-relay (TODO comment carried over).
- e2e test — devnet harness exists, scripted test follow-up.

### Test plan
- [ ] \`bun install\`, confirm clean tsc.
- [ ] Boot devnet (5 nodes). Confirm consensus rounds still complete.
- [ ] Inject chaos: stop one node mid-round. Confirm \`pro=3, con=1\` shape (down from 4 healthy).
- [ ] Confirm BFT correctly rejects when 3/5 vote con (threshold = 4, so \`pro=2\` should fail).