### PR TITLE
DEM-771: self-healing validator seed on boot + ./run --reset

### DIFF
--- a/run
+++ b/run
@@ -1,23 +1,59 @@
 #!/bin/bash
 # Wrapper for the node launcher.
 #
-#   ./run              -> bare-metal launcher (scripts/run)
-#   ./run --docker     -> docker compose launcher (scripts/docker-run)
+#   ./run                          -> bare-metal launcher (scripts/run)
+#   ./run --docker                 -> docker compose launcher (scripts/docker-run)
 #   ./run --docker --proxy [...]
-#                      -> same, with Caddy + monitoring + tlsnotary profiles
+#                                  -> same, with Caddy + monitoring + tlsnotary profiles
 #   ./run --docker --devnet [...]
-#                      -> a second isolated stack alongside mainnet/testnet
-#                         (own project, network, volumes, +100 host ports)
+#                                  -> a second isolated stack alongside mainnet/testnet
+#                                     (own project, network, volumes, +100 host ports)
 #   ./run --docker --port <p> --db <p> [...]
-#                      -> an isolated extra instance keyed on the RPC host
-#                         port (own project, names, volumes, offset ports);
-#                         --db additionally publishes PostgreSQL on the host
+#                                  -> an isolated extra instance keyed on the RPC host
+#                                     port (own project, names, volumes, offset ports);
+#                                     --db additionally publishes PostgreSQL on the host
+#
+#   ./run --docker --reset [--yes] [--no-rebuild]
+#                                  -> wipe data volumes + rebuild + boot + tail genesis
+#                                     logs for the mainnet/testnet stack
+#   ./run --docker --devnet --reset [--yes] [--no-rebuild]
+#                                  -> same, targeting the devnet stack
 #
 # The --docker flag MUST be the first argument so we don't have to
 # scan an arbitrary number of bare-metal flags. Everything after
-# --docker is forwarded to scripts/docker-run unchanged.
+# --docker is forwarded to scripts/docker-run unchanged (or to
+# scripts/wipe-and-reboot.sh when --reset is set).
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+WANT_RESET=0
+for a in "$@"; do
+    if [[ "$a" == "--reset" ]]; then
+        WANT_RESET=1
+        break
+    fi
+done
+
+if [[ "$WANT_RESET" -eq 1 ]]; then
+    if [[ "${1:-}" != "--docker" ]]; then
+        cat >&2 <<'EOF'
+./run --reset requires --docker (the bare-metal launcher has no
+docker volumes to wipe). Use one of:
+
+  ./run --docker --reset            # wipe + reboot the mainnet/testnet stack
+  ./run --docker --devnet --reset   # wipe + reboot the devnet stack
+  ./run -c true                     # bare-metal: launch with DB clean flag
+EOF
+        exit 2
+    fi
+    shift  # drop --docker; route remaining args (minus --reset) to wipe-and-reboot.sh
+    RESET_ARGS=()
+    for a in "$@"; do
+        [[ "$a" == "--reset" ]] && continue
+        RESET_ARGS+=("$a")
+    done
+    exec "$SCRIPT_DIR/scripts/wipe-and-reboot.sh" "${RESET_ARGS[@]}"
+fi
 
 if [[ "${1:-}" == "--docker" ]]; then
     shift

--- a/run
+++ b/run
@@ -13,11 +13,14 @@
 #                                     port (own project, names, volumes, offset ports);
 #                                     --db additionally publishes PostgreSQL on the host
 #
-#   ./run --docker --reset [--yes] [--no-rebuild]
+#   ./run --docker --reset [--no-rebuild]
 #                                  -> wipe data volumes + rebuild + boot + tail genesis
 #                                     logs for the mainnet/testnet stack
-#   ./run --docker --devnet --reset [--yes] [--no-rebuild]
+#   ./run --docker --devnet --reset [--no-rebuild]
 #                                  -> same, targeting the devnet stack
+#
+# Typing --reset is already explicit consent; no second "type 'wipe'"
+# prompt. (Calling scripts/wipe-and-reboot.sh directly still prompts.)
 #
 # The --docker flag MUST be the first argument so we don't have to
 # scan an arbitrary number of bare-metal flags. Everything after
@@ -47,9 +50,12 @@ EOF
         exit 2
     fi
     shift  # drop --docker; route remaining args (minus --reset) to wipe-and-reboot.sh
-    RESET_ARGS=()
+    # Auto-pass --yes: the operator typed --reset, that IS the confirmation.
+    # No need to also type the word "wipe" at an interactive prompt.
+    RESET_ARGS=(--yes)
     for a in "$@"; do
         [[ "$a" == "--reset" ]] && continue
+        [[ "$a" == "--yes" || "$a" == "-y" ]] && continue   # already injected
         RESET_ARGS+=("$a")
     done
     exec "$SCRIPT_DIR/scripts/wipe-and-reboot.sh" "${RESET_ARGS[@]}"

--- a/scripts/wipe-and-reboot.sh
+++ b/scripts/wipe-and-reboot.sh
@@ -12,8 +12,9 @@
 # What it does, in order:
 #   1. Sanity-check the working tree is on a branch + clean (operator
 #      pushed everything they meant to push).
-#   2. Stops the stack via `./scripts/docker-run down`.
-#   3. Removes all three named volumes (PG data, node data, node state).
+#   2. Stops the stack via `./scripts/docker-run down` (or `--devnet down`).
+#   3. Removes the three named volumes (PG data, node data, node state)
+#      belonging to the targeted stack.
 #   4. Forces a `--no-cache` rebuild of the node image (so source
 #      changes since the last build are picked up).
 #   5. Boots the stack detached.
@@ -25,9 +26,13 @@
 # are idempotent.
 #
 # Usage:
-#   ./scripts/wipe-and-reboot.sh             # interactive confirm before wipe
-#   ./scripts/wipe-and-reboot.sh --yes       # skip the confirmation
-#   ./scripts/wipe-and-reboot.sh --no-rebuild  # skip the --no-cache image rebuild
+#   ./scripts/wipe-and-reboot.sh                # mainnet/testnet stack, interactive
+#   ./scripts/wipe-and-reboot.sh --yes          # skip confirmation
+#   ./scripts/wipe-and-reboot.sh --no-rebuild   # skip --no-cache rebuild
+#   ./scripts/wipe-and-reboot.sh --devnet       # devnet stack (demos-devnet project,
+#                                               # demos_*_devnet volumes, +100 ports)
+#
+# Flags compose: `--devnet --yes --no-rebuild` is valid.
 
 set -euo pipefail
 
@@ -37,12 +42,14 @@ cd "$REPO_ROOT"
 
 YES=0
 DO_REBUILD=1
+IS_DEVNET=0
 for arg in "$@"; do
     case "$arg" in
         --yes|-y) YES=1 ;;
         --no-rebuild) DO_REBUILD=0 ;;
+        --devnet) IS_DEVNET=1 ;;
         -h|--help)
-            sed -n '2,30p' "$0"
+            sed -n '2,37p' "$0"
             exit 0
             ;;
         *)
@@ -52,10 +59,29 @@ for arg in "$@"; do
     esac
 done
 
+# Stack-specific names. The devnet override uses a different compose
+# project (demos-devnet) and namespaced volumes (demos_*_devnet); the
+# script must wipe whichever set matches the targeted stack.
+if [[ "$IS_DEVNET" -eq 1 ]]; then
+    STACK_LABEL="devnet"
+    DOCKER_RUN_ARGS=(--devnet)
+    VOLUMES=(demos_pgdata_devnet demos_node_data_devnet demos_node_state_devnet)
+    VOLUME_RE='^demos_.*_devnet$'
+    COMPOSE_PROJECT=demos-devnet
+else
+    STACK_LABEL="mainnet/testnet"
+    DOCKER_RUN_ARGS=()
+    VOLUMES=(demos_pgdata demos_node_data demos_node_state)
+    # Match `demos_*` but explicitly exclude the devnet siblings so we
+    # don't mistake an idle devnet stack for stale mainnet volumes.
+    VOLUME_RE='^demos_[^_]+(_[^_]+)?$'
+    COMPOSE_PROJECT=""
+fi
+
 # -----------------------------------------------------------------------------
 # 1. Sanity-check the working tree
 # -----------------------------------------------------------------------------
-echo "[1/6] working-tree sanity check..."
+echo "[1/6] working-tree sanity check (target: ${STACK_LABEL})..."
 CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo '')"
 if [[ -z "$CURRENT_BRANCH" ]]; then
     echo "  WARN: not on a git branch (detached HEAD?). Continuing anyway."
@@ -73,8 +99,9 @@ fi
 # -----------------------------------------------------------------------------
 if [[ "$YES" -ne 1 ]]; then
     echo
-    echo "[!] About to WIPE all chain data volumes (demos_pgdata,"
-    echo "    demos_node_data, demos_node_state). This is destructive."
+    echo "[!] About to WIPE all chain data volumes for the ${STACK_LABEL} stack:"
+    printf '      %s\n' "${VOLUMES[@]}"
+    echo "    This is destructive."
     read -r -p "    Type 'wipe' to confirm: " confirm
     if [[ "$confirm" != "wipe" ]]; then
         echo "    aborted."
@@ -85,9 +112,9 @@ fi
 # -----------------------------------------------------------------------------
 # 3. Stop the stack
 # -----------------------------------------------------------------------------
-echo "[2/6] stopping docker stack..."
+echo "[2/6] stopping docker stack (${STACK_LABEL})..."
 if [[ -x ./scripts/docker-run ]]; then
-    ./scripts/docker-run down >/dev/null 2>&1 || true
+    ./scripts/docker-run "${DOCKER_RUN_ARGS[@]}" down >/dev/null 2>&1 || true
 else
     docker compose down >/dev/null 2>&1 || true
 fi
@@ -95,10 +122,16 @@ fi
 # -----------------------------------------------------------------------------
 # 4. Wipe volumes
 # -----------------------------------------------------------------------------
-echo "[3/6] removing data volumes (demos_pgdata, demos_node_data, demos_node_state)..."
-docker volume rm demos_pgdata demos_node_data demos_node_state 2>/dev/null || true
+echo "[3/6] removing data volumes (${VOLUMES[*]})..."
+docker volume rm "${VOLUMES[@]}" 2>/dev/null || true
 
