### PR TITLE
fix(audit-sweep): batch E — remaining process.exit in boot + consensus paths

### DIFF
--- a/src/libs/blockchain/routines/beforeFindGenesisHooks.ts
+++ b/src/libs/blockchain/routines/beforeFindGenesisHooks.ts
@@ -67,7 +67,14 @@ export class BeforeFindGenesisHooks {
             )
         }
 
-        process.exit(0)
+        // Audit-sweep batch E: was `process.exit(0)`. The sole
+        // caller (`findGenesisBlock.ts:43`) is currently commented
+        // out, so this exit is a time-bomb — uncommenting the
+        // caller would have killed the node mid-boot the moment
+        // the maintenance hook finished its first run. Returning
+        // cleanly so the caller can resume the normal boot
+        // sequence after the one-shot point-award sweep completes.
+        return
     }
 
     /**

--- a/src/libs/blockchain/routines/findGenesisBlock.ts
+++ b/src/libs/blockchain/routines/findGenesisBlock.ts
@@ -93,7 +93,11 @@ export default async function findGenesisBlock() {
 
     if (!fs.existsSync("data/genesis.json")) {
         log.error("[GENESIS] No genesis block found, exiting")
-        process.exit(1)
+        // Audit-sweep batch E: was `process.exit(1)`. Throw so
+        // `main().catch → gracefulShutdown` handles uniformly.
+        throw new Error(
+            "[GENESIS] data/genesis.json missing — refusing to boot",
+        )
     }
 
     // Loading the genesis block

--- a/src/libs/blockchain/routines/findGenesisBlock.ts
+++ b/src/libs/blockchain/routines/findGenesisBlock.ts
@@ -92,7 +92,7 @@ export default async function findGenesisBlock() {
     }
 
     if (!fs.existsSync("data/genesis.json")) {
-        log.error("[GENESIS] No genesis block found, exiting")
+        log.error("[GENESIS] No genesis block found, aborting boot")
         // Audit-sweep batch E: was `process.exit(1)`. Throw so
         // `main().catch → gracefulShutdown` handles uniformly.
         throw new Error(

--- a/src/libs/consensus/v2/PoRBFT.ts
+++ b/src/libs/consensus/v2/PoRBFT.ts
@@ -324,7 +324,18 @@ export async function consensusRoutine(): Promise<void> {
         console.error(error)
         console.error((error as Error).stack)
         log.error(`[CONSENSUS] ${error}`)
-        process.exit(1)
+        // Audit-sweep batch E: was `process.exit(1)`. Throwing here
+        // lets the surrounding `finally` block run consensus
+        // cleanup (`cleanupConsensusState`, `manager.
+        // endConsensusRoutine`, DTR waiter release) and bubbles up
+        // to the outer `main().catch` → `gracefulShutdown`, matching
+        // the pattern Epic-14 + batch A established for the peer
+        // layer. `process.exit` skipped the cleanup entirely.
+        throw error instanceof Error
+            ? error
+            : new Error(
+                  `[CONSENSUS] fatal consensus error: ${String(error)}`,
+              )
     } finally {
         // INFO: If there was a relayed tx past finalize block step, release
         if (DTRManager.poolSize > 0) {

--- a/src/libs/consensus/v2/PoRBFT.ts
+++ b/src/libs/consensus/v2/PoRBFT.ts
@@ -324,18 +324,34 @@ export async function consensusRoutine(): Promise<void> {
         console.error(error)
         console.error((error as Error).stack)
         log.error(`[CONSENSUS] ${error}`)
-        // Audit-sweep batch E: was `process.exit(1)`. Throwing here
-        // lets the surrounding `finally` block run consensus
-        // cleanup (`cleanupConsensusState`, `manager.
-        // endConsensusRoutine`, DTR waiter release) and bubbles up
-        // to the outer `main().catch` → `gracefulShutdown`, matching
-        // the pattern Epic-14 + batch A established for the peer
-        // layer. `process.exit` skipped the cleanup entirely.
-        throw error instanceof Error
-            ? error
-            : new Error(
-                  `[CONSENSUS] fatal consensus error: ${String(error)}`,
-              )
+        // PR #898 Greptile P1: keep `process.exit(1)` here despite
+        // skipping the `finally` block below.
+        //
+        // `consensusRoutine` is invoked fire-and-forget at every
+        // caller (`mainLoop.ts:129`, `manageConsensusRoutines.ts:77`
+        // with explicit comment "Asynchronous function to avoid
+        // blocking the main thread"). The returned promise is never
+        // awaited, so a `throw` here becomes an unhandled rejection.
+        //
+        // The global `unhandledRejection` handler in `index.ts:94`
+        // intentionally does NOT exit ("let the node try to continue
+        // serving RPC"). That policy is correct for one-off RPC
+        // handler failures, but a fatal consensus error must take
+        // the node down so the supervisor restarts it with clean
+        // state — the alternative is a node serving RPC while its
+        // consensus routine is stuck in an undefined post-error
+        // state, silently accumulating divergence from the rest of
+        // the shard.
+        //
+        // The `finally` cleanup below would not run with
+        // `process.exit` AND would not run with `throw` given the
+        // fire-and-forget callers, so the behavioural delta of
+        // keeping `process.exit` here is zero. Restructuring the
+        // three call sites to await + catch with explicit
+        // gracefulShutdown delegation is the right long-term fix
+        // (tracked separately); for now `process.exit(1)` is the
+        // documented consensus-fatal escape hatch.
+        process.exit(1)
     } finally {
         // INFO: If there was a relayed tx past finalize block step, release
         if (DTRManager.poolSize > 0) {

--- a/src/libs/identity/identity.ts
+++ b/src/libs/identity/identity.ts
@@ -117,7 +117,11 @@ export default class Identity {
 
         if (!bip39.validateMnemonic(mnemonic, wordlist)) {
             log.error("Invalid mnemonic: not a valid BIP39 mnemonic phrase")
-            process.exit(1)
+            // Audit-sweep batch E: was `process.exit(1)`. Throwing
+            // lets `main().catch → gracefulShutdown` run, matches
+            // the pattern Epic-14 + batches A/B established for
+            // boot paths.
+            throw new Error("Invalid mnemonic: not a valid BIP39 mnemonic phrase")
         }
 
         // Use raw mnemonic string to match wallet/SDK derivation


### PR DESCRIPTION
## Plain-English summary

**What your code does**

The node has many places that call `process.exit()` to terminate. Some of these are correct (CLI scripts, worker-thread cleanup, env-gated debug helpers), but four were missed during earlier audit sweeps. Three of them (boot paths) kill the node mid-flight without running the graceful-shutdown path that closes DB connections, flushes L2PS state, drains RPC, and persists metrics. The fourth is a maintenance hook with a time-bomb `process.exit(0)`.

**What was broken**

1. **identity.ts:120** — invalid BIP39 mnemonic at boot. `process.exit(1)` instead of throw. Skips DB/network cleanup.

2. **findGenesisBlock.ts:96** — missing `data/genesis.json` at boot. `process.exit(1)` instead of throw. Same skip.

3. **beforeFindGenesisHooks.ts:70** — `awardDemosFollowPoints` maintenance hook ends with `process.exit(0)`. Sole caller in findGenesisBlock.ts is commented out. **Time bomb**: uncommenting the caller would have killed the node mid-boot the moment the hook finished its first run. Same shape as the `peerGossip` time-bomb batch A defused.

4. **PoRBFT.ts:327** — consensus fatal-error path. Kept as `process.exit(1)` — see "Triaged" below.

**What the fix does**

- Sites 1–3: convert `process.exit` to `throw` / `return`. Boot paths now route through `main().catch → gracefulShutdown` like every other failure mode Epic-14 standardised.
- Site 4 (PoRBFT): kept as `process.exit(1)` with an explicit doc block, because every caller is fire-and-forget (`mainLoop.ts:129`, `manageConsensusRoutines.ts:77`). A `throw` there becomes an unhandled rejection that the global handler in `index.ts:94` intentionally swallows ("Don't exit — let the node try to continue serving RPC"). Letting a fatal consensus error log-and-continue leaves the node in an undefined post-error state — process.exit(1) so the supervisor restarts is strictly safer until the call sites are refactored to await + `.catch(gracefulShutdown)`.

**Why this matters**

Three boot-path exits now go through clean teardown. The one consensus exit that *can't* yet stays a hard exit, with the reason documented inline so the next person doesn't repeat the mistake.

---

## Technical detail

### Triaged as acceptable (left in place)

- **PoRBFT.ts:327** — `process.exit(1)` kept; see plain-English summary above. The right long-term fix is to restructure the three call sites to await + `.catch(gracefulShutdown)`; tracked as a separate refactor.
- `secretaryManager.ts:400,421` — documented chaos-test helpers (batch B added the WARNING blocks).
- `omniprotocol/errors.ts:18`, `BaseAdapter.ts:246` — env-gated via `OMNI_FATAL=true`, opt-in design.
- `TLSNotaryService.ts:378,387,413,498,521,571` — gated by caller-supplied `fatal` boolean param.
- `txValidatorWorker.ts:27,34` — correct `worker_threads` exits (cooperative shutdown / messageerror crash signal to pool parent).
- `index.ts`, `scripts/`, `tests/`, `benchmark.ts`, `client.ts`, `commandLine.ts`, `showPubkey.ts`, `features/activitypub/fediverse.ts` — main bootstrap after gracefulShutdown, or CLI / standalone entry points.
- `features/zk/scripts/*`, `features/fhe/fhe_test.ts` — one-shot scripts / test entry points.

### Verification

- `tsc --noEmit` clean on all changed files.
- Three boot-path fixes preserve exit semantics via throw routed through gracefulShutdown.
- PoRBFT keeps process.exit(1) → supervisor-driven restart on consensus crash, identical to pre-PR behaviour.

## Test plan

- [ ] `bun install`; confirm clean tsc
- [ ] Boot with malformed mnemonic; confirm graceful shutdown
- [ ] Boot without `data/genesis.json`; confirm graceful shutdown
- [ ] Force PoRBFT consensus error in sandbox; confirm node exits with code 1 (supervisor can restart)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed abrupt process exits during startup and consensus errors so failures now flow through normal error handling and allow graceful shutdown/cleanup.
  * Validation failures (e.g., missing genesis config or invalid mnemonic) now raise errors instead of terminating the process, enabling consistent recovery paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->