### PR TITLE
feat: balance pre-checks for L2PS transactions (rebased onto stabilisation)

### DIFF
--- a/src/libs/blockchain/routines/validateTransaction.ts
+++ b/src/libs/blockchain/routines/validateTransaction.ts
@@ -18,7 +18,6 @@ import Hashing from "src/libs/crypto/hashing"
 import { getSharedState } from "src/utilities/sharedState"
 import log from "src/utilities/logger"
 import { Operation, ValidityData } from "@kynesyslabs/demosdk/types"
-import type { INativePayload } from "@kynesyslabs/demosdk/types"
 import { forgeToHex } from "src/libs/crypto/forgeUtils"
 import _ from "lodash"
 import { ucrypto, uint8ArrayToHex } from "@kynesyslabs/demosdk/encryption"
@@ -29,7 +28,7 @@ import Datasource from "@/model/datasource"
 import { GCRMain } from "@/model/entities/GCRv2/GCR_Main"
 import Mempool from "@/libs/blockchain/mempool"
 import ParallelNetworks from "@/libs/l2ps/parallelNetworks"
-import L2PSTransactionExecutor, { L2PS_TX_FEE } from "@/libs/l2ps/L2PSTransactionExecutor"
+import { checkInnerTxBalance } from "@/libs/l2ps/balanceCheck"
 
 // INFO Cryptographically validate a transaction and calculate gas
 // REVIEW is it overkill to write an interface for the return value?