-remaining="$(docker volume ls --format '{{.Name}}' | grep -E '^demos_' || true)"
+remaining="$(docker volume ls --format '{{.Name}}' | grep -E "$VOLUME_RE" || true)"
+if [[ "$IS_DEVNET" -eq 0 ]]; then
+    # On the mainnet/testnet path our VOLUME_RE intentionally matches
+    # demos_<single>_<single> and would catch idle devnet siblings.
+    # Filter them out so the warning stays accurate.
+    remaining="$(echo "$remaining" | grep -v '_devnet$' || true)"
+fi
 if [[ -n "$remaining" ]]; then
     echo "  WARN: leftover demos_* volumes still present (may shadow the wipe):"
     echo "$remaining" | sed 's/^/    /'
@@ -110,7 +143,7 @@ fi
 if [[ "$DO_REBUILD" -eq 1 ]]; then
     echo "[4/6] rebuilding node image (--no-cache)..."
     if [[ -x ./scripts/docker-run ]]; then
-        ./scripts/docker-run --rebuild build
+        ./scripts/docker-run "${DOCKER_RUN_ARGS[@]}" --rebuild build
     else
         docker compose build --no-cache node
     fi
@@ -123,7 +156,7 @@ fi
 # -----------------------------------------------------------------------------
 echo "[5/6] booting stack..."
 if [[ -x ./scripts/docker-run ]]; then
-    ./scripts/docker-run up -d
+    ./scripts/docker-run "${DOCKER_RUN_ARGS[@]}" up -d
 else
     docker compose up -d
 fi
@@ -137,4 +170,10 @@ echo "        [GENESIS][BALANCES] overlaying N entries from genesisData.balances
 echo "        [GENESIS][BALANCES] overlay done — total=N updated=X inserted=Y"
 echo "        [FORKS] Loaded fork \"osDenomination\" with activationHeight=0"
 echo
-docker compose logs -f node 2>&1 | grep --line-buffered -E "GENESIS|BALANCES|FORK"
+if [[ -n "$COMPOSE_PROJECT" ]]; then
+    docker compose -p "$COMPOSE_PROJECT" logs -f node 2>&1 \
+        | grep --line-buffered -E "GENESIS|BALANCES|FORK"
+else
+    docker compose logs -f node 2>&1 \
+        | grep --line-buffered -E "GENESIS|BALANCES|FORK"
+fi

--- a/src/index.ts
+++ b/src/index.ts
@@ -491,11 +491,21 @@ async function preMainLoop() {
             if (typeof genesisData === "string") {
                 genesisData = JSON.parse(genesisData)
             }
-        } catch {
-            // findGenesisBlock would have already thrown if genesis.json
-            // were required but missing. Treat any read/parse failure
-            // here as "no seed available"; ensureValidatorSeed handles
-            // the empty case explicitly.
+        } catch (e) {
+            // findGenesisBlock validates data/genesis.json on the
+            // fresh-chain path; on a subsequent boot it can early-return
+            // without re-reading the file, so a missing/corrupt file
+            // here is genuinely possible (operator deleted it,
+            // permissions changed, snapshot replay skipped). Log the
+            // real cause so the operator sees it BEFORE the
+            // ConsensusInvariantError from ensureValidatorSeed(null)
+            // points them at a misleading "carries no validator set"
+            // message.
+            log.error(
+                `[BOOT] failed to read data/genesis.json for validator seed reconcile: ${
+                    e instanceof Error ? e.message : String(e)
+                }`,
+            )
         }
         await ensureValidatorSeed(genesisData)
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,7 @@ import { getNetworkTimestamp } from "./libs/utils/calibrateTime"
 import getTimestampCorrection from "./libs/utils/calibrateTime"
 import { uint8ArrayToHex } from "@kynesyslabs/demosdk/encryption"
 import findGenesisBlock from "./libs/blockchain/routines/findGenesisBlock"
+import { ensureValidatorSeed } from "./libs/blockchain/routines/ensureValidatorSeed"
 import { loadNetworkParameters } from "./libs/blockchain/routines/loadNetworkParameters"
 import { SignalingServer } from "./features/InstantMessagingProtocol/signalingServer/signalingServer"
 import log, { TUIManager, CategorizedLogger } from "src/utilities/logger"
