### PR TITLE
Verify website ownership for domain identities

### DIFF
--- a/src/libs/abstraction/index.ts
+++ b/src/libs/abstraction/index.ts
@@ -231,9 +231,19 @@ export async function verifyWeb2Proof(
                     message: "Domain proof URL must use the default https port",
                 }
             }
+            // The claimed domain comes from an untrusted payload; guard its type
+            // before calling toLowerCase() (optional chaining only covers
+            // null/undefined, so a non-string would throw and escape as a 500
+            // instead of a clean verification failure).
+            if (typeof payload.username !== "string") {
+                return {
+                    success: false,
+                    message: "Domain proof is missing a valid claimed domain",
+                }
+            }
             // proofUrl.hostname is already lower-cased by the URL parser;
             // normalise the client-supplied username so casing never mismatches.
-            if (proofUrl.hostname !== payload.username?.toLowerCase()) {
+            if (proofUrl.hostname !== payload.username.toLowerCase()) {
                 return {
                     success: false,
                     message: "Proof host does not match the claimed domain",

--- a/src/libs/abstraction/index.ts
+++ b/src/libs/abstraction/index.ts
@@ -268,14 +268,16 @@ export async function verifyWeb2Proof(
         const { message, type, signature } = await instance.readData(
             payload.proof as string,
         )
-        // Domain proofs (#897): the signed message is bound to the verified
-        // host AND the sender, so a valid proof can't be lifted onto another
-        // domain or identity. Reconstruct it here from payload.username (already
-        // asserted === the proof URL host above) and the tx sender; the parsed
-        // payload tag is ignored for domain. Other contexts verify as-parsed.
+        // Domain proofs (#897 / DEM-767): the signed message is domain-separated
+        // and bound to the verified host AND the sender, so a signature can't be
+        // lifted onto another domain, identity, or web2 context. Reconstruct it
+        // from payload.username (already asserted === the proof URL host above)
+        // and the tx sender; the parsed payload tag is ignored for domain.
+        // This shape MUST stay in lockstep with the SDK's createDomainProofPayload.
+        // Freshness (nonce/issuedAt) is the Tier-2 follow-up tracked in DEM-767.
         const messageToVerify =
             payload.context === "domain"
-                ? `dw2p:domain:${(payload.username as string).toLowerCase()}:${sender}`
+                ? `dacs-domain:v1:${(payload.username as string).toLowerCase()}:${sender}`
                 : message
         try {
             const verified = await TxValidatorPool.getInstance().verify({

--- a/src/libs/abstraction/index.ts
+++ b/src/libs/abstraction/index.ts
@@ -222,6 +222,15 @@ export async function verifyWeb2Proof(
                     message: `Domain proof must be hosted at ${DOMAIN_PROOF_PATH}`,
                 }
             }
+            // Reject non-default ports: URL.hostname strips the port, so the
+            // host<->claim check below would otherwise pass example.com:9999,
+            // letting a claim ride on a service the owner may not control.
+            if (proofUrl.port !== "") {
+                return {
+                    success: false,
+                    message: "Domain proof URL must use the default https port",
+                }
+            }
             // proofUrl.hostname is already lower-cased by the URL parser;
             // normalise the client-supplied username so casing never mismatches.
             if (proofUrl.hostname !== payload.username?.toLowerCase()) {

--- a/src/libs/abstraction/index.ts
+++ b/src/libs/abstraction/index.ts
@@ -1,6 +1,7 @@
 import { GithubProofParser } from "./web2/github"
 import { TwitterProofParser } from "./web2/twitter"
 import { DiscordProofParser } from "./web2/discord"
+import { DomainProofParser, DOMAIN_PROOF_PATH } from "./web2/domain"
 import { type Web2ProofParser } from "./web2/parsers"
 import { Web2CoreTargetIdentityPayload } from "@kynesyslabs/demosdk/abstraction"
 import { hexToUint8Array, ucrypto } from "@kynesyslabs/demosdk/encryption"
@@ -180,6 +181,7 @@ export async function verifyWeb2Proof(
         | typeof TwitterProofParser
         | typeof GithubProofParser
         | typeof DiscordProofParser
+        | typeof DomainProofParser
 
     switch (payload.context) {
         case "twitter":
@@ -194,6 +196,41 @@ export async function verifyWeb2Proof(
         case "discord":
             parser = DiscordProofParser
             break
+        case "domain": {
+            // The proof must be the well-known file ON the claimed domain.
+            // Binding the proof URL's host to the claimed hostname is what stops
+            // a sender from pointing at someone else's (their own) valid proof
+            // while claiming an unrelated domain.
+            let proofUrl: URL
+            try {
+                proofUrl = new URL(payload.proof as string)
+            } catch {
+                return {
+                    success: false,
+                    message: "Invalid domain proof URL",
+                }
+            }
+            if (proofUrl.protocol !== "https:") {
+                return {
+                    success: false,
+                    message: "Domain proof URL must use https",
+                }
+            }
+            if (proofUrl.pathname !== DOMAIN_PROOF_PATH) {
+                return {
+                    success: false,
+                    message: `Domain proof must be hosted at ${DOMAIN_PROOF_PATH}`,
+                }
+            }
+            if (proofUrl.hostname !== payload.username) {
+                return {
+                    success: false,
+                    message: "Proof host does not match the claimed domain",
+                }
+            }
+            parser = DomainProofParser
+            break
+        }
         default:
             return {
                 success: false,

--- a/src/libs/abstraction/index.ts
+++ b/src/libs/abstraction/index.ts
@@ -222,7 +222,9 @@ export async function verifyWeb2Proof(
                     message: `Domain proof must be hosted at ${DOMAIN_PROOF_PATH}`,
                 }
             }
-            if (proofUrl.hostname !== payload.username) {
+            // proofUrl.hostname is already lower-cased by the URL parser;
+            // normalise the client-supplied username so casing never mismatches.
+            if (proofUrl.hostname !== payload.username?.toLowerCase()) {
                 return {
                     success: false,
                     message: "Proof host does not match the claimed domain",

--- a/src/libs/abstraction/index.ts
+++ b/src/libs/abstraction/index.ts
@@ -268,10 +268,19 @@ export async function verifyWeb2Proof(
         const { message, type, signature } = await instance.readData(
             payload.proof as string,
         )
+        // Domain proofs (#897): the signed message is bound to the verified
+        // host AND the sender, so a valid proof can't be lifted onto another
+        // domain or identity. Reconstruct it here from payload.username (already
+        // asserted === the proof URL host above) and the tx sender; the parsed
+        // payload tag is ignored for domain. Other contexts verify as-parsed.
+        const messageToVerify =
+            payload.context === "domain"
+                ? `dw2p:domain:${(payload.username as string).toLowerCase()}:${sender}`
+                : message
         try {
             const verified = await TxValidatorPool.getInstance().verify({
                 algorithm: type,
-                message: new TextEncoder().encode(message),
+                message: new TextEncoder().encode(messageToVerify),
                 publicKey: hexToUint8Array(sender),
                 signature: hexToUint8Array(signature),
             })

--- a/src/libs/abstraction/web2/domain.ts
+++ b/src/libs/abstraction/web2/domain.ts
@@ -1,5 +1,7 @@
 import axios from "axios"
 import https from "https"
+import dns from "dns"
+import ipaddr from "ipaddr.js"
 import { Web2ProofParser } from "./parsers"
 import { SigningAlgorithm } from "@kynesyslabs/demosdk/types"
 import SharedState from "@/utilities/sharedState"
@@ -11,14 +13,66 @@ export const DOMAIN_PROOF_PATH = "/.well-known/demos-cci.txt"
 /** Max bytes we read from a well-known file — the proof payload is tiny. */
 const MAX_PROOF_BYTES = 4096
 
+/** Non-public ranges tolerated only outside production (for local testing). */
+const DEV_ALLOWED_RANGES = new Set(["loopback", "private", "uniqueLocal"])
+
+/**
+ * SSRF guard for the attacker-controlled proof URL.
+ *
+ * The proof URL is supplied by the caller, so without this a request could be
+ * pointed at internal services or the cloud-metadata endpoint
+ * (e.g. 169.254.169.254) and the response read back. We resolve every A/AAAA
+ * record and reject non-public targets:
+ *
+ * - link-local (incl. metadata), multicast, broadcast, reserved and CGNAT are
+ *   blocked in ALL environments;
+ * - loopback / private / unique-local are blocked in production but allowed
+ *   in dev, so local hosts (e.g. localhost) stay testable.
+ *
+ * @param allowLocal Permit loopback/private/unique-local (true outside prod).
+ */
+async function assertAllowedHostname(
+    hostname: string,
+    allowLocal: boolean,
+): Promise<void> {
+    let resolved: { address: string }[]
+    try {
+        resolved = await dns.promises.lookup(hostname, { all: true })
+    } catch {
+        throw new Error(`Could not resolve host: ${hostname}`)
+    }
+    if (resolved.length === 0) {
+        throw new Error(`Could not resolve host: ${hostname}`)
+    }
+
+    for (const { address } of resolved) {
+        let addr = ipaddr.parse(address)
+        // Classify the embedded v4 for IPv4-mapped IPv6 (::ffff:a.b.c.d).
+        if (
+            addr.kind() === "ipv6" &&
+            (addr as ipaddr.IPv6).isIPv4MappedAddress()
+        ) {
+            addr = (addr as ipaddr.IPv6).toIPv4Address()
+        }
+        const range = addr.range()
+        if (range === "unicast") continue
+        if (allowLocal && DEV_ALLOWED_RANGES.has(range)) continue
+        throw new Error(
+            `Refusing to fetch from non-public address: ${hostname} (${address}, ${range})`,
+        )
+    }
+}
+
 /**
  * Fetch a domain ownership proof file over HTTPS.
  *
  * The TLS certificate, validated during the handshake, binds the response to
  * the requested hostname — so a successful fetch is itself proof that the
  * content was served from a host presenting a valid cert for that domain.
- * (Certificate validation is enabled in production and relaxed in dev so local
- * self-signed hosts can be tested.)
+ *
+ * In production, certificate validation and the SSRF public-address check are
+ * enforced; both are relaxed in dev so local self-signed hosts (e.g. localhost)
+ * can be tested.
  *
  * @param url Full proof URL, e.g. https://example.com/.well-known/demos-cci.txt
  * @returns The trimmed file body and the verified hostname.
@@ -31,8 +85,13 @@ export async function fetchDomainProof(
         throw new Error("Domain proof URL must use https")
     }
 
-    const verifyCertificates = SharedState.getInstance().PROD
-    const agent = new https.Agent({ rejectUnauthorized: verifyCertificates })
+    const isProd = SharedState.getInstance().PROD
+
+    // SSRF guard: block internal / metadata targets. Loopback/private hosts are
+    // permitted only in dev so local test servers (localhost) remain reachable.
+    await assertAllowedHostname(parsed.hostname, !isProd)
+
+    const agent = new https.Agent({ rejectUnauthorized: isProd })
 
     const response = await axios.get(url, {
         httpsAgent: agent,
@@ -69,9 +128,13 @@ export class DomainProofParser extends Web2ProofParser {
         try {
             ;({ body } = await fetchDomainProof(proofUrl))
         } catch (error) {
-            log.error("[DOMAIN] Failed to fetch proof: " + error)
+            const errorMsg =
+                error instanceof Error ? error.message : String(error)
+            log.error(
+                `[DOMAIN] Failed to fetch proof for ${proofUrl}: ${errorMsg}`,
+            )
             throw new Error(
-                `Failed to read domain proof at ${proofUrl}`,
+                `Failed to read domain proof at ${proofUrl}: ${errorMsg}`,
             )
         }
 

--- a/src/libs/abstraction/web2/domain.ts
+++ b/src/libs/abstraction/web2/domain.ts
@@ -153,12 +153,13 @@ export class DomainProofParser extends Web2ProofParser {
         } catch (error) {
             const errorMsg =
                 error instanceof Error ? error.message : String(error)
+            // Full detail (resolved IP / range from the SSRF guard) stays in the
+            // server log; the thrown message is static so verifyWeb2Proof cannot
+            // leak internal network info back to the caller.
             log.error(
                 `[DOMAIN] Failed to fetch proof for ${proofUrl}: ${errorMsg}`,
             )
-            throw new Error(
-                `Failed to read domain proof at ${proofUrl}: ${errorMsg}`,
-            )
+            throw new Error("Failed to fetch domain proof")
         }
 
         const payload = this.parsePayload(body)

--- a/src/libs/abstraction/web2/domain.ts
+++ b/src/libs/abstraction/web2/domain.ts
@@ -2,13 +2,14 @@ import axios from "axios"
 import https from "https"
 import dns from "dns"
 import ipaddr from "ipaddr.js"
-import { Web2ProofParser } from "./parsers"
+import { Web2ProofParser, DOMAIN_PROOF_PATH } from "./parsers"
 import { SigningAlgorithm } from "@kynesyslabs/demosdk/types"
 import SharedState from "@/utilities/sharedState"
 import log from "src/utilities/logger"
 
-/** The well-known path a domain owner hosts to prove control. */
-export const DOMAIN_PROOF_PATH = "/.well-known/demos-cci.txt"
+// Defined in ./parsers (the format choke point) and re-exported here so the
+// existing import site (verifyWeb2Proof) keeps resolving it from ./web2/domain.
+export { DOMAIN_PROOF_PATH }
 
 /** Max bytes we read from a well-known file — the proof payload is tiny. */
 const MAX_PROOF_BYTES = 4096

--- a/src/libs/abstraction/web2/domain.ts
+++ b/src/libs/abstraction/web2/domain.ts
@@ -31,11 +31,11 @@ const DEV_ALLOWED_RANGES = new Set(["loopback", "private", "uniqueLocal"])
  *
  * @param allowLocal Permit loopback/private/unique-local (true outside prod).
  */
-async function assertAllowedHostname(
+async function resolveAndValidateHost(
     hostname: string,
     allowLocal: boolean,
-): Promise<void> {
-    let resolved: { address: string }[]
+): Promise<{ address: string; family: number }> {
+    let resolved: { address: string; family: number }[]
     try {
         resolved = await dns.promises.lookup(hostname, { all: true })
     } catch {
@@ -61,6 +61,10 @@ async function assertAllowedHostname(
             `Refusing to fetch from non-public address: ${hostname} (${address}, ${range})`,
         )
     }
+
+    // Return the first validated address so the caller can pin the socket to it
+    // (prevents DNS-rebinding between this check and connect time).
+    return resolved[0]
 }
 
 /**
@@ -89,9 +93,28 @@ export async function fetchDomainProof(
 
     // SSRF guard: block internal / metadata targets. Loopback/private hosts are
     // permitted only in dev so local test servers (localhost) remain reachable.
-    await assertAllowedHostname(parsed.hostname, !isProd)
+    const pinned = await resolveAndValidateHost(parsed.hostname, !isProd)
 
-    const agent = new https.Agent({ rejectUnauthorized: isProd })
+    // Pin the socket to the validated IP so DNS cannot rebind to an internal
+    // address between the check above and connect time. The URL still carries
+    // the original hostname, so the Host header and TLS SNI / cert validation
+    // are unchanged; only the address the socket dials is forced.
+    const agent = new https.Agent({
+        rejectUnauthorized: isProd,
+        lookup: (
+            _hostname: string,
+            options: { all?: boolean },
+            callback: (...args: any[]) => void,
+        ) => {
+            if (options && options.all) {
+                callback(null, [
+                    { address: pinned.address, family: pinned.family },
+                ])
+            } else {
+                callback(null, pinned.address, pinned.family)
+            }
+        },
+    } as https.AgentOptions)
 
     const response = await axios.get(url, {
         httpsAgent: agent,

--- a/src/libs/abstraction/web2/domain.ts
+++ b/src/libs/abstraction/web2/domain.ts
@@ -1,0 +1,92 @@
+import axios from "axios"
+import https from "https"
+import { Web2ProofParser } from "./parsers"
+import { SigningAlgorithm } from "@kynesyslabs/demosdk/types"
+import SharedState from "@/utilities/sharedState"
+import log from "src/utilities/logger"
+
+/** The well-known path a domain owner hosts to prove control. */
+export const DOMAIN_PROOF_PATH = "/.well-known/demos-cci.txt"
+
+/** Max bytes we read from a well-known file — the proof payload is tiny. */
+const MAX_PROOF_BYTES = 4096
+
+/**
+ * Fetch a domain ownership proof file over HTTPS.
+ *
+ * The TLS certificate, validated during the handshake, binds the response to
+ * the requested hostname — so a successful fetch is itself proof that the
+ * content was served from a host presenting a valid cert for that domain.
+ * (Certificate validation is enabled in production and relaxed in dev so local
+ * self-signed hosts can be tested.)
+ *
+ * @param url Full proof URL, e.g. https://example.com/.well-known/demos-cci.txt
+ * @returns The trimmed file body and the verified hostname.
+ */
+export async function fetchDomainProof(
+    url: string,
+): Promise<{ hostname: string; body: string }> {
+    const parsed = new URL(url)
+    if (parsed.protocol !== "https:") {
+        throw new Error("Domain proof URL must use https")
+    }
+
+    const verifyCertificates = SharedState.getInstance().PROD
+    const agent = new https.Agent({ rejectUnauthorized: verifyCertificates })
+
+    const response = await axios.get(url, {
+        httpsAgent: agent,
+        responseType: "text",
+        maxContentLength: MAX_PROOF_BYTES,
+        maxRedirects: 0,
+        timeout: 10_000,
+        // The proof file is plain text; never follow it as JSON.
+        transformResponse: r => r,
+        headers: { Accept: "text/plain" },
+    })
+
+    const body =
+        typeof response.data === "string"
+            ? response.data.trim()
+            : String(response.data).trim()
+
+    return { hostname: parsed.hostname, body }
+}
+
+export class DomainProofParser extends Web2ProofParser {
+    private static instance: DomainProofParser
+
+    constructor() {
+        super()
+    }
+
+    async readData(
+        proofUrl: string,
+    ): Promise<{ message: string; type: SigningAlgorithm; signature: string }> {
+        this.verifyProofFormat(proofUrl, "domain")
+
+        let body: string
+        try {
+            ;({ body } = await fetchDomainProof(proofUrl))
+        } catch (error) {
+            log.error("[DOMAIN] Failed to fetch proof: " + error)
+            throw new Error(
+                `Failed to read domain proof at ${proofUrl}`,
+            )
+        }
+
+        const payload = this.parsePayload(body)
+        if (!payload) {
+            throw new Error("Invalid domain proof format")
+        }
+
+        return payload
+    }
+
+    static async getInstance() {
+        if (!this.instance) {
+            this.instance = new this()
+        }
+        return this.instance
+    }
+}

--- a/src/libs/abstraction/web2/parsers.ts
+++ b/src/libs/abstraction/web2/parsers.ts
@@ -1,6 +1,9 @@
 import { SigningAlgorithm } from "@kynesyslabs/demosdk/types"
 import log from "@/utilities/logger"
 
+/** The well-known path a domain owner hosts to prove control. */
+export const DOMAIN_PROOF_PATH = "/.well-known/demos-cci.txt"
+
 export abstract class Web2ProofParser {
     formats = {
         github: [
@@ -15,14 +18,37 @@ export abstract class Web2ProofParser {
             "https://canary.discord.com/channels",
             "https://discordapp.com/channels",
         ],
-        // Only enforces the scheme here; the hostname<->claimed-domain binding
-        // and the exact DOMAIN_PROOF_PATH are validated upstream in verifyWeb2Proof.
+        // `domain` is validated structurally below (https + exact
+        // DOMAIN_PROOF_PATH), not via this prefix list.
         domain: ["https://"],
     }
 
     constructor() {}
 
     verifyProofFormat(proofUrl: string, context: string) {
+        // A domain proof must be the well-known file served over https on the
+        // claimed host. Enforcing the full shape here — the choke point every
+        // parser's readData runs through — means no opcode can route a domain
+        // proof past the path/scheme check (it previously lived only in
+        // verifyWeb2Proof, so a new caller could bypass it).
+        if (context === "domain") {
+            let url: URL
+            try {
+                url = new URL(proofUrl)
+            } catch {
+                throw new Error("Invalid domain proof URL")
+            }
+            if (url.protocol !== "https:") {
+                throw new Error("Domain proof URL must use https")
+            }
+            if (url.pathname !== DOMAIN_PROOF_PATH) {
+                throw new Error(
+                    `Domain proof must be hosted at ${DOMAIN_PROOF_PATH}`,
+                )
+            }
+            return
+        }
+
         if (
             !this.formats[context].some((format: string) =>
                 proofUrl.startsWith(format),

--- a/src/libs/abstraction/web2/parsers.ts
+++ b/src/libs/abstraction/web2/parsers.ts
@@ -46,6 +46,14 @@ export abstract class Web2ProofParser {
                     `Domain proof must be hosted at ${DOMAIN_PROOF_PATH}`,
                 )
             }
+            // A non-default port lets a claim ride on a service the domain owner
+            // may not control (URL.hostname strips the port, so the host<->claim
+            // check alone would pass example.com:9999). Require the default 443.
+            if (url.port !== "") {
+                throw new Error(
+                    "Domain proof URL must use the default https port",
+                )
+            }
             return
         }
 

--- a/src/libs/abstraction/web2/parsers.ts
+++ b/src/libs/abstraction/web2/parsers.ts
@@ -15,6 +15,8 @@ export abstract class Web2ProofParser {
             "https://canary.discord.com/channels",
             "https://discordapp.com/channels",
         ],
+        // Only enforces the scheme here; the hostname<->claimed-domain binding
+        // and the exact DOMAIN_PROOF_PATH are validated upstream in verifyWeb2Proof.
         domain: ["https://"],
     }
 

--- a/src/libs/abstraction/web2/parsers.ts
+++ b/src/libs/abstraction/web2/parsers.ts
@@ -15,6 +15,7 @@ export abstract class Web2ProofParser {
             "https://canary.discord.com/channels",
             "https://discordapp.com/channels",
         ],
+        domain: ["https://"],
     }
 
     constructor() {}

--- a/src/libs/network/handlers/identityHandlers.ts
+++ b/src/libs/network/handlers/identityHandlers.ts
@@ -1,5 +1,6 @@
 import { Twitter } from "../../identity/tools/twitter"
 import { Discord } from "../../identity/tools/discord"
+import { fetchDomainProof, DOMAIN_PROOF_PATH } from "../../abstraction/web2/domain"
 import { UDIdentityManager } from "../../blockchain/gcr/gcr_routines/udIdentityManager"
 import ensureGCRForUser from "../../blockchain/gcr/gcr_routines/ensureGCRForUser"
 import type { Tweet } from "@kynesyslabs/demosdk/types"
@@ -154,6 +155,46 @@ export const identityHandlers: Record<string, NodeCallHandler> = {
             response.response = {
                 success: false,
                 error: "Failed to get Discord message",
+            }
+        }
+        return response
+    },
+
+    getDomainProof: async (data, response) => {
+        if (!data.url) {
+            response.result = 400
+            response.response = { success: false, error: "No url specified" }
+            return response
+        }
+
+        let parsed: URL
+        try {
+            parsed = new URL(data.url)
+        } catch {
+            response.result = 400
+            response.response = { success: false, error: "Invalid url" }
+            return response
+        }
+
+        if (parsed.pathname !== DOMAIN_PROOF_PATH) {
+            response.result = 400
+            response.response = {
+                success: false,
+                error: `Proof must be hosted at ${DOMAIN_PROOF_PATH}`,
+            }
+            return response
+        }
+
+        try {
+            const { hostname, body } = await fetchDomainProof(data.url)
+            response.result = 200
+            response.response = { success: true, hostname, body }
+        } catch (error) {
+            log.error("[getDomainProof] " + error)
+            response.result = 400
+            response.response = {
+                success: false,
+                error: "Failed to fetch domain proof",
             }
         }
         return response

--- a/src/libs/network/handlers/identityHandlers.ts
+++ b/src/libs/network/handlers/identityHandlers.ts
@@ -176,6 +176,15 @@ export const identityHandlers: Record<string, NodeCallHandler> = {
             return response
         }
 
+        if (parsed.protocol !== "https:") {
+            response.result = 400
+            response.response = {
+                success: false,
+                error: "Proof URL must use https",
+            }
+            return response
+        }
+
         if (parsed.pathname !== DOMAIN_PROOF_PATH) {
             response.result = 400
             response.response = {
@@ -190,7 +199,7 @@ export const identityHandlers: Record<string, NodeCallHandler> = {
             response.result = 200
             response.response = { success: true, hostname, body }
         } catch (error) {
-            log.error("[getDomainProof] " + error)
+            log.error("[getDomainProof] failed to fetch domain proof", error)
             response.result = 400
             response.response = {
                 success: false,

--- a/src/libs/network/handlers/identityHandlers.ts
+++ b/src/libs/network/handlers/identityHandlers.ts
@@ -194,6 +194,16 @@ export const identityHandlers: Record<string, NodeCallHandler> = {
             return response
         }
 
+        // Default https port only — consistent with verifyWeb2Proof / the parser.
+        if (parsed.port !== "") {
+            response.result = 400
+            response.response = {
+                success: false,
+                error: "Proof URL must use the default https port",
+            }
+            return response
+        }
+
         try {
             const { hostname, body } = await fetchDomainProof(data.url)
             response.result = 200

--- a/src/libs/omniprotocol/protocol/opcodes.ts
+++ b/src/libs/omniprotocol/protocol/opcodes.ts
@@ -62,6 +62,7 @@ export enum OmniOpcode {
     WEB2_PROXY_REQUEST = 0x52,
     GET_TWEET = 0x53,
     GET_DISCORD_MESSAGE = 0x54,
+    GET_DOMAIN_PROOF = 0x55,
 
     // 0x6X Admin Operations
     ADMIN_RATE_LIMIT_UNBLOCK = 0x60,

--- a/src/libs/omniprotocol/protocol/registry.ts
+++ b/src/libs/omniprotocol/protocol/registry.ts
@@ -402,6 +402,12 @@ const DESCRIPTORS: HandlerDescriptor[] = [
         authRequired: false,
         handler: createHttpFallbackHandler(),
     },
+    {
+        opcode: OmniOpcode.GET_DOMAIN_PROOF,
+        name: "getDomainProof",
+        authRequired: false,
+        handler: createHttpFallbackHandler(),
+    },
 
     // 0x6X Admin
     {


### PR DESCRIPTION
Adds the node side of website-ownership identity.

The node fetches the wallet-signed proof file from the claimed domain over HTTPS (TLS cert binds content to the hostname), verifies the signature against the sender, and enforces that the proof URL's host matches the claimed domain. Verified domains flow through the existing generic web2 GCR write path as web2.domain.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added HTTPS-only domain ownership proof support, including a new protocol opcode and a new request handler to fetch domain proof data.
* **Bug Fixes**
  * Tightened proof URL validation (HTTPS scheme, exact expected proof path, and default HTTPS port only).
  * Improved proof fetching hardening with DNS/IP resolution checks, IP pinning, and safer handling of fetch failures.
* **Security / Compatibility**
  * Updated domain-context signature verification to use the domain-specific verification message format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->