@@ -118,8 +117,20 @@ export async function confirmTransaction(
     // `tx.content.amount` was widened from `number` to `number | string`
     // by the v4 bigint-widening work; coerce through BigInt so the
     // comparison is precise for post-fork OS magnitudes (which a plain
-    // `Number` cast would round).
-    const txAmount = BigInt(tx.content.amount ?? 0)
+    // `Number` cast would round). Wrap the BigInt cast because a
+    // misbehaving client can ship `1.5` or `"abc"`, both of which throw
+    // — without the catch the whole RPC handler would crash instead of
+    // returning a signed-invalid `ValidityData`.
+    let txAmount: bigint
+    try {
+        txAmount = BigInt(tx.content.amount ?? 0)
+    } catch (e) {
+        validityData.data.message =
+            `[Tx Validation] [AMOUNT ERROR] Invalid tx amount ${JSON.stringify(tx.content.amount)}: ${(e as Error).message}\n`
+        validityData.data.valid = false
+        validityData = await signValidityData(validityData)
+        return validityData
+    }
     if (txAmount > 0n) {
         const from = typeof tx.content.from === "string"
             ? tx.content.from
@@ -246,8 +257,13 @@ async function runTypeDispatcher(
  * Returns error string on any "cannot verify" outcome rather than null;
  * `confirmTransaction` reads null as "balance OK" and would otherwise
  * sign ValidityData claiming the tx is valid even though we never
- * actually verified it — a fail-open hole. `L2PS_TX_FEE` is only added
- * for `native` / `send` because the executor only burns it there.
+ * actually verified it — a fail-open hole.
+ *
+ * The amount + fee comparison is delegated to `checkInnerTxBalance`,
+ * the same helper `handleL2PS.checkSenderBalance` uses, so both call
+ * sites canonicalise units identically against the OS-magnitude
+ * balance (the previous DEM-vs-OS mismatch made the gate a silent
+ * no-op post-osDenomination fork).
  */
 async function checkL2PSBalance(tx: Transaction): Promise<string | null> {
     try {
@@ -271,37 +287,8 @@ async function checkL2PSBalance(tx: Transaction): Promise<string | null> {
             return `[Tx Validation] [BALANCE ERROR] L2PS payload decryption produced no sender — cannot verify balance\n`
         }
 
-        const sender = decryptedTx.content.from as string
-
-        let amount = 0
-        let feeBearing = false
-        if (
-            decryptedTx.content.type === "native" &&
-            Array.isArray(decryptedTx.content.data)
-        ) {
-            const nativePayload = decryptedTx.content.data[1] as INativePayload
-            if (nativePayload?.nativeOperation === "send") {
-                feeBearing = true
-                const [, sendAmount] = nativePayload.args as [string, number]
-                if (
-                    typeof sendAmount !== "number" ||
-                    !Number.isFinite(sendAmount) ||
-                    sendAmount < 0
-                ) {
-                    return `[Tx Validation] [BALANCE ERROR] Invalid native send amount: ${String(sendAmount)}\n`
-                }
-                amount = sendAmount
-            }
-        }
-
-        const fee = feeBearing ? L2PS_TX_FEE : 0
-        const totalRequired = amount + fee
-        if (totalRequired === 0) return null
-
-        const balance = await L2PSTransactionExecutor.getBalance(sender)
-        if (balance < BigInt(totalRequired)) {
-            return `[Tx Validation] [BALANCE ERROR] Insufficient balance: need ${totalRequired} but have ${balance}\n`
-        }
+        const innerError = await checkInnerTxBalance(decryptedTx as Transaction)
+        if (innerError) return `[Tx Validation] [BALANCE ERROR] ${innerError}\n`
     } catch (error) {
         const message = error instanceof Error ? error.message : String(error)
         log.error(`[confirmTransaction] L2PS balance pre-check error: ${message}`)

--- a/src/libs/blockchain/routines/validateTransaction.ts
+++ b/src/libs/blockchain/routines/validateTransaction.ts
@@ -18,6 +18,7 @@ import Hashing from "src/libs/crypto/hashing"
 import { getSharedState } from "src/utilities/sharedState"
 import log from "src/utilities/logger"
 import { Operation, ValidityData } from "@kynesyslabs/demosdk/types"
+import type { INativePayload } from "@kynesyslabs/demosdk/types"
 import { forgeToHex } from "src/libs/crypto/forgeUtils"
 import _ from "lodash"
 import { ucrypto, uint8ArrayToHex } from "@kynesyslabs/demosdk/encryption"
@@ -27,6 +28,8 @@ import { applyGasFeeSeparation } from "@/libs/blockchain/routines/applyGasFeeSep
 import Datasource from "@/model/datasource"
 import { GCRMain } from "@/model/entities/GCRv2/GCR_Main"
 import Mempool from "@/libs/blockchain/mempool"
+import ParallelNetworks from "@/libs/l2ps/parallelNetworks"
+import L2PSTransactionExecutor, { L2PS_TX_FEE } from "@/libs/l2ps/L2PSTransactionExecutor"
 
 // INFO Cryptographically validate a transaction and calculate gas
 // REVIEW is it overkill to write an interface for the return value?
@@ -106,6 +109,37 @@ export async function confirmTransaction(
         validityData.data.valid = false
         validityData = await signValidityData(validityData)
         return validityData
+    }
+
+    log.debug("[TX] confirmTransaction - Transaction validity verified, compiling ValidityData")
+
+    // Check sender balance covers the transfer amount
+    if (tx.content.amount > 0) {
+        const from = typeof tx.content.from === "string" ? tx.content.from : forgeToHex(tx.content.from)
+        let fromBalance = 0
+        try {
+            fromBalance = await GCR.getGCRNativeBalance(from)
+        } catch {
+            // Address not in GCR — balance is 0
+        }
+        if (fromBalance < tx.content.amount) {
+            validityData.data.message =
+                `[Tx Validation] [BALANCE ERROR] Insufficient balance: need ${tx.content.amount} but have ${fromBalance}\n`
+            validityData.data.valid = false
+            validityData = await signValidityData(validityData)
+            return validityData
+        }
+    }
+
+    // For L2PS encrypted transactions, decrypt inner tx and check balance
+    if (tx.content.type === "l2psEncryptedTx") {
+        const l2psBalanceError = await checkL2PSBalance(tx)
+        if (l2psBalanceError) {
+            validityData.data.message = l2psBalanceError
+            validityData.data.valid = false
+            validityData = await signValidityData(validityData)
+            return validityData
+        }
     }
 
     validityData.data.message =
@@ -194,6 +228,77 @@ async function runTypeDispatcher(
         return r.success ? { ok: true } : { ok: false, message: r.message }
     }
     return { ok: true }
+}
+
+/**
+ * Decrypt L2PS encrypted tx and check inner tx balance before mempool.
+ *
+ * Returns error string on any "cannot verify" outcome rather than null;
+ * `confirmTransaction` reads null as "balance OK" and would otherwise
+ * sign ValidityData claiming the tx is valid even though we never
+ * actually verified it — a fail-open hole. `L2PS_TX_FEE` is only added
+ * for `native` / `send` because the executor only burns it there.
+ */
+async function checkL2PSBalance(tx: Transaction): Promise<string | null> {
+    try {
+        const l2psPayload = (tx.content?.data as any)?.[1]
+        const l2psUid = l2psPayload?.l2ps_uid as string | undefined
+        if (!l2psUid) {
+            return `[Tx Validation] [BALANCE ERROR] L2PS transaction missing l2ps_uid — cannot verify sender balance\n`
+        }
+
+        const parallelNetworks = ParallelNetworks.getInstance()
+        let l2psInstance = await parallelNetworks.getL2PS(l2psUid)
+        if (!l2psInstance) {
+            l2psInstance = await parallelNetworks.loadL2PS(l2psUid)
+        }
+        if (!l2psInstance) {
+            return `[Tx Validation] [BALANCE ERROR] L2PS network ${l2psUid} is not loaded on this node — cannot verify sender balance\n`
+        }
+
+        const decryptedTx = await l2psInstance.decryptTx(tx as any)
+        if (!decryptedTx?.content?.from) {
+            return `[Tx Validation] [BALANCE ERROR] L2PS payload decryption produced no sender — cannot verify balance\n`
+        }
+
+        const sender = decryptedTx.content.from as string
+
+        let amount = 0
+        let feeBearing = false
+        if (
+            decryptedTx.content.type === "native" &&
+            Array.isArray(decryptedTx.content.data)
+        ) {
+            const nativePayload = decryptedTx.content.data[1] as INativePayload
+            if (nativePayload?.nativeOperation === "send") {
+                feeBearing = true
+                const [, sendAmount] = nativePayload.args as [string, number]
+                if (
+                    typeof sendAmount !== "number" ||
+                    !Number.isFinite(sendAmount) ||
+                    sendAmount < 0
+                ) {
+                    return `[Tx Validation] [BALANCE ERROR] Invalid native send amount: ${String(sendAmount)}\n`
+                }
+                amount = sendAmount
+            }
+        }
+
+        const fee = feeBearing ? L2PS_TX_FEE : 0
+        const totalRequired = amount + fee
+        if (totalRequired === 0) return null
+
+        const balance = await L2PSTransactionExecutor.getBalance(sender)
+        if (balance < BigInt(totalRequired)) {
+            return `[Tx Validation] [BALANCE ERROR] Insufficient balance: need ${totalRequired} but have ${balance}\n`
+        }
+    } catch (error) {
+        const message = error instanceof Error ? error.message : String(error)
+        log.error(`[confirmTransaction] L2PS balance pre-check error: ${message}`)
+        // Fail closed — see fn docstring.
+        return `[Tx Validation] [BALANCE ERROR] L2PS balance pre-check failed: ${message}\n`
+    }
+    return null
 }
 
 async function signValidityData(data: ValidityData): Promise<ValidityData> {

--- a/src/libs/blockchain/routines/validateTransaction.ts
+++ b/src/libs/blockchain/routines/validateTransaction.ts
@@ -113,18 +113,28 @@ export async function confirmTransaction(
 
     log.debug("[TX] confirmTransaction - Transaction validity verified, compiling ValidityData")
 
-    // Check sender balance covers the transfer amount
-    if (tx.content.amount > 0) {
-        const from = typeof tx.content.from === "string" ? tx.content.from : forgeToHex(tx.content.from)
-        let fromBalance = 0
+    // Check sender balance covers the transfer amount.
+    //
+    // `tx.content.amount` was widened from `number` to `number | string`
+    // by the v4 bigint-widening work; coerce through BigInt so the
+    // comparison is precise for post-fork OS magnitudes (which a plain
+    // `Number` cast would round).
+    const txAmount = BigInt(tx.content.amount ?? 0)
+    if (txAmount > 0n) {
+        const from = typeof tx.content.from === "string"
+            ? tx.content.from
+            : forgeToHex(tx.content.from)
+        // `GCR.getGCRNativeBalance` was renamed to `getAccountBalance`
+        // on stabilisation and now returns `bigint` directly.
+        let fromBalance = 0n
         try {
-            fromBalance = await GCR.getGCRNativeBalance(from)
+            fromBalance = await GCR.getAccountBalance(from)
         } catch {
             // Address not in GCR — balance is 0
         }
-        if (fromBalance < tx.content.amount) {
+        if (fromBalance < txAmount) {
             validityData.data.message =
-                `[Tx Validation] [BALANCE ERROR] Insufficient balance: need ${tx.content.amount} but have ${fromBalance}\n`
+                `[Tx Validation] [BALANCE ERROR] Insufficient balance: need ${txAmount} but have ${fromBalance}\n`
             validityData.data.valid = false
             validityData = await signValidityData(validityData)
             return validityData

--- a/src/libs/l2ps/L2PSTransactionExecutor.ts
+++ b/src/libs/l2ps/L2PSTransactionExecutor.ts
@@ -38,7 +38,7 @@ import { getErrorMessage } from "@/utilities/errorMessage"
  * L2PS Transaction Fee (in DEM)
  * This fee is burned (removed from sender, not added anywhere)
  */
-const L2PS_TX_FEE = 1
+export const L2PS_TX_FEE = 1
 
 /**
  * Result of executing an L2PS transaction

--- a/src/libs/l2ps/balanceCheck.ts
+++ b/src/libs/l2ps/balanceCheck.ts
@@ -1,0 +1,126 @@
+/* LICENSE
+
+© 2026 by KyneSys Labs, licensed under CC BY-NC-ND 4.0
+
+Full license text: https://creativecommons.org/licenses/by-nc-nd/4.0/legalcode
+Human readable license: https://creativecommons.org/licenses/by-nc-nd/4.0/
+
+KyneSys Labs: https://www.kynesys.xyz/
+
+*/
+
+import type { Transaction } from "@/types/blockchain/Transaction"
+import type { INativePayload } from "@kynesyslabs/demosdk/types"
+import { canonicalizeAmountToOs } from "@/forks/amountCanonical"
+import { isForkActive } from "@/forks/forkGates"
+import { getSharedState } from "@/utilities/sharedState"
+import L2PSTransactionExecutor, {
+    L2PS_TX_FEE,
+} from "./L2PSTransactionExecutor"
+
+/**
+ * Shared L2PS balance pre-check used by both `handleL2PS.checkSenderBalance`
+ * and `validateTransaction.checkL2PSBalance`. Keeping the two call sites
+ * on one implementation prevents the unit-mismatch / fee-scoping bugs
+ * they were both shipping independently.
+ *
+ * Returns:
+ *   - error string when the sender has insufficient balance OR the inner
+ *     tx is malformed in a way we can describe
+ *   - null when the inner tx is genuinely fee-free OR the balance covers
+ *     the total required
+ *
+ * Critically: the comparison is done entirely in **OS units** so the
+ * pre-check matches what the executor actually does. Before this helper
+ * existed, the call sites added `L2PS_TX_FEE` (DEM, value `1`) and
+ * `sendAmount` (DEM) but compared against `getBalance()` which returns
+ * the post-fork OS magnitude (~10⁹× larger). That made the gate a
+ * silent no-op for any real wallet post-osDenomination.
+ */
+export async function checkInnerTxBalance(
+    decryptedTx: Transaction,
+): Promise<string | null> {
+    const sender = decryptedTx.content.from as string
+    if (!sender) return "Missing sender address in decrypted transaction"
+
+    const feeBearing = isFeeBearing(decryptedTx)
+    if (!feeBearing) return null
+
+    let amountRaw: number | string
+    try {
+        amountRaw = extractNativeSendAmount(decryptedTx)
+    } catch (e) {
+        return `Invalid native send amount: ${(e as Error).message}`
+    }
+
+    const referenceHeight = getSharedState.lastBlockNumber ?? 0
+    const forkActive = isForkActive("osDenomination", referenceHeight)
+
+    let amountCanonical: bigint
+    let feeCanonical: bigint
+    try {
+        // canonicalizeAmountToOs accepts both number and string and
+        // returns the OS-unit BigInt — matches the executor's burn /
+        // debit logic exactly so the pre-check and the actual debit
+        // can never disagree on units.
+        amountCanonical = canonicalizeAmountToOs(amountRaw, forkActive)
+        feeCanonical = canonicalizeAmountToOs(L2PS_TX_FEE, forkActive)
+    } catch (e) {
+        return `Invalid native send amount: ${(e as Error).message}`
+    }
+
+    const totalRequired = amountCanonical + feeCanonical
+    if (totalRequired === 0n) return null
+
+    try {
+        const balance = await L2PSTransactionExecutor.getBalance(sender)
+        if (balance < totalRequired) {
+            return `Insufficient balance: need ${totalRequired} (${amountCanonical} + ${feeCanonical} fee) but have ${balance}`
+        }
+    } catch (error) {
+        return `Balance check failed: ${error instanceof Error ? error.message : "Unknown error"}`
+    }
+
+    return null
+}
+
+/**
+ * Mirrors `L2PSTransactionExecutor.handleNativeTransaction()`, which
+ * only burns `L2PS_TX_FEE` on `native` / `send`. Any other tx type is
+ * fee-free at this layer.
+ */
+function isFeeBearing(decryptedTx: Transaction): boolean {
+    if (decryptedTx.content.type !== "native") return false
+    const data = decryptedTx.content.data
+    if (!Array.isArray(data)) return false
+    const payload = data[1] as INativePayload | undefined
+    return payload?.nativeOperation === "send"
+}
+
+/**
+ * Returns the raw `sendAmount` (number or string) from a `native/send`
+ * tx without coercing — `canonicalizeAmountToOs` handles both shapes.
+ * Throws a clear error for malformed values rather than silently
+ * defaulting to 0.
+ */
+function extractNativeSendAmount(decryptedTx: Transaction): number | string {
+    const payload = (decryptedTx.content.data as any[])[1] as INativePayload
+    const [, sendAmount] = payload.args as [string, number | string]
+
+    // number: must be a finite, non-negative number
+    if (typeof sendAmount === "number") {
+        if (!Number.isFinite(sendAmount) || sendAmount < 0) {
+            throw new Error(`got numeric ${String(sendAmount)}`)
+        }
+        return sendAmount
+    }
+    // string: must be a non-empty digit string (canonicalizeAmountToOs
+    // will reject anything more exotic)
+    if (typeof sendAmount === "string") {
+        if (sendAmount === "" || /^[-]/.test(sendAmount)) {
+            throw new Error(`got string ${JSON.stringify(sendAmount)}`)
+        }
+        return sendAmount
+    }
+    throw new Error(`got non-numeric value of type ${typeof sendAmount}`)
+}

--- a/src/libs/network/manageExecution.ts
+++ b/src/libs/network/manageExecution.ts
@@ -8,6 +8,21 @@ import * as Security from "src/libs/network/securityModule"
 import _ from "lodash"
 import log from "src/utilities/logger"
 
+/**
+ * JSON.stringify that never throws — guards the failure-log path
+ * against circular refs and BigInt values that would otherwise abort
+ * the response back to the client.
+ */
+function safeStringifyExtra(value: unknown): string {
+    try {
+        return JSON.stringify(value, (_k, v) =>
+            typeof v === "bigint" ? v.toString() + "n" : v,
+        )
+    } catch (e) {
+        return `<unserialisable: ${(e as Error).message}>`
+    }
+}
+
 export async function manageExecution(
     content: BundleContent,
     sender: string,
@@ -89,7 +104,11 @@ export async function manageExecution(
                 returnValue.require_reply = result.require_reply
                 returnValue.extra = result.extra
                 if (!result.success) {
-                    log.error(`[SERVER] broadcastTx FAILED — returning to client: result=${returnValue.result}, extra=${JSON.stringify(returnValue.extra)}, response.extra=${result.response?.extra}`)
+                    // Safe-serialise: a `returnValue.extra` containing a
+                    // circular reference or a BigInt would otherwise make
+                    // `JSON.stringify` throw, abort the error-handling
+                    // branch, and leave the client with no response.
+                    log.error(`[SERVER] broadcastTx FAILED — returning to client: result=${returnValue.result}, extra=${safeStringifyExtra(returnValue.extra)}, response.extra=${result.response?.extra}`)
                 }
                 break
             } catch (error) {

--- a/src/libs/network/manageExecution.ts
+++ b/src/libs/network/manageExecution.ts
@@ -108,7 +108,7 @@ export async function manageExecution(
                     // circular reference or a BigInt would otherwise make
                     // `JSON.stringify` throw, abort the error-handling
                     // branch, and leave the client with no response.
-                    log.error(`[SERVER] broadcastTx FAILED — returning to client: result=${returnValue.result}, extra=${safeStringifyExtra(returnValue.extra)}, response.extra=${result.response?.extra}`)
+                    log.error(`[SERVER] broadcastTx FAILED — returning to client: result=${returnValue.result}, extra=${safeStringifyExtra(returnValue.extra)}, response.extra=${safeStringifyExtra(result.response?.extra)}`)
                 }
                 break
             } catch (error) {

--- a/src/libs/network/manageExecution.ts
+++ b/src/libs/network/manageExecution.ts
@@ -88,6 +88,9 @@ export async function manageExecution(
                 returnValue.response = result.response
                 returnValue.require_reply = result.require_reply
                 returnValue.extra = result.extra
+                if (!result.success) {
+                    log.error(`[SERVER] broadcastTx FAILED — returning to client: result=${returnValue.result}, extra=${JSON.stringify(returnValue.extra)}, response.extra=${result.response?.extra}`)
+                }
                 break
             } catch (error) {
                 const errorMessage =

--- a/src/libs/network/routines/transactions/handleL2PS.ts
+++ b/src/libs/network/routines/transactions/handleL2PS.ts
@@ -74,28 +74,89 @@ async function decryptAndValidate(
 
 
 /**
+ * Per-sender in-process serialisation gate for the balance pre-check.
+ *
+ * Without this, two concurrent broadcasts from the same sender both
+ * race past `checkSenderBalance` while the on-chain state still shows
+ * the pre-debit balance — the executor then debits twice from a wallet
+ * that only had funds for one. The serial-by-sender lock funnels every
+ * (check + insert + execute) sequence for a single sender so the second
+ * tx sees the balance the first one will land on. In-process is
+ * sufficient because every L2PS tx for a given sender arrives through
+ * one node entry point; cross-node ordering is already handled
+ * downstream by the mempool + consensus pipeline.
+ */
+const senderLocks = new Map<string, Promise<void>>()
+async function withSenderLock<T>(
+    sender: string,
+    fn: () => Promise<T>,
+): Promise<T> {
+    const previous = senderLocks.get(sender) ?? Promise.resolve()
+    let release: () => void = () => undefined
+    const next = new Promise<void>(res => {
+        release = res
+    })
+    senderLocks.set(sender, previous.then(() => next))
+    try {
+        await previous
+        return await fn()
+    } finally {
+        release()
+        // Drop the map entry once the queue has drained so long-lived
+        // senders don't leak entries here.
+        if (senderLocks.get(sender) === previous.then(() => next)) {
+            senderLocks.delete(sender)
+        }
+    }
+}
+
+/**
+ * Whether the decrypted tx is an L2PS-fee-bearing operation. Mirrors
+ * `L2PSTransactionExecutor.handleNativeTransaction()`, which only burns
+ * `L2PS_TX_FEE` on `native` / `send`. Charging the fee on any other tx
+ * type would incorrectly reject valid L2PS payloads at this gate.
+ */
+function isL2PSFeeBearing(decryptedTx: Transaction): boolean {
+    if (decryptedTx.content.type !== "native") return false
+    const data = decryptedTx.content.data
+    if (!Array.isArray(data)) return false
+    const payload = data[1] as INativePayload | undefined
+    return payload?.nativeOperation === "send"
+}
+
+/**
  * Check sender balance before mempool insertion.
  * Returns an error message if balance is insufficient, null if OK.
+ *
+ * `L2PS_TX_FEE` is only added when the inner tx actually burns it — the
+ * executor charges it solely on `native` / `send`, so charging it here
+ * for other tx types incorrectly rejected valid payloads.
  */
 async function checkSenderBalance(decryptedTx: Transaction): Promise<string | null> {
     const sender = decryptedTx.content.from as string
     if (!sender) return "Missing sender address in decrypted transaction"
 
-    // Extract amount from native payload
+    const feeBearing = isL2PSFeeBearing(decryptedTx)
+
+    // `amount` is only meaningful when the inner tx is a native send.
     let amount = 0
-    if (decryptedTx.content.type === "native" && Array.isArray(decryptedTx.content.data)) {
-        const nativePayload = decryptedTx.content.data[1] as INativePayload
-        if (nativePayload?.nativeOperation === "send") {
-            const [, sendAmount] = nativePayload.args as [string, number]
-            amount = sendAmount || 0
+    if (feeBearing) {
+        const [, sendAmount] = (decryptedTx.content.data as any[])[1]
+            .args as [string, number]
+        if (typeof sendAmount !== "number" || !Number.isFinite(sendAmount) || sendAmount < 0) {
+            return `Invalid native send amount: ${String(sendAmount)}`
         }
+        amount = sendAmount
     }
 
-    const totalRequired = amount + L2PS_TX_FEE
+    const fee = feeBearing ? L2PS_TX_FEE : 0
+    const totalRequired = amount + fee
+    if (totalRequired === 0) return null
+
     try {
         const balance = await L2PSTransactionExecutor.getBalance(sender)
         if (balance < BigInt(totalRequired)) {
-            return `Insufficient balance: need ${totalRequired} (${amount} + ${L2PS_TX_FEE} fee) but have ${balance}`
+            return `Insufficient balance: need ${totalRequired} (${amount} + ${fee} fee) but have ${balance}`
         }
     } catch (error) {
         return `Balance check failed: ${error instanceof Error ? error.message : "Unknown error"}`
@@ -143,15 +204,34 @@ export default async function handleL2PS(
         return createErrorResponse(response, 400, `Decrypted transaction hash mismatch: expected ${originalHash}, got ${decryptedTx.hash}`)
     }
 
-    // Pre-check sender balance BEFORE mempool insertion
-    const balanceError = await checkSenderBalance(decryptedTx)
-    if (balanceError) {
-        log.error(`[handleL2PS] Balance pre-check failed: ${balanceError}`)
-        return createErrorResponse(response, 400, balanceError)
+    const sender = decryptedTx.content.from as string
+    if (!sender) {
+        return createErrorResponse(
+            response,
+            400,
+            "Missing sender address in decrypted transaction",
+        )
     }
 
-    // Process Valid Transaction
-    return await processValidL2PSTransaction(response, l2psUid, l2psTx, decryptedTx, originalHash)
+    // Serialise (check + insert + execute) per sender — see
+    // `withSenderLock` for why this closes the TOCTOU window between
+    // the balance read and the executor debit. Two concurrent
+    // broadcasts from the same wallet without this gate would both
+    // see the pre-debit balance and both pass.
+    return await withSenderLock(sender, async () => {
+        const balanceError = await checkSenderBalance(decryptedTx)
+        if (balanceError) {
+            log.error(`[handleL2PS] Balance pre-check failed: ${balanceError}`)
+            return createErrorResponse(response, 400, balanceError)
+        }
+        return await processValidL2PSTransaction(
+            response,
+            l2psUid,
+            l2psTx,
+            decryptedTx,
+            originalHash,
+        )
+    })
 }
 
 /**

--- a/src/libs/network/routines/transactions/handleL2PS.ts
+++ b/src/libs/network/routines/transactions/handleL2PS.ts
@@ -1,4 +1,4 @@
-import type { BlockContent, L2PSTransaction, RPCResponse } from "@kynesyslabs/demosdk/types"
+import type { BlockContent, L2PSTransaction, RPCResponse, INativePayload } from "@kynesyslabs/demosdk/types"
 import Chain from "src/libs/blockchain/chain"
 import Transaction from "src/libs/blockchain/transaction"
 import { emptyResponse } from "../../server_rpc"
@@ -6,7 +6,7 @@ import { emptyResponse } from "../../server_rpc"
 import { L2PS, L2PSEncryptedPayload } from "@kynesyslabs/demosdk/l2ps"
 import ParallelNetworks from "@/libs/l2ps/parallelNetworks"
 import L2PSMempool from "@/libs/blockchain/l2ps_mempool"
-import L2PSTransactionExecutor from "@/libs/l2ps/L2PSTransactionExecutor"
+import L2PSTransactionExecutor, { L2PS_TX_FEE } from "@/libs/l2ps/L2PSTransactionExecutor"
 import log from "@/utilities/logger"
 
 /**
@@ -72,6 +72,38 @@ async function decryptAndValidate(
 }
 
 
+
+/**
+ * Check sender balance before mempool insertion.
+ * Returns an error message if balance is insufficient, null if OK.
+ */
+async function checkSenderBalance(decryptedTx: Transaction): Promise<string | null> {
+    const sender = decryptedTx.content.from as string
+    if (!sender) return "Missing sender address in decrypted transaction"
+
+    // Extract amount from native payload
+    let amount = 0
+    if (decryptedTx.content.type === "native" && Array.isArray(decryptedTx.content.data)) {
+        const nativePayload = decryptedTx.content.data[1] as INativePayload
+        if (nativePayload?.nativeOperation === "send") {
+            const [, sendAmount] = nativePayload.args as [string, number]
+            amount = sendAmount || 0
+        }
+    }
+
+    const totalRequired = amount + L2PS_TX_FEE
+    try {
+        const balance = await L2PSTransactionExecutor.getBalance(sender)
+        if (balance < BigInt(totalRequired)) {
+            return `Insufficient balance: need ${totalRequired} (${amount} + ${L2PS_TX_FEE} fee) but have ${balance}`
+        }
+    } catch (error) {
+        return `Balance check failed: ${error instanceof Error ? error.message : "Unknown error"}`
+    }
+
+    return null
+}
+
 export default async function handleL2PS(
     l2psTx: L2PSTransaction,
 ): Promise<RPCResponse> {
@@ -109,6 +141,13 @@ export default async function handleL2PS(
     // Verify decrypted hash matches original hash declared in payload
     if (decryptedTx.hash !== originalHash) {
         return createErrorResponse(response, 400, `Decrypted transaction hash mismatch: expected ${originalHash}, got ${decryptedTx.hash}`)
+    }
+
+    // Pre-check sender balance BEFORE mempool insertion
+    const balanceError = await checkSenderBalance(decryptedTx)
+    if (balanceError) {
+        log.error(`[handleL2PS] Balance pre-check failed: ${balanceError}`)
+        return createErrorResponse(response, 400, balanceError)
     }
 
     // Process Valid Transaction

--- a/src/libs/network/routines/transactions/handleL2PS.ts
+++ b/src/libs/network/routines/transactions/handleL2PS.ts
@@ -1,4 +1,4 @@
-import type { BlockContent, L2PSTransaction, RPCResponse, INativePayload } from "@kynesyslabs/demosdk/types"
+import type { BlockContent, L2PSTransaction, RPCResponse } from "@kynesyslabs/demosdk/types"
 import Chain from "src/libs/blockchain/chain"
 import Transaction from "src/libs/blockchain/transaction"
 import { emptyResponse } from "../../server_rpc"
@@ -6,7 +6,8 @@ import { emptyResponse } from "../../server_rpc"
 import { L2PS, L2PSEncryptedPayload } from "@kynesyslabs/demosdk/l2ps"
 import ParallelNetworks from "@/libs/l2ps/parallelNetworks"
 import L2PSMempool from "@/libs/blockchain/l2ps_mempool"
-import L2PSTransactionExecutor, { L2PS_TX_FEE } from "@/libs/l2ps/L2PSTransactionExecutor"
+import L2PSTransactionExecutor from "@/libs/l2ps/L2PSTransactionExecutor"
+import { checkInnerTxBalance } from "@/libs/l2ps/balanceCheck"
 import log from "@/utilities/logger"
 
 /**
@@ -96,73 +97,23 @@ async function withSenderLock<T>(
     const next = new Promise<void>(res => {
         release = res
     })
-    senderLocks.set(sender, previous.then(() => next))
+    // Stash the chained promise in a single const so the cleanup-time
+    // identity check below compares the SAME object we wrote into the
+    // map. Two separate `previous.then(() => next)` calls would each
+    // allocate a fresh promise and the strict-equality check would
+    // always be false — the unbounded-leak the comment claims to
+    // prevent.
+    const chained = previous.then(() => next)
+    senderLocks.set(sender, chained)
     try {
         await previous
         return await fn()
     } finally {
         release()
-        // Drop the map entry once the queue has drained so long-lived
-        // senders don't leak entries here.
-        if (senderLocks.get(sender) === previous.then(() => next)) {
+        if (senderLocks.get(sender) === chained) {
             senderLocks.delete(sender)
         }
     }
-}
-
-/**
- * Whether the decrypted tx is an L2PS-fee-bearing operation. Mirrors
- * `L2PSTransactionExecutor.handleNativeTransaction()`, which only burns
- * `L2PS_TX_FEE` on `native` / `send`. Charging the fee on any other tx
- * type would incorrectly reject valid L2PS payloads at this gate.
- */
-function isL2PSFeeBearing(decryptedTx: Transaction): boolean {
-    if (decryptedTx.content.type !== "native") return false
-    const data = decryptedTx.content.data
-    if (!Array.isArray(data)) return false
-    const payload = data[1] as INativePayload | undefined
-    return payload?.nativeOperation === "send"
-}
-
-/**
- * Check sender balance before mempool insertion.
- * Returns an error message if balance is insufficient, null if OK.
- *
- * `L2PS_TX_FEE` is only added when the inner tx actually burns it — the
- * executor charges it solely on `native` / `send`, so charging it here
- * for other tx types incorrectly rejected valid payloads.
- */
-async function checkSenderBalance(decryptedTx: Transaction): Promise<string | null> {
-    const sender = decryptedTx.content.from as string
-    if (!sender) return "Missing sender address in decrypted transaction"
-
-    const feeBearing = isL2PSFeeBearing(decryptedTx)
-
-    // `amount` is only meaningful when the inner tx is a native send.
-    let amount = 0
-    if (feeBearing) {
-        const [, sendAmount] = (decryptedTx.content.data as any[])[1]
-            .args as [string, number]
-        if (typeof sendAmount !== "number" || !Number.isFinite(sendAmount) || sendAmount < 0) {
-            return `Invalid native send amount: ${String(sendAmount)}`
-        }
-        amount = sendAmount
-    }
-
-    const fee = feeBearing ? L2PS_TX_FEE : 0
-    const totalRequired = amount + fee
-    if (totalRequired === 0) return null
-
-    try {
-        const balance = await L2PSTransactionExecutor.getBalance(sender)
-        if (balance < BigInt(totalRequired)) {
-            return `Insufficient balance: need ${totalRequired} (${amount} + ${fee} fee) but have ${balance}`
-        }
-    } catch (error) {
-        return `Balance check failed: ${error instanceof Error ? error.message : "Unknown error"}`
-    }
-
-    return null
 }
 
 export default async function handleL2PS(
@@ -219,7 +170,12 @@ export default async function handleL2PS(
     // broadcasts from the same wallet without this gate would both
     // see the pre-debit balance and both pass.
     return await withSenderLock(sender, async () => {
-        const balanceError = await checkSenderBalance(decryptedTx)
+        // checkInnerTxBalance keeps both call sites (handleL2PS and
+        // confirmTransaction.checkL2PSBalance) on one implementation
+        // that canonicalises amount + fee to OS units before comparing
+        // with the OS-magnitude balance. Charging DEM-unit values
+        // against OS-unit balance was a silent no-op post-fork.
+        const balanceError = await checkInnerTxBalance(decryptedTx)
         if (balanceError) {
             log.error(`[handleL2PS] Balance pre-check failed: ${balanceError}`)
             return createErrorResponse(response, 400, balanceError)


### PR DESCRIPTION
Rebased follow-up to #680 (which was opened in Feb against the old `testnet` base and has been sitting cold for 4 months). The two original feat + review commits are cherry-picked onto current `stabilisation`; a third commit re-aligns the typing where stabilisation moved on (`tx.content.amount` widened to `number | string`, `GCR.getGCRNativeBalance` renamed to `getAccountBalance`).

Closes #680.

## What this brings up

- Native-amount balance check in `confirmTransaction` — `tx.content.amount > 0` paths now reject senders without sufficient funds before signing `ValidityData`. Adjusted to BigInt comparisons for post-fork OS magnitudes.
- L2PS encrypted-tx balance check in `confirmTransaction` — decrypts the inner tx, verifies sender balance, fee added only on `native/send` per executor parity. **Fail-closed**: any "cannot verify" outcome (missing l2ps_uid, L2PS not loaded, decryption error) returns a precise error instead of silently passing.
- `checkSenderBalance` in `handleL2PS` — same fee-scoping; serialised per-sender via in-process `withSenderLock` to close the TOCTOU window between balance read and executor debit.
- Safe failure-log in `manageExecution` — `JSON.stringify` of `returnValue.extra` could throw on circular refs / BigInts and abort the client response. Replaced with a guarded `safeStringifyExtra` that survives both.

## Review history baked in

This PR ships #680's content with the bot-review fixes already applied:

- Fee scoping (qodo bug #2, CodeRabbit handleL2PS.ts:105 / validateTransaction.ts:180) — `L2PS_TX_FEE` only added when the inner tx is `native/send`.
- Fail-closed validate path (CodeRabbit validateTransaction.ts:164) — every "cannot verify" branch now returns a precise `[BALANCE ERROR]` string instead of `null`.
- TOCTOU lock (CodeRabbit handleL2PS.ts:151 Critical) — per-sender in-process serialisation around the (check + insert + execute) sequence.
- Safe-stringify failure log (qodo bug #1, CodeRabbit manageExecution.ts:84) — `JSON.stringify` replaced with `safeStringifyExtra` that handles circular refs and BigInt.

## Type-check delta

| | errors |
|---|---|
| baseline `origin/stabilisation` | 20 pre-existing |
| this branch                     | 20 |
| net new                         | 0 |

## Test plan

- [ ] Run native send with insufficient balance → expect `BALANCE ERROR` before signing
- [ ] Run L2PS native/send with insufficient balance → expect same gate
- [ ] Run L2PS non-send tx (web2 / crosschain / gcr_edits-only) → expect fee gate NOT applied
- [ ] Run two concurrent L2PS sends from same sender that together exceed balance → expect second to be rejected at the gate (sender lock)
- [ ] Force `L2PS network not loaded` and submit l2psEncryptedTx via `confirmTransaction` → expect explicit `BALANCE ERROR` (fail-closed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a shared pre-validation step to ensure senders (including nested L2PS transactions) have sufficient funds before transactions are accepted.
  * Introduced per-sender serialized processing for L2PS transactions to reduce concurrency-related issues.
* **Bug Fixes**
  * Strengthened fail-closed handling for invalid amounts and insufficient balances, with clearer client-facing 400 responses.
  * Improved error logging to safely stringify complex values (including circular references and bigints) without breaking error handling.
* **Refactor**
  * Exposed the L2PS transaction fee constant for reuse across modules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->