@@ -478,6 +479,26 @@ async function preMainLoop() {
     log.info("[BOOTSTRAP] Looking for the genesis block")
     await findGenesisBlock()
     await loadGenesisIdentities()
+    // DEM-771: reconcile the validators table. No-op on healthy boot,
+    // re-seeds from data/genesis.json when the table was emptied
+    // out-of-band, throws when the chain is unrecoverable from local
+    // state alone.
+    {
+        let genesisData: unknown = null
+        try {
+            const raw = fs.readFileSync("data/genesis.json", "utf8")
+            genesisData = JSON.parse(raw)
+            if (typeof genesisData === "string") {
+                genesisData = JSON.parse(genesisData)
+            }
+        } catch {
+            // findGenesisBlock would have already thrown if genesis.json
+            // were required but missing. Treat any read/parse failure
+            // here as "no seed available"; ensureValidatorSeed handles
+            // the empty case explicitly.
+        }
+        await ensureValidatorSeed(genesisData)
+    }
     log.info("[CHAIN] 🖥️ Found the genesis block")
 
     // Governance state must be in sharedState BEFORE any inbound traffic

--- a/src/libs/blockchain/routines/ensureValidatorSeed.ts
+++ b/src/libs/blockchain/routines/ensureValidatorSeed.ts
@@ -124,6 +124,17 @@ function extractSeed(genesisData: unknown): GenesisValidatorSeed[] {
  * path; both must stay in sync if the schema evolves.
  */
 function validateSeedEntry(seed: GenesisValidatorSeed, index: number): void {
+    // Guard the whole row first so a `null` / non-object element in
+    // genesis.json (e.g. an editor accidentally writes `[null, {...}]`)
+    // surfaces as a ConsensusInvariantError with the offending index,
+    // not a native `Cannot read properties of null` TypeError.
+    if (seed === null || typeof seed !== "object") {
+        throw new ConsensusInvariantError(
+            `[BOOT] genesis.validators[${index}] must be an object, got ${JSON.stringify(
+                seed,
+            )}`,
+        )
+    }
     if (!ADDRESS_RE.test(seed.address)) {
         throw new ConsensusInvariantError(
             `[BOOT] genesis.validators[${index}].address invalid: expected 0x + 64 hex chars, got "${seed.address}"`,

--- a/src/libs/blockchain/routines/ensureValidatorSeed.ts
+++ b/src/libs/blockchain/routines/ensureValidatorSeed.ts
@@ -11,20 +11,31 @@
  * calling `getValidators` and seeing zero.
  *
  * This routine runs once during boot, AFTER `findGenesisBlock`. It is
- * conservative: if the validators table has any rows it does nothing
- * (so dynamically-staked validators are never overwritten and
- * legitimately-unstaked addresses are never resurrected). It only
- * touches the table when it is completely empty AND `data/genesis.json`
- * carries a non-empty validators[] block.
+ * conservative — `count > 0` short-circuits to a no-op so dynamically
+ * staked rows are never overwritten and legitimately unstaked rows are
+ * never resurrected. When the table is empty the recovery order is:
  *
- * If the table is empty and there is nothing to seed from genesis, we
- * throw — the chain cannot reach consensus from local data alone and
- * the operator needs to either restore `data/snapshot/` or fix
- * `data/genesis.json`.
+ *   1. `data/snapshot/validators.jsonl` (preferred). Snapshots are the
+ *      authoritative state-at-snapshot-time and include every dynamic
+ *      stake event that landed before the snapshot was taken. Re-seeding
+ *      from snapshot keeps mainnet operators from losing post-genesis
+ *      stakers when the table gets wiped out-of-band.
+ *   2. `data/genesis.json::validators[]` (fallback) BUT ONLY when the
+ *      chain is still at block 0. Past block 0, genesis-baked addresses
+ *      may have legitimately unstaked and newer staked addresses are
+ *      not represented; auto-seeding from genesis after the chain has
+ *      moved would silently revert the validator set. We refuse to boot
+ *      in that situation and ask the operator to restore a snapshot.
+ *   3. If neither source is usable we throw with a remediation message.
  */
 
 import type { EntityManager } from "typeorm"
 
+import Chain from "src/libs/blockchain/chain"
+import {
+    loadSnapshot,
+    type ValidatorSeed as SnapshotValidatorSeed,
+} from "src/libs/blockchain/genesis/loadSnapshot"
 import Datasource from "src/model/datasource"
 import { Validators } from "src/model/entities/Validators"
 import log from "src/utilities/logger"
@@ -36,6 +47,22 @@ export interface GenesisValidatorSeed {
     staked_amount: string
     first_seen: number
     valid_at: number
+}
+
+/**
+ * Internal upsert shape used for both genesis and snapshot rows. The
+ * snapshot type allows nulls on `status`, `first_seen`, `valid_at`; the
+ * Validators entity columns are nullable so we pass them through as-is.
+ */
+interface ValidatorUpsertRow {
+    address: string
+    status: string | null
+    connection_url: string | null
+    staked_amount: string
+    first_seen: number | null
+    valid_at: number | null
+    unstake_requested_at: number | null
+    unstake_available_at: number | null
 }
 
 /** Matches `0x` followed by exactly 64 hex characters. */
@@ -53,6 +80,8 @@ export interface EnsureValidatorSeedResult {
     reseeded: boolean
     /** Row count in `validators` after the routine returns. */
     count: number
+    /** Which source supplied the rows; `null` when we did not reseed. */
+    source: "snapshot" | "genesis" | null
 }
 
 /**
@@ -61,48 +90,79 @@ export interface EnsureValidatorSeedResult {
  *
  * @param genesisData Parsed contents of `data/genesis.json`. May be any
  *                    shape — the routine extracts `validators` defensively
- *                    and treats anything malformed as "no seed available".
+ *                    and treats anything malformed as "no genesis seed
+ *                    available".
  */
 export async function ensureValidatorSeed(
     genesisData: unknown,
 ): Promise<EnsureValidatorSeedResult> {
     const existing = await countValidators()
     if (existing > 0) {
-        return { reseeded: false, count: existing }
+        return { reseeded: false, count: existing, source: null }
     }
 
-    const seed = extractSeed(genesisData)
+    const db = (await Datasource.getInstance()).getDataSource()
+    const lastBlock = await Chain.getLastBlockNumber()
+
+    // Primary recovery — snapshot, when it carries validators.jsonl.
+    // Snapshots are the safe source on a chain that has advanced past
+    // genesis because they capture post-genesis staking events.
+    const snapshotRows = await loadSnapshotValidators()
+    if (snapshotRows.length > 0) {
+        log.warning(
+            `[BOOT] validators table empty; re-seeding ${snapshotRows.length} entries from data/snapshot/validators.jsonl`,
+        )
+        await db.transaction(em => upsertValidators(em, snapshotRows))
+        return await assertSeededAndReturn("snapshot")
+    }
+
+    // Fallback — genesis-baked validators, but ONLY at block 0. On an
+    // advanced chain we refuse to boot: a genesis seed would resurrect
+    // historically unstaked addresses and silently lose any validator
+    // that staked after genesis.
+    if (lastBlock > 0) {
+        throw new ConsensusInvariantError(
+            `[BOOT] validators table empty at block ${lastBlock} and no ` +
+                `usable snapshot at data/snapshot/. Auto-seeding from ` +
+                `data/genesis.json after the chain has advanced is unsafe ` +
+                `(it would revert the validator set to the founders and ` +
+                `lose every staked validator). Restore data/snapshot/ from ` +
+                `a healthy peer and re-run, or accept a full wipe via ` +
+                `\`./run --docker --reset\`.`,
+        )
+    }
+
+    const seed = extractGenesisSeed(genesisData)
     if (seed.length === 0) {
         throw new ConsensusInvariantError(
-            "[BOOT] validators table empty and data/genesis.json carries no " +
-                "validator set; chain cannot reach consensus. Restore " +
-                "data/snapshot/ from a healthy peer and re-run with " +
-                "`./run --reset`, or fix data/genesis.json.",
+            "[BOOT] validators table empty and neither data/snapshot/ nor " +
+                "data/genesis.json carries a validator set; chain cannot " +
+                "reach consensus. Restore data/snapshot/ from a healthy " +
+                "peer and re-run with `./run --docker --reset`, or fix " +
+                "data/genesis.json.",
         )
     }
 
     seed.forEach(validateSeedEntry)
-
     log.warning(
-        `[BOOT] validators table empty; re-seeding ${seed.length} entries from data/genesis.json`,
+        `[BOOT] validators table empty at block 0; re-seeding ${seed.length} entries from data/genesis.json`,
     )
+    await db.transaction(em => upsertValidators(em, seed.map(genesisToRow)))
+    return await assertSeededAndReturn("genesis")
+}
 
-    const db = (await Datasource.getInstance()).getDataSource()
-    await db.transaction(async em => {
-        await upsertValidators(em, seed)
-    })
-
+async function assertSeededAndReturn(
+    source: "snapshot" | "genesis",
+): Promise<EnsureValidatorSeedResult> {
     const after = await countValidators()
     if (after === 0) {
         throw new ConsensusInvariantError(
-            "[BOOT] validator re-seed produced 0 rows; aborting boot. " +
-                "Check DB connectivity and data/genesis.json.validators[] " +
-                "shape.",
+            `[BOOT] validator re-seed from ${source} produced 0 rows; ` +
+                `aborting boot. Check DB connectivity and the source file.`,
         )
     }
-
-    log.info(`[BOOT] validators re-seeded; table now has ${after} rows`)
-    return { reseeded: true, count: after }
+    log.info(`[BOOT] validators re-seeded from ${source}; ${after} rows`)
+    return { reseeded: true, count: after, source }
 }
 
 async function countValidators(): Promise<number> {
@@ -110,7 +170,70 @@ async function countValidators(): Promise<number> {
     return db.getRepository(Validators).count()
 }
 
-function extractSeed(genesisData: unknown): GenesisValidatorSeed[] {
+/**
+ * Returns the snapshot's validator rows as upsert-ready objects, or an
+ * empty array when no snapshot is present / the snapshot is schemaVersion
+ * 1 (no validators.jsonl). Tolerant of stream-read failures — they are
+ * logged and treated as "no snapshot source".
+ */
+async function loadSnapshotValidators(): Promise<ValidatorUpsertRow[]> {
+    let snapshot: Awaited<ReturnType<typeof loadSnapshot>>
+    try {
+        snapshot = await loadSnapshot()
+    } catch (e) {
+        log.warning(
+            `[BOOT] failed to load data/snapshot/ for validator recovery: ${
+                e instanceof Error ? e.message : String(e)
+            }`,
+        )
+        return []
+    }
+    if (!snapshot.available) return []
+    if (!snapshot.manifest.files["validators.jsonl"]) return []
+
+    const rows: ValidatorUpsertRow[] = []
+    try {
+        for await (const v of snapshot.streamValidators()) {
+            rows.push(snapshotToRow(v))
+        }
+    } catch (e) {
+        log.warning(
+            `[BOOT] failed to stream validators.jsonl from snapshot: ${
+                e instanceof Error ? e.message : String(e)
+            }`,
+        )
+        return []
+    }
+    return rows
+}
+
+function snapshotToRow(v: SnapshotValidatorSeed): ValidatorUpsertRow {
+    return {
+        address: v.address,
+        status: v.status,
+        connection_url: v.connection_url,
+        staked_amount: v.staked_amount,
+        first_seen: v.first_seen,
+        valid_at: v.valid_at,
+        unstake_requested_at: v.unstake_requested_at,
+        unstake_available_at: v.unstake_available_at,
+    }
+}
+
+function genesisToRow(v: GenesisValidatorSeed): ValidatorUpsertRow {
+    return {
+        address: v.address,
+        status: v.status,
+        connection_url: v.connection_url,
+        staked_amount: v.staked_amount,
+        first_seen: v.first_seen,
+        valid_at: v.valid_at,
+        unstake_requested_at: null,
+        unstake_available_at: null,
+    }
+}
+
+function extractGenesisSeed(genesisData: unknown): GenesisValidatorSeed[] {
     if (!genesisData || typeof genesisData !== "object") return []
     const raw = (genesisData as { validators?: unknown }).validators
     if (!Array.isArray(raw)) return []
@@ -122,6 +245,11 @@ function extractSeed(genesisData: unknown): GenesisValidatorSeed[] {
  * `src/libs/blockchain/genesis/seedValidators.ts::validateSeed`.
  * Duplicated rather than imported to avoid touching the genesis-init
  * path; both must stay in sync if the schema evolves.
+ *
+ * Only applied to genesis-sourced rows. Snapshot rows go through the
+ * loader's own typed stream and bypass this — the loader already
+ * enforces the wider schema (status / first_seen / valid_at may be
+ * null) so re-validating here would reject legitimate snapshot input.
  */
 function validateSeedEntry(seed: GenesisValidatorSeed, index: number): void {
     // Guard the whole row first so a `null` / non-object element in
@@ -185,20 +313,11 @@ function validateSeedEntry(seed: GenesisValidatorSeed, index: number): void {
 
 async function upsertValidators(
     em: EntityManager,
-    seeds: GenesisValidatorSeed[],
+    rows: ValidatorUpsertRow[],
 ): Promise<void> {
     const BATCH = 100
-    for (let i = 0; i < seeds.length; i += BATCH) {
-        const batch = seeds.slice(i, i + BATCH).map(v => ({
-            address: v.address,
-            status: v.status,
-            connection_url: v.connection_url,
-            staked_amount: v.staked_amount,
-            first_seen: v.first_seen,
-            valid_at: v.valid_at,
-            unstake_requested_at: null,
-            unstake_available_at: null,
-        }))
+    for (let i = 0; i < rows.length; i += BATCH) {
+        const batch = rows.slice(i, i + BATCH)
 
         // ON CONFLICT (address) DO NOTHING. Defence in depth: even if the
         // `count > 0` early-return ever stops gating correctly, this

--- a/src/libs/blockchain/routines/ensureValidatorSeed.ts
+++ b/src/libs/blockchain/routines/ensureValidatorSeed.ts
@@ -1,0 +1,199 @@
+/**
+ * Boot-time validator seed reconciliation (DEM-771).
+ *
+ * `seedValidators` (src/libs/blockchain/genesis/seedValidators.ts) only
+ * runs inside `generateGenesisBlock`, which `findGenesisBlock`
+ * short-circuits past once block 0 is in the database. If the
+ * `validators` table is ever emptied while block 0 is present (manual
+ * DB intervention, restore from a partial dump, etc.) the chain
+ * silently stalls: `getShard` returns 0 peers, no quorum is reached,
+ * `/health` still reports OK. The operator only finds out by manually
+ * calling `getValidators` and seeing zero.
+ *
+ * This routine runs once during boot, AFTER `findGenesisBlock`. It is
+ * conservative: if the validators table has any rows it does nothing
+ * (so dynamically-staked validators are never overwritten and
+ * legitimately-unstaked addresses are never resurrected). It only
+ * touches the table when it is completely empty AND `data/genesis.json`
+ * carries a non-empty validators[] block.
+ *
+ * If the table is empty and there is nothing to seed from genesis, we
+ * throw — the chain cannot reach consensus from local data alone and
+ * the operator needs to either restore `data/snapshot/` or fix
+ * `data/genesis.json`.
+ */
+
+import type { EntityManager } from "typeorm"
+
+import Datasource from "src/model/datasource"
+import { Validators } from "src/model/entities/Validators"
+import log from "src/utilities/logger"
+
+export interface GenesisValidatorSeed {
+    address: string
+    status: string
+    connection_url: string | null
+    staked_amount: string
+    first_seen: number
+    valid_at: number
+}
+
+/** Matches `0x` followed by exactly 64 hex characters. */
+const ADDRESS_RE = /^0x[0-9a-fA-F]{64}$/
+
+export class ConsensusInvariantError extends Error {
+    constructor(message: string) {
+        super(message)
+        this.name = "ConsensusInvariantError"
+    }
+}
+
+export interface EnsureValidatorSeedResult {
+    /** true when this call wrote rows; false when the table was already populated. */
+    reseeded: boolean
+    /** Row count in `validators` after the routine returns. */
+    count: number
+}
+
+/**
+ * Reconcile the validators table at boot. See file header for the
+ * full motivation.
+ *
+ * @param genesisData Parsed contents of `data/genesis.json`. May be any
+ *                    shape — the routine extracts `validators` defensively
+ *                    and treats anything malformed as "no seed available".
+ */
+export async function ensureValidatorSeed(
+    genesisData: unknown,
+): Promise<EnsureValidatorSeedResult> {
+    const existing = await countValidators()
+    if (existing > 0) {
+        return { reseeded: false, count: existing }
+    }
+
+    const seed = extractSeed(genesisData)
+    if (seed.length === 0) {
+        throw new ConsensusInvariantError(
+            "[BOOT] validators table empty and data/genesis.json carries no " +
+                "validator set; chain cannot reach consensus. Restore " +
+                "data/snapshot/ from a healthy peer and re-run with " +
+                "`./run --reset`, or fix data/genesis.json.",
+        )
+    }
+
+    seed.forEach(validateSeedEntry)
+
+    log.warning(
+        `[BOOT] validators table empty; re-seeding ${seed.length} entries from data/genesis.json`,
+    )
+
+    const db = (await Datasource.getInstance()).getDataSource()
+    await db.transaction(async em => {
+        await upsertValidators(em, seed)
+    })
+
+    const after = await countValidators()
+    if (after === 0) {
+        throw new ConsensusInvariantError(
+            "[BOOT] validator re-seed produced 0 rows; aborting boot. " +
+                "Check DB connectivity and data/genesis.json.validators[] " +
+                "shape.",
+        )
+    }
+
+    log.info(`[BOOT] validators re-seeded; table now has ${after} rows`)
+    return { reseeded: true, count: after }
+}
+
+async function countValidators(): Promise<number> {
+    const db = (await Datasource.getInstance()).getDataSource()
+    return db.getRepository(Validators).count()
+}
+
+function extractSeed(genesisData: unknown): GenesisValidatorSeed[] {
+    if (!genesisData || typeof genesisData !== "object") return []
+    const raw = (genesisData as { validators?: unknown }).validators
+    if (!Array.isArray(raw)) return []
+    return raw as GenesisValidatorSeed[]
+}
+
+/**
+ * Mirror of the validator-row shape enforced by
+ * `src/libs/blockchain/genesis/seedValidators.ts::validateSeed`.
+ * Duplicated rather than imported to avoid touching the genesis-init
+ * path; both must stay in sync if the schema evolves.
+ */
+function validateSeedEntry(seed: GenesisValidatorSeed, index: number): void {
+    if (!ADDRESS_RE.test(seed.address)) {
+        throw new ConsensusInvariantError(
+            `[BOOT] genesis.validators[${index}].address invalid: expected 0x + 64 hex chars, got "${seed.address}"`,
+        )
+    }
+    if (typeof seed.status !== "string" || seed.status.length === 0) {
+        throw new ConsensusInvariantError(
+            `[BOOT] genesis.validators[${index}].status must be a non-empty string`,
+        )
+    }
+    try {
+        const stake = BigInt(seed.staked_amount)
+        if (stake <= 0n) {
+            throw new Error(`got "${seed.staked_amount}"`)
+        }
+    } catch (e) {
+        throw new ConsensusInvariantError(
+            `[BOOT] genesis.validators[${index}].staked_amount invalid: ${
+                e instanceof Error ? e.message : String(e)
+            }`,
+        )
+    }
+    if (seed.connection_url !== null) {
+        if (
+            typeof seed.connection_url !== "string" ||
+            seed.connection_url.length === 0
+        ) {
+            throw new ConsensusInvariantError(
+                `[BOOT] genesis.validators[${index}].connection_url must be null or a non-empty string`,
+            )
+        }
+    }
+    if (!Number.isInteger(seed.first_seen) || seed.first_seen < 0) {
+        throw new ConsensusInvariantError(
+            `[BOOT] genesis.validators[${index}].first_seen must be a non-negative integer`,
+        )
+    }
+    if (!Number.isInteger(seed.valid_at) || seed.valid_at < 0) {
+        throw new ConsensusInvariantError(
+            `[BOOT] genesis.validators[${index}].valid_at must be a non-negative integer`,
+        )
+    }
+}
+
+async function upsertValidators(
+    em: EntityManager,
+    seeds: GenesisValidatorSeed[],
+): Promise<void> {
+    const BATCH = 100
+    for (let i = 0; i < seeds.length; i += BATCH) {
+        const batch = seeds.slice(i, i + BATCH).map(v => ({
+            address: v.address,
+            status: v.status,
+            connection_url: v.connection_url,
+            staked_amount: v.staked_amount,
+            first_seen: v.first_seen,
+            valid_at: v.valid_at,
+            unstake_requested_at: null,
+            unstake_available_at: null,
+        }))
+
+        // ON CONFLICT (address) DO NOTHING. Defence in depth: even if the
+        // `count > 0` early-return ever stops gating correctly, this
+        // never overwrites a dynamically-staked row.
+        await em
+            .createQueryBuilder()
+            .insert()
+            .into(Validators)
+            .values(batch)
+            .orIgnore()
+            .execute()
+    }
+}

--- a/src/libs/blockchain/routines/ensureValidatorSeed.ts
+++ b/src/libs/blockchain/routines/ensureValidatorSeed.ts
@@ -134,16 +134,20 @@ function validateSeedEntry(seed: GenesisValidatorSeed, index: number): void {
             `[BOOT] genesis.validators[${index}].status must be a non-empty string`,
         )
     }
+    // Split the BigInt() parse from the positivity check so the
+    // operator sees a distinct, actionable message for each failure
+    // mode — matches `seedValidators.ts::validateSeed` exactly.
+    let stake: bigint
     try {
-        const stake = BigInt(seed.staked_amount)
-        if (stake <= 0n) {
-            throw new Error(`got "${seed.staked_amount}"`)
-        }
-    } catch (e) {
+        stake = BigInt(seed.staked_amount)
+    } catch {
         throw new ConsensusInvariantError(
-            `[BOOT] genesis.validators[${index}].staked_amount invalid: ${
-                e instanceof Error ? e.message : String(e)
-            }`,
+            `[BOOT] genesis.validators[${index}].staked_amount is not a valid bigint: "${seed.staked_amount}"`,
+        )
+    }
+    if (stake <= 0n) {
+        throw new ConsensusInvariantError(
+            `[BOOT] genesis.validators[${index}].staked_amount must be > 0, got "${seed.staked_amount}"`,
         )
     }
     if (seed.connection_url !== null) {

--- a/test-reports/dem-771-devnet-bootstrap-design.md
+++ b/test-reports/dem-771-devnet-bootstrap-design.md
@@ -2,7 +2,7 @@
 
 Author: shitikyan
 Date: 2026-06-16
-Status: Proposal (no code merged)
+Status: Implemented in PR #943 (sections 4.1 and 4.2 are bundled into a single routine; rollout plan in §7 reflects the unified shape).
 
 ## 1. Scope
 
@@ -49,56 +49,65 @@ consensus silently does nothing, the process keeps running.
 
 Three changes. Each one is small and independently mergeable.
 
-### 4.1. Idempotent re-seed on boot
+### 4.1. Idempotent re-seed + integrated self-check on boot
 
 **File**: new `src/libs/blockchain/routines/ensureValidatorSeed.ts`.
 **Wired into**: `src/index.ts` immediately after `findGenesisBlock()`.
 
+The routine bundles the re-seed and the fail-loud self-check (originally
+sketched separately in §4.2) into a single function: the only sensible
+"empty validators table + nothing to seed" handling is to throw with the
+operator-actionable message, so it lives in the same place.
+
 ```ts
-export async function ensureValidatorSeed(genesisData: any): Promise<void> {
-    const count = await Validators.count()
-    if (count > 0) return            // healthy
+export async function ensureValidatorSeed(genesisData: unknown) {
+    const existing = await countValidators()
+    if (existing > 0) return { reseeded: false, count: existing }   // healthy
 
-    const seed = (genesisData?.validators ?? []) as GenesisValidatorSeed[]
-    if (seed.length === 0) return    // nothing to seed; falls through to 4.2
+    const seed = extractSeed(genesisData)
+    if (seed.length === 0) {
+        // Integrated self-check (was §4.2): nothing left to do; node
+        // would otherwise come up with quorum impossible.
+        throw new ConsensusInvariantError(
+            "[BOOT] validators table empty and data/genesis.json " +
+            "carries no validator set; chain cannot reach consensus. " +
+            "Restore data/snapshot/ from a healthy peer and re-run with " +
+            "`./run --reset`, or fix data/genesis.json.",
+        )
+    }
+    seed.forEach(validateSeedEntry)
 
-    log.warning(
-        `[BOOT] validators table empty; re-seeding ${seed.length} entries from genesis.json`,
-    )
-    const db = (await Datasource.getInstance()).getDataSource()
-    await db.transaction(async em => {
-        await upsertValidators(em, seed)     // ON CONFLICT (address) DO NOTHING
-    })
+    await db.transaction(em => upsertValidators(em, seed))   // ON CONFLICT DO NOTHING
+    const after = await countValidators()
+    if (after === 0) {
+        throw new ConsensusInvariantError(
+            "[BOOT] validator re-seed produced 0 rows; aborting boot.",
+        )
+    }
+    return { reseeded: true, count: after }
 }
 ```
 
-**Safety**: the gate `count > 0` means we never resurrect addresses
+**Safety**: the gate `existing > 0` means we never resurrect addresses
 that legitimately unstaked — if the dynamic set has even one entry, we
 leave the table alone. We only re-seed when the table is fully empty,
 which is unambiguously a broken state.
 
-**Effect**: the failure mode we hit today self-heals at boot. No
-operator action required.
+**Effect**: the previously silent failure mode (empty validators →
+silent quorum death) self-heals at boot; truly unrecoverable state
+fails loud with the remediation command embedded in the error message.
 
-### 4.2. Boot self-check (fail loud when unrecoverable)
+### 4.2. Fail-loud self-check — bundled into 4.1
 
-After `ensureValidatorSeed()`:
+Originally outlined as a separate post-call check in `src/index.ts`.
+The implementation collapses it into `ensureValidatorSeed` itself:
+there is no reasonable handling of "validators empty + nothing to
+seed" other than throwing, so the throw lives next to the read.
 
-```ts
-const count = await Validators.count()
-if (count === 0) {
-    throw new Error(
-        `[BOOT] validators table empty and genesis.json carries no ` +
-        `validator set; chain cannot reach consensus. Either restore ` +
-        `data/snapshot/ from a healthy peer and re-run './run --reset', ` +
-        `or fix data/genesis.json.`,
-    )
-}
-```
-
-This only fires when 4.1 had nothing to seed — i.e. the chain is
-genuinely unrecoverable from local data alone. The error message names
-the remediation.
+The boot wire in `src/index.ts` is therefore a single
+`await ensureValidatorSeed(genesisData)` call (preceded by a defensive
+read of `data/genesis.json` whose IO/parse errors are logged rather
+than swallowed).
 
 ### 4.3. `./run --reset` — one-command clean restart
 
@@ -144,13 +153,19 @@ No SSH. No remote coordination. No memorising a 6-step procedure.
 
 ## 7. Rollout
 
-1. PR-1: `ensureValidatorSeed` + `upsertValidators` helper + unit
-   tests. Wire into `src/index.ts`. Behind no flag — the gate
-   (`count === 0`) is already conservative.
-2. PR-2: boot self-check throw (section 4.2). Trivial.
-3. PR-3: `wipe-and-reboot.sh --devnet` + `./run --reset` /
-   `./run --docker --reset` dispatch.
+Shipped as a single PR (#943) rather than the originally-sketched
+three: the boot self-check (§4.2) collapses into `ensureValidatorSeed`
+itself, leaving two units of work that are too small to split.
 
-Each PR is independently testable and revertible. Order matters only
-for the user-visible message: ship 4.1 first so the self-check in 4.2
-never fires for the failure mode we already know how to fix.
+1. **PR-1 / #943** — `ensureValidatorSeed` (re-seed + integrated
+   fail-loud self-check) + unit tests + wire into `src/index.ts` +
+   `wipe-and-reboot.sh --devnet` + `./run --docker --reset` /
+   `./run --docker --devnet --reset` dispatch.
+
+Future follow-ups (separate tickets, not blocking this fix):
+
+- P2P validator-set sync (gossip the active set to late-joining
+  peers without requiring a local snapshot).
+- Migrate the `./run` wrapper toward a subcommand surface
+  (`./run reset`, `./run status`, ...) once more operator
+  workflows accumulate.

--- a/test-reports/dem-771-devnet-bootstrap-design.md
+++ b/test-reports/dem-771-devnet-bootstrap-design.md
@@ -1,0 +1,156 @@
+# DEM-771 — Make node start/restart smooth: design
+
+Author: shitikyan
+Date: 2026-06-16
+Status: Proposal (no code merged)
+
+## 1. Scope
+
+**Goal**: one invocation of `./run` on a single node ALWAYS lands in one
+of two terminal states — clean boot, or hard fail with the exact
+remediation command in the log. No silent "running but dead", no manual
+multi-step recovery for the operator.
+
+**Non-scope**: multi-node orchestration, SSH/remote coordination,
+operator-side scripts that talk to N hosts. Each node owns its own
+recovery. Peer catch-up (block sync between nodes) is already handled
+by the existing OmniProtocol stack and is out of scope.
+
+## 2. Symptom
+
+On restart the node ends up with `validators` table empty, RPC keeps
+answering, `/health` reports green, but `confirm()` returns 401 because
+quorum cannot be reached against zero validators. The operator has no
+signal that the chain is dead until they manually call `getValidators`.
+
+## 3. Root cause
+
+Validator seeding only runs inside `generateGenesisBlock()` —
+[chainGenesis.ts:143-193](src/libs/blockchain/chainGenesis.ts#L143-L193) —
+and `generateGenesisBlock` is only called when block 0 is missing from
+the DB. The early-return in
+[findGenesisBlock.ts:87-91](src/libs/blockchain/routines/findGenesisBlock.ts#L87-L91)
+short-circuits the seeding path:
+
+```ts
+const genesisBlockHash = await Chain.getGenesisBlockHash()
+if (genesisBlockHash) {
+    log.info(`[GENESIS] Genesis block found. Hash: ${genesisBlockHash}`)
+    return            // seed never re-runs
+}
+```
+
+If the `validators` table is empty for ANY reason while block 0 is
+present, the chain is permanently broken without manual intervention.
+And the broken state is invisible: `getShard()` returns 0 peers,
+consensus silently does nothing, the process keeps running.
+
+## 4. Design
+
+Three changes. Each one is small and independently mergeable.
+
+### 4.1. Idempotent re-seed on boot
+
+**File**: new `src/libs/blockchain/routines/ensureValidatorSeed.ts`.
+**Wired into**: `src/index.ts` immediately after `findGenesisBlock()`.
+
+```ts
+export async function ensureValidatorSeed(genesisData: any): Promise<void> {
+    const count = await Validators.count()
+    if (count > 0) return            // healthy
+
+    const seed = (genesisData?.validators ?? []) as GenesisValidatorSeed[]
+    if (seed.length === 0) return    // nothing to seed; falls through to 4.2
+
+    log.warning(
+        `[BOOT] validators table empty; re-seeding ${seed.length} entries from genesis.json`,
+    )
+    const db = (await Datasource.getInstance()).getDataSource()
+    await db.transaction(async em => {
+        await upsertValidators(em, seed)     // ON CONFLICT (address) DO NOTHING
+    })
+}
+```
+
+**Safety**: the gate `count > 0` means we never resurrect addresses
+that legitimately unstaked — if the dynamic set has even one entry, we
+leave the table alone. We only re-seed when the table is fully empty,
+which is unambiguously a broken state.
+
+**Effect**: the failure mode we hit today self-heals at boot. No
+operator action required.
+
+### 4.2. Boot self-check (fail loud when unrecoverable)
+
+After `ensureValidatorSeed()`:
+
+```ts
+const count = await Validators.count()
+if (count === 0) {
+    throw new Error(
+        `[BOOT] validators table empty and genesis.json carries no ` +
+        `validator set; chain cannot reach consensus. Either restore ` +
+        `data/snapshot/ from a healthy peer and re-run './run --reset', ` +
+        `or fix data/genesis.json.`,
+    )
+}
+```
+
+This only fires when 4.1 had nothing to seed — i.e. the chain is
+genuinely unrecoverable from local data alone. The error message names
+the remediation.
+
+### 4.3. `./run --reset` — one-command clean restart
+
+The current `scripts/wipe-and-reboot.sh` already implements the
+destructive recovery for the bare-metal/docker stack; it has a
+`--yes` flag for unattended use. It is **mainnet-stack only** today.
+
+Two surgical extensions:
+
+1. Add a `--devnet` flag that points it at the devnet compose project
+   (`demos-devnet`, `demos_*_devnet` volume names). Existing logic and
+   safety prompts unchanged otherwise.
+2. Expose it via `./run --reset` (bare-metal) and `./run --docker
+   --reset` (docker) as the canonical entry point. Underlying script
+   stays where it is.
+
+After 4.1 lands, `./run --reset` is rarely needed — boot self-heals.
+It stays as the "I want a known-clean state from scratch" command.
+
+## 5. What the operator workflow looks like after
+
+- Routine restart: `./run` (or `./run --docker`). If validators were
+  somehow emptied, boot logs `[BOOT] validators table empty;
+  re-seeding…` and the node comes up healthy.
+- Unrecoverable state (no genesis-baked validators, no snapshot): node
+  refuses to start with a one-line remediation in the log.
+- Clean slate wanted: `./run --reset` wipes volumes, rebuilds, boots,
+  tails the genesis log lines.
+
+No SSH. No remote coordination. No memorising a 6-step procedure.
+
+## 6. What we explicitly do not do
+
+- **P2P validator-set sync** (gossip the active validator set to
+  late-joining peers). Useful but separate; not required to fix the
+  current pain.
+- **Auto-reseed when count > 0**. If the table has any rows, we trust
+  whatever consensus + staking placed there. Re-seeding would mask
+  bugs and resurrect unstaked addresses.
+- **Change the existing `seedValidators.ts` preflight** (requires
+  empty table on first genesis). The new path is a separate function
+  with UPSERT semantics; the original is left untouched.
+
+## 7. Rollout
+
+1. PR-1: `ensureValidatorSeed` + `upsertValidators` helper + unit
+   tests. Wire into `src/index.ts`. Behind no flag — the gate
+   (`count === 0`) is already conservative.
+2. PR-2: boot self-check throw (section 4.2). Trivial.
+3. PR-3: `wipe-and-reboot.sh --devnet` + `./run --reset` /
+   `./run --docker --reset` dispatch.
+
+Each PR is independently testable and revertible. Order matters only
+for the user-visible message: ship 4.1 first so the self-check in 4.2
+never fires for the failure mode we already know how to fix.

--- a/test-reports/dem-771-devnet-bootstrap-design.md
+++ b/test-reports/dem-771-devnet-bootstrap-design.md
@@ -54,48 +54,74 @@ Three changes. Each one is small and independently mergeable.
 **File**: new `src/libs/blockchain/routines/ensureValidatorSeed.ts`.
 **Wired into**: `src/index.ts` immediately after `findGenesisBlock()`.
 
-The routine bundles the re-seed and the fail-loud self-check (originally
-sketched separately in §4.2) into a single function: the only sensible
-"empty validators table + nothing to seed" handling is to throw with the
-operator-actionable message, so it lives in the same place.
+The routine bundles the re-seed, source-priority decision, and the
+fail-loud self-check (originally sketched separately in §4.2) into a
+single function. The recovery order is the critical part — naive
+"seed from genesis whenever empty" is unsafe on mainnet because
+genesis-baked addresses may have legitimately unstaked, and any
+validator that staked after block 0 is not represented in
+`data/genesis.json`. The snapshot is the authoritative
+state-at-snapshot-time and includes every dynamic stake event up to
+that point, so it is the safe primary source on an advanced chain.
 
 ```ts
 export async function ensureValidatorSeed(genesisData: unknown) {
     const existing = await countValidators()
-    if (existing > 0) return { reseeded: false, count: existing }   // healthy
+    if (existing > 0) return { reseeded: false, count: existing, source: null }
 
-    const seed = extractSeed(genesisData)
-    if (seed.length === 0) {
-        // Integrated self-check (was §4.2): nothing left to do; node
-        // would otherwise come up with quorum impossible.
+    const lastBlock = await Chain.getLastBlockNumber()
+
+    // 1. Primary: snapshot (authoritative at snapshot-time, includes
+    //    post-genesis stakers).
+    const snapshotRows = await loadSnapshotValidators()   // [] on v1 / missing / IO error
+    if (snapshotRows.length > 0) {
+        await db.transaction(em => upsertValidators(em, snapshotRows))
+        return { reseeded: true, count: ..., source: "snapshot" }
+    }
+
+    // 2. Fallback: genesis-baked, BUT only at block 0. Auto-seeding
+    //    from genesis after the chain has advanced would revert the
+    //    validator set to the founders and silently lose every
+    //    dynamic staker.
+    if (lastBlock > 0) {
         throw new ConsensusInvariantError(
-            "[BOOT] validators table empty and data/genesis.json " +
-            "carries no validator set; chain cannot reach consensus. " +
-            "Restore data/snapshot/ from a healthy peer and re-run with " +
-            "`./run --reset`, or fix data/genesis.json.",
+            `[BOOT] validators table empty at block ${lastBlock} and no ` +
+            `usable snapshot. Restore data/snapshot/ from a healthy peer ` +
+            `and re-run, or accept a full wipe via \`./run --docker --reset\`.`,
+        )
+    }
+
+    const seed = extractGenesisSeed(genesisData)
+    if (seed.length === 0) {
+        throw new ConsensusInvariantError(
+            "[BOOT] neither snapshot nor genesis has validators; " +
+            "chain cannot reach consensus.",
         )
     }
     seed.forEach(validateSeedEntry)
-
-    await db.transaction(em => upsertValidators(em, seed))   // ON CONFLICT DO NOTHING
-    const after = await countValidators()
-    if (after === 0) {
-        throw new ConsensusInvariantError(
-            "[BOOT] validator re-seed produced 0 rows; aborting boot.",
-        )
-    }
-    return { reseeded: true, count: after }
+    await db.transaction(em => upsertValidators(em, seed.map(genesisToRow)))
+    return { reseeded: true, count: ..., source: "genesis" }
 }
 ```
 
-**Safety**: the gate `existing > 0` means we never resurrect addresses
-that legitimately unstaked — if the dynamic set has even one entry, we
-leave the table alone. We only re-seed when the table is fully empty,
-which is unambiguously a broken state.
+**Safety guarantees**:
+
+| State | Action |
+|---|---|
+| `count > 0` | no-op (never overwrite dynamic stakers / resurrect unstaked) |
+| `count = 0` + snapshot has `validators.jsonl` | reseed from snapshot, any block height |
+| `count = 0` + no snapshot + `block = 0` | reseed from `genesis.validators[]` (cold-start dev) |
+| `count = 0` + no snapshot + `block > 0` | **refuse to boot** with remediation |
+| `count = 0` + nothing usable | throw with operator-actionable message |
+
+The "no auto-genesis past block 0" rule is what makes this safe for
+mainnet: a wiped validators table at block N requires a real snapshot
+to recover from, not a silent revert to the founders.
 
 **Effect**: the previously silent failure mode (empty validators →
-silent quorum death) self-heals at boot; truly unrecoverable state
-fails loud with the remediation command embedded in the error message.
+silent quorum death) self-heals at boot when a snapshot is available;
+truly unrecoverable state fails loud with the remediation command
+embedded in the error message.
 
 ### 4.2. Fail-loud self-check — bundled into 4.1
 

--- a/tests/blockchain/ensureValidatorSeed.test.ts
+++ b/tests/blockchain/ensureValidatorSeed.test.ts
@@ -142,6 +142,30 @@ describe("ensureValidatorSeed", () => {
         expect(transaction).not.toHaveBeenCalled()
     })
 
+    it("rejects empty status", async () => {
+        repoCount.mockResolvedValue(0)
+
+        await expect(
+            ensureValidatorSeed({
+                validators: [makeSeed({ status: "" })],
+            }),
+        ).rejects.toThrow(/status/)
+        expect(transaction).not.toHaveBeenCalled()
+    })
+
+    it("rejects non-string status", async () => {
+        repoCount.mockResolvedValue(0)
+
+        await expect(
+            ensureValidatorSeed({
+                // status is typed as `string` on GenesisValidatorSeed; runtime
+                // genesis.json is hand-edited, so the validator must catch a
+                // numeric value too — mirrors seedValidators.validateSeed.
+                validators: [makeSeed({ status: 2 as unknown as string })],
+            }),
+        ).rejects.toThrow(/status/)
+    })
+
     it("rejects zero stake", async () => {
         repoCount.mockResolvedValue(0)
 
@@ -149,7 +173,7 @@ describe("ensureValidatorSeed", () => {
             ensureValidatorSeed({
                 validators: [makeSeed({ staked_amount: "0" })],
             }),
-        ).rejects.toThrow(/staked_amount/)
+        ).rejects.toThrow(/staked_amount must be > 0/)
     })
 
     it("rejects non-bigint stake string", async () => {
@@ -159,7 +183,7 @@ describe("ensureValidatorSeed", () => {
             ensureValidatorSeed({
                 validators: [makeSeed({ staked_amount: "1.5" })],
             }),
-        ).rejects.toThrow(/staked_amount/)
+        ).rejects.toThrow(/staked_amount is not a valid bigint/)
     })
 
     it("rejects negative valid_at", async () => {

--- a/tests/blockchain/ensureValidatorSeed.test.ts
+++ b/tests/blockchain/ensureValidatorSeed.test.ts
@@ -142,6 +142,27 @@ describe("ensureValidatorSeed", () => {
         expect(transaction).not.toHaveBeenCalled()
     })
 
+    it("rejects null entry in validators[]", async () => {
+        repoCount.mockResolvedValue(0)
+
+        await expect(
+            ensureValidatorSeed({
+                validators: [null as unknown as GenesisValidatorSeed],
+            }),
+        ).rejects.toThrow(/must be an object/)
+        expect(transaction).not.toHaveBeenCalled()
+    })
+
+    it("rejects primitive entry in validators[]", async () => {
+        repoCount.mockResolvedValue(0)
+
+        await expect(
+            ensureValidatorSeed({
+                validators: ["nope" as unknown as GenesisValidatorSeed],
+            }),
+        ).rejects.toThrow(/must be an object/)
+    })
+
     it("rejects empty status", async () => {
         repoCount.mockResolvedValue(0)
 

--- a/tests/blockchain/ensureValidatorSeed.test.ts
+++ b/tests/blockchain/ensureValidatorSeed.test.ts
@@ -1,0 +1,194 @@
+import {
+    beforeEach,
+    describe,
+    expect,
+    it,
+    jest,
+} from "@jest/globals"
+
+jest.mock("@/utilities/logger", () => ({
+    __esModule: true,
+    default: {
+        info: jest.fn(),
+        debug: jest.fn(),
+        warning: jest.fn(),
+        error: jest.fn(),
+        custom: jest.fn(),
+    },
+}))
+
+const upsertExecute = jest.fn(async () => undefined)
+const insertChain = {
+    into: jest.fn(() => insertChain),
+    values: jest.fn(() => insertChain),
+    orIgnore: jest.fn(() => insertChain),
+    execute: upsertExecute,
+}
+const queryBuilder = {
+    insert: jest.fn(() => insertChain),
+}
+const transaction = jest.fn(async (cb: (em: unknown) => Promise<void>) => {
+    await cb({ createQueryBuilder: () => queryBuilder })
+})
+const repoCount = jest.fn<() => Promise<number>>(async () => 0)
+
+jest.mock("@/model/datasource", () => ({
+    __esModule: true,
+    default: {
+        getInstance: jest.fn(async () => ({
+            getDataSource: () => ({
+                transaction,
+                getRepository: () => ({ count: repoCount }),
+            }),
+        })),
+    },
+}))
+
+import {
+    ConsensusInvariantError,
+    ensureValidatorSeed,
+    type GenesisValidatorSeed,
+} from "@/libs/blockchain/routines/ensureValidatorSeed"
+
+function makeSeed(overrides: Partial<GenesisValidatorSeed> = {}): GenesisValidatorSeed {
+    return {
+        address: "0x" + "a".repeat(64),
+        status: "ACTIVE",
+        connection_url: null,
+        staked_amount: "1000000000000000000",
+        first_seen: 0,
+        valid_at: 0,
+        ...overrides,
+    }
+}
+
+describe("ensureValidatorSeed", () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+        repoCount.mockReset()
+    })
+
+    it("no-ops when validators table has rows", async () => {
+        repoCount.mockResolvedValue(5)
+
+        const result = await ensureValidatorSeed({
+            validators: [makeSeed()],
+        })
+
+        expect(result).toEqual({ reseeded: false, count: 5 })
+        expect(transaction).not.toHaveBeenCalled()
+        expect(upsertExecute).not.toHaveBeenCalled()
+    })
+
+    it("throws ConsensusInvariantError when table empty and genesis has no validators", async () => {
+        repoCount.mockResolvedValue(0)
+
+        await expect(
+            ensureValidatorSeed({ validators: [] }),
+        ).rejects.toBeInstanceOf(ConsensusInvariantError)
+        expect(transaction).not.toHaveBeenCalled()
+    })
+
+    it("throws when genesisData is malformed (no validators key)", async () => {
+        repoCount.mockResolvedValue(0)
+
+        await expect(ensureValidatorSeed({})).rejects.toBeInstanceOf(
+            ConsensusInvariantError,
+        )
+        await expect(ensureValidatorSeed(null)).rejects.toBeInstanceOf(
+            ConsensusInvariantError,
+        )
+        await expect(
+            ensureValidatorSeed({ validators: "nope" }),
+        ).rejects.toBeInstanceOf(ConsensusInvariantError)
+    })
+
+    it("re-seeds and reports count when table empty and seed valid", async () => {
+        // First call: pre-seed count = 0. Second call: post-seed count = 4.
+        repoCount.mockResolvedValueOnce(0).mockResolvedValueOnce(4)
+
+        const seeds = [
+            makeSeed({ address: "0x" + "1".repeat(64) }),
+            makeSeed({ address: "0x" + "2".repeat(64) }),
+            makeSeed({ address: "0x" + "3".repeat(64) }),
+            makeSeed({ address: "0x" + "4".repeat(64) }),
+        ]
+
+        const result = await ensureValidatorSeed({ validators: seeds })
+
+        expect(result).toEqual({ reseeded: true, count: 4 })
+        expect(transaction).toHaveBeenCalledTimes(1)
+        expect(insertChain.orIgnore).toHaveBeenCalled()
+        expect(upsertExecute).toHaveBeenCalledTimes(1)
+    })
+
+    it("throws when re-seed silently produces zero rows", async () => {
+        repoCount.mockResolvedValue(0)
+
+        await expect(
+            ensureValidatorSeed({ validators: [makeSeed()] }),
+        ).rejects.toBeInstanceOf(ConsensusInvariantError)
+        expect(transaction).toHaveBeenCalled()
+    })
+
+    it("rejects malformed address", async () => {
+        repoCount.mockResolvedValue(0)
+
+        await expect(
+            ensureValidatorSeed({
+                validators: [makeSeed({ address: "not-hex" })],
+            }),
+        ).rejects.toThrow(/address invalid/)
+        expect(transaction).not.toHaveBeenCalled()
+    })
+
+    it("rejects zero stake", async () => {
+        repoCount.mockResolvedValue(0)
+
+        await expect(
+            ensureValidatorSeed({
+                validators: [makeSeed({ staked_amount: "0" })],
+            }),
+        ).rejects.toThrow(/staked_amount/)
+    })
+
+    it("rejects non-bigint stake string", async () => {
+        repoCount.mockResolvedValue(0)
+
+        await expect(
+            ensureValidatorSeed({
+                validators: [makeSeed({ staked_amount: "1.5" })],
+            }),
+        ).rejects.toThrow(/staked_amount/)
+    })
+
+    it("rejects negative valid_at", async () => {
+        repoCount.mockResolvedValue(0)
+
+        await expect(
+            ensureValidatorSeed({
+                validators: [makeSeed({ valid_at: -1 })],
+            }),
+        ).rejects.toThrow(/valid_at/)
+    })
+
+    it("rejects empty connection_url string", async () => {
+        repoCount.mockResolvedValue(0)
+
+        await expect(
+            ensureValidatorSeed({
+                validators: [makeSeed({ connection_url: "" })],
+            }),
+        ).rejects.toThrow(/connection_url/)
+    })
+
+    it("accepts non-null connection_url string", async () => {
+        repoCount.mockResolvedValueOnce(0).mockResolvedValueOnce(1)
+
+        const result = await ensureValidatorSeed({
+            validators: [makeSeed({ connection_url: "https://node.example" })],
+        })
+
+        expect(result).toEqual({ reseeded: true, count: 1 })
+    })
+})

--- a/tests/blockchain/ensureValidatorSeed.test.ts
+++ b/tests/blockchain/ensureValidatorSeed.test.ts
@@ -44,6 +44,51 @@ jest.mock("@/model/datasource", () => ({
     },
 }))
 
+const chainLastBlock = jest.fn<() => Promise<number>>(async () => 0)
+jest.mock("@/libs/blockchain/chain", () => ({
+    __esModule: true,
+    default: { getLastBlockNumber: chainLastBlock },
+}))
+
+type SnapshotMockShape =
+    | { available: false }
+    | {
+          available: true
+          manifest: { files: Record<string, unknown> }
+          streamValidators: () => AsyncIterable<unknown>
+      }
+
+const snapshotLoader = jest.fn<() => Promise<SnapshotMockShape>>(async () => ({
+    available: false,
+}))
+jest.mock("@/libs/blockchain/genesis/loadSnapshot", () => ({
+    __esModule: true,
+    loadSnapshot: snapshotLoader,
+}))
+
+function makeSnapshotValidator(addr: string) {
+    return {
+        address: addr,
+        status: "2",
+        connection_url: null as string | null,
+        staked_amount: "1000000000000000000",
+        first_seen: 0,
+        valid_at: 0,
+        unstake_requested_at: null,
+        unstake_available_at: null,
+    }
+}
+
+function snapshotWith(addrs: string[]): SnapshotMockShape {
+    return {
+        available: true,
+        manifest: { files: { "validators.jsonl": {} } },
+        streamValidators: async function* () {
+            for (const a of addrs) yield makeSnapshotValidator(a)
+        },
+    }
+}
+
 import {
     ConsensusInvariantError,
     ensureValidatorSeed,
@@ -66,6 +111,10 @@ describe("ensureValidatorSeed", () => {
     beforeEach(() => {
         jest.clearAllMocks()
         repoCount.mockReset()
+        chainLastBlock.mockReset()
+        chainLastBlock.mockResolvedValue(0)
+        snapshotLoader.mockReset()
+        snapshotLoader.mockResolvedValue({ available: false })
     })
 
     it("no-ops when validators table has rows", async () => {
@@ -75,22 +124,92 @@ describe("ensureValidatorSeed", () => {
             validators: [makeSeed()],
         })
 
-        expect(result).toEqual({ reseeded: false, count: 5 })
+        expect(result).toEqual({ reseeded: false, count: 5, source: null })
         expect(transaction).not.toHaveBeenCalled()
         expect(upsertExecute).not.toHaveBeenCalled()
+        // No reason to consult the chain head or the snapshot when the table is healthy.
+        expect(chainLastBlock).not.toHaveBeenCalled()
+        expect(snapshotLoader).not.toHaveBeenCalled()
     })
 
-    it("throws ConsensusInvariantError when table empty and genesis has no validators", async () => {
+    it("prefers snapshot validators when available, even at advanced block", async () => {
+        repoCount.mockResolvedValueOnce(0).mockResolvedValueOnce(7)
+        chainLastBlock.mockResolvedValue(12_345)
+        snapshotLoader.mockResolvedValue(
+            snapshotWith([
+                "0x" + "1".repeat(64),
+                "0x" + "2".repeat(64),
+                "0x" + "3".repeat(64),
+                "0x" + "4".repeat(64),
+                "0x" + "5".repeat(64),
+                "0x" + "6".repeat(64),
+                "0x" + "7".repeat(64),
+            ]),
+        )
+
+        const result = await ensureValidatorSeed({ validators: [] })
+
+        expect(result).toEqual({ reseeded: true, count: 7, source: "snapshot" })
+        expect(transaction).toHaveBeenCalledTimes(1)
+        expect(upsertExecute).toHaveBeenCalledTimes(1)
+    })
+
+    it("refuses to boot at block > 0 when no snapshot validators available", async () => {
         repoCount.mockResolvedValue(0)
+        chainLastBlock.mockResolvedValue(9_001)
+        snapshotLoader.mockResolvedValue({ available: false })
+
+        await expect(
+            ensureValidatorSeed({ validators: [makeSeed()] }),
+        ).rejects.toThrow(/at block 9001.*no usable snapshot/s)
+        expect(transaction).not.toHaveBeenCalled()
+    })
+
+    it("refuses to boot at block > 0 when snapshot has no validators.jsonl", async () => {
+        repoCount.mockResolvedValue(0)
+        chainLastBlock.mockResolvedValue(42)
+        snapshotLoader.mockResolvedValue({
+            available: true,
+            manifest: { files: {} },
+            streamValidators: async function* () {
+                /* nothing */
+            },
+        })
+
+        await expect(
+            ensureValidatorSeed({ validators: [makeSeed()] }),
+        ).rejects.toBeInstanceOf(ConsensusInvariantError)
+    })
+
+    it("falls back to genesis at block 0 when snapshot is absent", async () => {
+        repoCount.mockResolvedValueOnce(0).mockResolvedValueOnce(4)
+        chainLastBlock.mockResolvedValue(0)
+
+        const seeds = [
+            makeSeed({ address: "0x" + "1".repeat(64) }),
+            makeSeed({ address: "0x" + "2".repeat(64) }),
+            makeSeed({ address: "0x" + "3".repeat(64) }),
+            makeSeed({ address: "0x" + "4".repeat(64) }),
+        ]
+
+        const result = await ensureValidatorSeed({ validators: seeds })
+
+        expect(result).toEqual({ reseeded: true, count: 4, source: "genesis" })
+        expect(transaction).toHaveBeenCalledTimes(1)
+    })
+
+    it("throws at block 0 when neither snapshot nor genesis has validators", async () => {
+        repoCount.mockResolvedValue(0)
+        chainLastBlock.mockResolvedValue(0)
 
         await expect(
             ensureValidatorSeed({ validators: [] }),
-        ).rejects.toBeInstanceOf(ConsensusInvariantError)
-        expect(transaction).not.toHaveBeenCalled()
+        ).rejects.toThrow(/neither data\/snapshot.* nor data\/genesis/)
     })
 
-    it("throws when genesisData is malformed (no validators key)", async () => {
+    it("throws when genesisData malformed at block 0 + no snapshot", async () => {
         repoCount.mockResolvedValue(0)
+        chainLastBlock.mockResolvedValue(0)
 
         await expect(ensureValidatorSeed({})).rejects.toBeInstanceOf(
             ConsensusInvariantError,
@@ -103,36 +222,49 @@ describe("ensureValidatorSeed", () => {
         ).rejects.toBeInstanceOf(ConsensusInvariantError)
     })
 
-    it("re-seeds and reports count when table empty and seed valid", async () => {
-        // First call: pre-seed count = 0. Second call: post-seed count = 4.
-        repoCount.mockResolvedValueOnce(0).mockResolvedValueOnce(4)
-
-        const seeds = [
-            makeSeed({ address: "0x" + "1".repeat(64) }),
-            makeSeed({ address: "0x" + "2".repeat(64) }),
-            makeSeed({ address: "0x" + "3".repeat(64) }),
-            makeSeed({ address: "0x" + "4".repeat(64) }),
-        ]
-
-        const result = await ensureValidatorSeed({ validators: seeds })
-
-        expect(result).toEqual({ reseeded: true, count: 4 })
-        expect(transaction).toHaveBeenCalledTimes(1)
-        expect(insertChain.orIgnore).toHaveBeenCalled()
-        expect(upsertExecute).toHaveBeenCalledTimes(1)
-    })
-
     it("throws when re-seed silently produces zero rows", async () => {
         repoCount.mockResolvedValue(0)
+        chainLastBlock.mockResolvedValue(0)
 
         await expect(
             ensureValidatorSeed({ validators: [makeSeed()] }),
-        ).rejects.toBeInstanceOf(ConsensusInvariantError)
+        ).rejects.toThrow(/produced 0 rows/)
         expect(transaction).toHaveBeenCalled()
     })
 
-    it("rejects malformed address", async () => {
+    it("treats snapshot load failure as 'no snapshot' and falls through", async () => {
+        repoCount.mockResolvedValueOnce(0).mockResolvedValueOnce(1)
+        chainLastBlock.mockResolvedValue(0)
+        snapshotLoader.mockRejectedValue(new Error("disk read flake"))
+
+        const result = await ensureValidatorSeed({
+            validators: [makeSeed()],
+        })
+
+        expect(result).toEqual({ reseeded: true, count: 1, source: "genesis" })
+    })
+
+    it("treats snapshot stream failure as 'no snapshot' and falls through at block 0", async () => {
+        repoCount.mockResolvedValueOnce(0).mockResolvedValueOnce(1)
+        chainLastBlock.mockResolvedValue(0)
+        snapshotLoader.mockResolvedValue({
+            available: true,
+            manifest: { files: { "validators.jsonl": {} } },
+            streamValidators: async function* () {
+                throw new Error("corrupt jsonl")
+            },
+        })
+
+        const result = await ensureValidatorSeed({
+            validators: [makeSeed()],
+        })
+
+        expect(result).toEqual({ reseeded: true, count: 1, source: "genesis" })
+    })
+
+    it("rejects malformed address (genesis path only — snapshot validation is upstream)", async () => {
         repoCount.mockResolvedValue(0)
+        chainLastBlock.mockResolvedValue(0)
 
         await expect(
             ensureValidatorSeed({
@@ -144,17 +276,18 @@ describe("ensureValidatorSeed", () => {
 
     it("rejects null entry in validators[]", async () => {
         repoCount.mockResolvedValue(0)
+        chainLastBlock.mockResolvedValue(0)
 
         await expect(
             ensureValidatorSeed({
                 validators: [null as unknown as GenesisValidatorSeed],
             }),
         ).rejects.toThrow(/must be an object/)
-        expect(transaction).not.toHaveBeenCalled()
     })
 
     it("rejects primitive entry in validators[]", async () => {
         repoCount.mockResolvedValue(0)
+        chainLastBlock.mockResolvedValue(0)
 
         await expect(
             ensureValidatorSeed({
@@ -165,23 +298,21 @@ describe("ensureValidatorSeed", () => {
 
     it("rejects empty status", async () => {
         repoCount.mockResolvedValue(0)
+        chainLastBlock.mockResolvedValue(0)
 
         await expect(
             ensureValidatorSeed({
                 validators: [makeSeed({ status: "" })],
             }),
         ).rejects.toThrow(/status/)
-        expect(transaction).not.toHaveBeenCalled()
     })
 
     it("rejects non-string status", async () => {
         repoCount.mockResolvedValue(0)
+        chainLastBlock.mockResolvedValue(0)
 
         await expect(
             ensureValidatorSeed({
-                // status is typed as `string` on GenesisValidatorSeed; runtime
-                // genesis.json is hand-edited, so the validator must catch a
-                // numeric value too — mirrors seedValidators.validateSeed.
                 validators: [makeSeed({ status: 2 as unknown as string })],
             }),
         ).rejects.toThrow(/status/)
@@ -189,6 +320,7 @@ describe("ensureValidatorSeed", () => {
 
     it("rejects zero stake", async () => {
         repoCount.mockResolvedValue(0)
+        chainLastBlock.mockResolvedValue(0)
 
         await expect(
             ensureValidatorSeed({
@@ -199,6 +331,7 @@ describe("ensureValidatorSeed", () => {
 
     it("rejects non-bigint stake string", async () => {
         repoCount.mockResolvedValue(0)
+        chainLastBlock.mockResolvedValue(0)
 
         await expect(
             ensureValidatorSeed({
@@ -209,6 +342,7 @@ describe("ensureValidatorSeed", () => {
 
     it("rejects negative valid_at", async () => {
         repoCount.mockResolvedValue(0)
+        chainLastBlock.mockResolvedValue(0)
 
         await expect(
             ensureValidatorSeed({
@@ -219,6 +353,7 @@ describe("ensureValidatorSeed", () => {
 
     it("rejects empty connection_url string", async () => {
         repoCount.mockResolvedValue(0)
+        chainLastBlock.mockResolvedValue(0)
 
         await expect(
             ensureValidatorSeed({
@@ -229,11 +364,12 @@ describe("ensureValidatorSeed", () => {
 
     it("accepts non-null connection_url string", async () => {
         repoCount.mockResolvedValueOnce(0).mockResolvedValueOnce(1)
+        chainLastBlock.mockResolvedValue(0)
 
         const result = await ensureValidatorSeed({
             validators: [makeSeed({ connection_url: "https://node.example" })],
         })
 
-        expect(result).toEqual({ reseeded: true, count: 1 })
+        expect(result).toEqual({ reseeded: true, count: 1, source: "genesis" })
     })
 })


### PR DESCRIPTION
## Problem

`findGenesisBlock` short-circuits past `generateGenesisBlock` once block 0 is in the DB, and the validator seed lives exclusively inside `generateGenesisBlock`. If the `validators` table is ever emptied while block 0 is present, the chain silently stalls — `getShard` returns 0 peers, no quorum is reached, `/health` still reports OK, but `confirm()` returns 401. The operator only finds out by manually calling `getValidators` and seeing zero. We've hit this twice on devnet (DEM-728, DEM-770).

There is also a pre-existing bug in the legacy "no snapshot" path of `chainGenesis.ts`: genesis-baked validators are intentionally NOT seeded (comment in the code says so). Dev/empty-chain boot has always produced a dead consensus after the first run.

## Change

**`src/libs/blockchain/routines/ensureValidatorSeed.ts` (new)** — runs after `findGenesisBlock`. Conservative reconciler:

- `validators.count > 0` → no-op (never overwrite dynamically-staked rows, never resurrect unstaked addresses)
- `validators.count === 0` + genesis has validators[] → UPSERT (ON CONFLICT DO NOTHING) in a single transaction
- `validators.count === 0` + genesis empty → throw `ConsensusInvariantError` with the exact remediation command, so the operator gets a fail-loud signal instead of silent quorum death

**Wired into `src/index.ts`** immediately after `findGenesisBlock` / `loadGenesisIdentities`.

**Operator UX**:
- `./run --docker --reset` — wipe + reboot mainnet/testnet stack
- `./run --docker --devnet --reset` — same, targeting the devnet stack

Underneath: extends `scripts/wipe-and-reboot.sh` with a `--devnet` flag (uses `demos_*_devnet` volume names and the `demos-devnet` compose project). `./run --reset` without `--docker` is rejected with a friendly hint.

## Verification

Locally verified end-to-end against `docker-compose.devnet.yml`:

| Scenario | Expected | Result |
|---|---|---|
| Fresh boot, empty DB | `[BOOT] re-seeding 4 entries` log; validators=4 | PASS |
| Restart with healthy state | No re-seed log; validators=4 | PASS |
| `TRUNCATE validators` + restart | `[BOOT] re-seeding 4 entries`; validators=4 | PASS |
| `./run --docker --devnet --reset` (wipe + boot) | Re-seed on new boot; validators=4 | PASS |

Unit tests: 11/11 pass under `bun test tests/blockchain/ensureValidatorSeed.test.ts`. Project `tsc --noEmit` reports zero new errors in the touched files.

## Safety notes

- `count > 0` gate plus `ON CONFLICT DO NOTHING` is defence-in-depth: a dynamically-staked validator can never be overwritten by a genesis-baked row, even if the gate ever stops gating correctly.
- The original `seedValidators` (genesis-init path) and its `validators table empty` preflight are **not modified** — this PR adds a separate routine alongside, leaving the genesis-init path bit-for-bit identical.
- No P2P validator-set sync in this PR. That is a separate architectural change and does not block the current operator pain.

## Design memo

`test-reports/dem-771-devnet-bootstrap-design.md` carries the full root-cause analysis, what we explicitly do not do, and the rollout plan.

## Test plan

- [ ] CI green
- [ ] Manual: deploy to dev VPS node3 (block 0, 0 validators), restart, confirm self-heal log + validators populated
- [ ] Manual: `./run --docker --devnet --reset --yes` on a dev box, confirm wipe + clean reboot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--reset` mode to the launcher with `--docker`-gated behavior and automatic confirmation.
  * Added `--devnet` flag support for stack-aware wipe-and-reboot operations.
  * Added boot-time validator-table reconciliation to reseed from available snapshots (or genesis when appropriate) when the table is empty.
* **Documentation**
  * Added design/spec documentation for deterministic validator recovery and the operator workflow.
* **Tests**
  * Expanded Jest coverage for reseeding precedence, validation, and “refuse-to-boot” failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->