### PR TITLE
Add git commit hash to /version endpoint response

### DIFF
--- a/src/libs/network/openapi-spec.json
+++ b/src/libs/network/openapi-spec.json
@@ -126,6 +126,7 @@
                             "application/json": {
                                 "schema": {
                                     "type": "object",
+                                    "required": ["version"],
                                     "properties": {
                                         "version": {
                                             "type": "string"

--- a/src/libs/network/openapi-spec.json
+++ b/src/libs/network/openapi-spec.json
@@ -123,9 +123,19 @@
                     "200": {
                         "description": "Successful response",
                         "content": {
-                            "text/plain": {
+                            "application/json": {
                                 "schema": {
-                                    "type": "string"
+                                    "type": "object",
+                                    "properties": {
+                                        "version": {
+                                            "type": "string"
+                                        },
+                                        "commit": {
+                                            "type": "string",
+                                            "nullable": true,
+                                            "description": "Git commit hash of the running binary, or null if unresolvable."
+                                        }
+                                    }
                                 }
                             }
                         }

--- a/src/libs/network/server_rpc.ts
+++ b/src/libs/network/server_rpc.ts
@@ -234,7 +234,12 @@ export async function serverRpcBun() {
         })
     })
 
-    server.get("/version", () => jsonResponse(getSharedState.version))
+    server.get("/version", () =>
+        jsonResponse({
+            version: getSharedState.version,
+            commit: getSharedState.commitHash,
+        }),
+    )
 
     server.get("/publickey", () => jsonResponse(getSharedState.publicKeyHex))
 

--- a/src/utilities/constants.ts
+++ b/src/utilities/constants.ts
@@ -6,7 +6,7 @@
  */
 
 // --- Application metadata ---
-export const APP_VERSION = "0.9.8"
+export const APP_VERSION = "0.9.9 RC"
 export const APP_VERSION_NAME = "Oxlong Michael"
 export const DEFAULT_SIGNING_ALGORITHM = "ed25519" as const
 

--- a/src/utilities/sharedState.ts
+++ b/src/utilities/sharedState.ts
@@ -46,6 +46,7 @@ import {
     buildInitialSubsystemRegistry,
     type SubsystemInfo,
 } from "./subsystemRegistry"
+import { NODE_VERSION } from "./nodeVersion"
 
 dotenv.config()
 
@@ -80,6 +81,14 @@ export default class SharedState {
     prod = Config.getInstance().core.prod
     version = APP_VERSION
     version_name = APP_VERSION_NAME
+
+    // Git commit hash of the running binary, resolved once at boot from
+    // `.git/HEAD` (or the GIT_COMMIT env override). Exposed over /version
+    // so the exact running revision can be confirmed — and any future
+    // tamper-detection can pin against the build it expects. `null` when
+    // the commit can't be resolved (e.g. a stripped Docker image without
+    // .git/ and no GIT_COMMIT build arg).
+    commitHash = NODE_VERSION.commit
     signingAlgorithm = DEFAULT_SIGNING_ALGORITHM as SigningAlgorithm
 
     // Node start time in milliseconds since epoch — set when this singleton


### PR DESCRIPTION
## Summary
Enhanced the `/version` endpoint to return structured JSON with both version and git commit information, improving deployment tracking and verification capabilities.

## Key Changes
- **API Response Format**: Changed `/version` endpoint response from plain text string to JSON object containing `version` and `commit` fields
- **Commit Hash Tracking**: Added `commitHash` property to `SharedState` that captures the git commit hash of the running binary at boot time
- **New Module**: Introduced `nodeVersion` utility module to resolve git commit information from `.git/HEAD` or `GIT_COMMIT` environment variable
- **Version Bump**: Updated `APP_VERSION` from "0.9.8" to "0.9.9 RC"

## Implementation Details
- The commit hash is resolved once at application startup and stored in `SharedState.commitHash`
- The commit value can be `null` if unresolvable (e.g., stripped Docker images without `.git/` directory and no `GIT_COMMIT` build argument)
- The `/version` endpoint now returns a JSON object with the structure:
  ```json
  {
    "version": "0.9.9 RC",
    "commit": "<git-hash-or-null>"
  }
  ```
- This enables deployment verification and tamper detection by confirming the exact running revision

https://claude.ai/code/session_015ZdtuWdzFZWLTj6URHsG9h

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Version endpoint now returns commit information alongside the version number.

* **Chores**
  * Updated application version to 0.9.9 RC.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->