### PR TITLE
fix(mempool): exempt l2psBatch from sequential nonce enforcement

### DIFF
--- a/src/libs/blockchain/mempool.ts
+++ b/src/libs/blockchain/mempool.ts
@@ -21,6 +21,19 @@ import { CHUNK_MEMPOOL_TX, chunkedInsert } from "./chainDb"
 import { isForkActive } from "@/forks"
 import { GCRMain } from "@/model/entities/GCRv2/GCR_Main"
 
+/**
+ * System relay transaction types: node-generated txs that carry no
+ * balance edits and no `nonce` GCR edit, so they never advance the
+ * sender's account.nonce. Their `content.nonce` is monotonic-for-
+ * uniqueness (see L2PSBatchAggregator.getNextBatchNonce), NOT a
+ * sequential per-account counter, so the value-transfer nonce TOCTOU
+ * check in `addTransaction` must not apply to them. Admission is still
+ * gated on the tx originating from THIS node's own identity (see
+ * `addTransaction`) so an arbitrary signer cannot label a tx with one
+ * of these types to bypass the per-account nonce throttle.
+ */
+const SYSTEM_RELAY_TX_TYPES = new Set<string>(["l2psBatch"])
+
 export default class Mempool {
     public static repo: Repository<MempoolTx> = null
     public static async init() {
@@ -202,25 +215,37 @@ export default class Mempool {
         const txNonce = transaction.content?.nonce
         const blockHeight = getSharedState.lastBlockNumber ?? 0
 
-        // System relay transactions carry a node-generated nonce that is
-        // monotonic-for-uniqueness, NOT a sequential per-account counter:
-        // `l2psBatch` is emitted by L2PSBatchAggregator from the node's
-        // own identity, carries amount=0 and no `nonce` GCR edit, so it
-        // never advances the sender's account.nonce. The sequential
-        // `account.nonce + 1 + pendingCount` check below is designed for
-        // value-transfer txs and would reject every batch (the
-        // timestamp-based nonce never equals account.nonce+1), trapping
-        // the aggregator in a permanent retry loop. Replay safety for
-        // these txs comes from the in-mempool hash dedup, not the nonce.
-        const SYSTEM_RELAY_TX_TYPES = new Set(["l2psBatch"])
-        const isSystemRelayTx =
+        // System relay transactions (SYSTEM_RELAY_TX_TYPES, e.g.
+        // `l2psBatch`) carry a node-generated monotonic-for-uniqueness
+        // nonce, not a sequential per-account counter, and never advance
+        // the sender's account.nonce (no `nonce` GCR edit). The
+        // sequential `account.nonce + 1 + pendingCount` check below is
+        // built for value-transfer txs and would reject every batch (the
+        // timestamp nonce never equals account.nonce+1), trapping the
+        // L2PSBatchAggregator in a permanent retry loop.
+        //
+        // The exemption is gated on the tx originating from THIS node's
+        // OWN identity. The aggregator only ever submits batch txs from
+        // the node's own keypair, via a direct local addTransaction call;
+        // legitimate batch txs reach other nodes inside a block, not via
+        // mempool admission. Gating on own-identity means an arbitrary
+        // signer (or a remote peer) cannot self-label a tx `l2psBatch`
+        // to skip the per-account nonce throttle and flood the mempool —
+        // their `from` won't match this node's identity and they stay on
+        // the enforced path. Replay safety for the node's own batches
+        // comes from the in-mempool hash dedup above, not the nonce.
+        const ownIdentityHex =
+            getSharedState.publicKeyHex?.toLowerCase() ?? null
+        const isOwnSystemRelayTx =
             typeof transaction.content?.type === "string" &&
-            SYSTEM_RELAY_TX_TYPES.has(transaction.content.type)
+            SYSTEM_RELAY_TX_TYPES.has(transaction.content.type) &&
+            ownIdentityHex !== null &&
+            senderFrom === ownIdentityHex
 
         if (
             senderFrom &&
             typeof txNonce === "number" &&
-            !isSystemRelayTx &&
+            !isOwnSystemRelayTx &&
             isForkActive("nonceEnforcement", blockHeight)
         ) {
             try {

--- a/src/libs/blockchain/mempool.ts
+++ b/src/libs/blockchain/mempool.ts
@@ -191,8 +191,9 @@ export default class Mempool {
         // re-check fails, return error without inserting.
         //
         // Skip when not native, when no sender (genesis path), when
-        // fork inactive, or when the tx doesn't carry a nonce —
-        // those paths preserve the legacy behaviour bit-identically.
+        // fork inactive, when the tx doesn't carry a nonce, or when the
+        // tx is a system relay type (see below) — those paths preserve
+        // the legacy behaviour bit-identically.
         const senderFromRaw = transaction.content?.from
         const senderFrom =
             typeof senderFromRaw === "string"
@@ -201,9 +202,25 @@ export default class Mempool {
         const txNonce = transaction.content?.nonce
         const blockHeight = getSharedState.lastBlockNumber ?? 0
 
+        // System relay transactions carry a node-generated nonce that is
+        // monotonic-for-uniqueness, NOT a sequential per-account counter:
+        // `l2psBatch` is emitted by L2PSBatchAggregator from the node's
+        // own identity, carries amount=0 and no `nonce` GCR edit, so it
+        // never advances the sender's account.nonce. The sequential
+        // `account.nonce + 1 + pendingCount` check below is designed for
+        // value-transfer txs and would reject every batch (the
+        // timestamp-based nonce never equals account.nonce+1), trapping
+        // the aggregator in a permanent retry loop. Replay safety for
+        // these txs comes from the in-mempool hash dedup, not the nonce.
+        const SYSTEM_RELAY_TX_TYPES = new Set(["l2psBatch"])
+        const isSystemRelayTx =
+            typeof transaction.content?.type === "string" &&
+            SYSTEM_RELAY_TX_TYPES.has(transaction.content.type)
+
         if (
             senderFrom &&
             typeof txNonce === "number" &&
+            !isSystemRelayTx &&
             isForkActive("nonceEnforcement", blockHeight)
         ) {
             try {


### PR DESCRIPTION
## Problem

L2PS transactions never reach L1. `L2PSBatchAggregator` submits a consolidated `l2psBatch` tx from the node's own ed25519 identity every aggregation tick, but `Mempool.addTransaction` rejects every one with:

```
Nonce TOCTOU recheck failed: tx.content.nonce=1781723273110000, expected=1
```

The aggregator then retries forever (observed looping every ~10s on dev devnet).

## Root cause

Two facts collide:

1. `getNextBatchNonce()` returns `Date.now() * 1000` — a monotonic-**for-uniqueness** nonce, not a sequential per-account counter. The `l2psBatch` tx carries `amount: 0` and no `nonce` GCR edit, so it never advances the node's `account.nonce`.

2. The `nonceEnforcement` fork added a strict `expected = account.nonce + 1 + pendingCount` TOCTOU recheck in `Mempool.addTransaction` for any sender with a numeric nonce. That's correct for value-transfer txs, but the batch tx's timestamp nonce (`~1.78e15`) can never equal `account.nonce + 1` (`1`), so it's rejected every time.

The non-hex `l2ps:consensus` system sender is already implicitly exempt (no gcr_main account); the aggregator's batch tx uses the node's real hex identity and so gets caught by the account-based check.

## Fix

Exempt system relay tx types (currently just `l2psBatch`) from the sequential nonce TOCTOU check. These txs:

- carry no balance edits (no double-spend surface),
- never advance `account.nonce` (no nonce GCR edit),
- are already replay-protected by the in-mempool **hash dedup** (the `Transaction already in mempool` check inside the same lock).

So sequential-nonce semantics simply don't apply to them. One-line guard added to the existing condition, plus a named `SYSTEM_RELAY_TX_TYPES` set and an explanatory comment. Value-transfer path is untouched.

## Verification

- `tsc --noEmit` — no new errors in `mempool.ts`.
- End-to-end on dev devnet (pending this merge): send an L2PS tx via `bun scripts/send-l2-batch.ts --uid <subnet>`, confirm the batch aggregator log shows the batch entering the L1 mempool instead of the `Nonce TOCTOU recheck failed` loop, and the inner tx reaches `batched` status.

There is no existing mempool unit-test harness (the function needs a live Postgres txn + advisory locks); the real proof is the devnet repro above.

## Scope

One surgical change to the nonce-enforcement guard. No change to value-transfer nonce handling, no consensus-side change (`GCRNonceRoutines` only acts on `type: "nonce"` edits, which `l2psBatch` does not carry).