### PR TITLE
fix(consensus): resolve cross-RPC tx freeze — deterministic ordering + derive-at-apply fees + min-shard floor [epic #21]

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "demos-node-software",
@@ -11,7 +10,7 @@
         "@fastify/cors": "^9.0.1",
         "@fastify/swagger": "^8.15.0",
         "@fastify/swagger-ui": "^4.1.0",
-        "@kynesyslabs/demosdk": "4.0.9",
+        "@kynesyslabs/demosdk": "4.0.12",
         "@metaplex-foundation/js": "^0.20.1",
         "@modelcontextprotocol/sdk": "^1.13.3",
         "@noble/ed25519": "^3.0.0",
@@ -104,6 +103,7 @@
     },
   },
   "overrides": {
+    "@kynesyslabs/demosdk": "4.0.12",
     "fast-xml-parser": ">=5.3.4",
     "socket.io-parser": ">=4.2.6",
     "valibot": ">=1.2.0",
@@ -561,7 +561,7 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.29", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ=="],
 
-    "@kynesyslabs/demosdk": ["@kynesyslabs/demosdk@4.0.9", "", { "dependencies": { "@aptos-labs/ts-sdk": "^1.39.0", "@bitcoinerlab/secp256k1": "^1.2.0", "@coral-xyz/anchor": "^0.32.1", "@cosmjs/proto-signing": "^0.32.4", "@cosmjs/stargate": "^0.32.4", "@cryptkeeperzk/snarkjs": "^0.7.2", "@metaplex-foundation/js": "^0.20.1", "@multiversx/sdk-core": "^13.17.2", "@multiversx/sdk-extension-provider": "^3.0.0", "@multiversx/sdk-network-providers": "^2.9.3", "@multiversx/sdk-wallet": "^4.6.0", "@noble/curves": "1.9.4", "@noble/hashes": "1.8.0", "@noble/post-quantum": "^0.4.1", "@project-serum/anchor": "^0.26.0", "@roamhq/wrtc": "^0.8.0", "@scure/bip39": "^2.2.0", "@simplewebauthn/browser": "^11.0.0", "@simplewebauthn/server": "^11.0.0", "@solana/buffer-layout": "^4.0.1", "@solana/web3.js": "1.98.0", "@ton/core": "^0.62.1", "@ton/crypto": "^3.3.0", "@ton/ton": "^16.2.4", "@types/simple-peer": "^9.11.9", "axios": "^1.16.1", "big-integer": "^1.6.52", "bignumber.js": "^9.3.1", "bip32": "^5.0.1", "bip39": "^3.1.0", "bitcoinjs-lib": "^6.1.7", "bitcoinjs-message": "^2.2.0", "bs58": "^5.0.0", "buffer": "^6.0.3", "comlink": "^4.4.2", "dotenv": "^16.6.1", "ecpair": "^3.0.1", "ed25519-hd-key": "^1.3.0", "ethers": "^6.16.0", "falcon-js": "^1.0.0", "falcon-sign": "^1.0.4", "js-sha256": "^0.11.1", "js-sha3": "^0.9.3", "libsodium-wrappers-sumo": "^0.7.16", "lodash": "^4.18.1", "micro-ed25519-hdkey": "^0.1.2", "mlkem": "^2.7.0", "near-api-js": "^4.0.4", "node-forge": "^1.4.0", "node-seal": "^5.1.7", "ntru": "^4.0.4", "poseidon-lite": "^0.3.0", "pqcrypto": "^1.0.1", "protobufjs": "^7.6.2", "ripple-keypairs": "^2.0.0", "rubic-sdk": "^5.57.4", "simple-peer": "^9.11.1", "socket.io-client": "^4.8.3", "sphincs": "^3.0.4", "superdilithium": "^2.0.6", "tlsn-js": "0.1.0-alpha.12.0", "tronweb": "^6.3.0", "web3": "^4.16.0", "xrpl": "^3.1.0" } }, "sha512-+jAZmZB7xB6pJjWmYN3l5K72whVd4JdkuXagYbGrYsmtdavzKh348CjB1wGd2iWz6+FZLRulfpBW5GbFhneJMA=="],
+    "@kynesyslabs/demosdk": ["@kynesyslabs/demosdk@4.0.12", "", { "dependencies": { "@aptos-labs/ts-sdk": "^1.39.0", "@bitcoinerlab/secp256k1": "^1.2.0", "@coral-xyz/anchor": "^0.32.1", "@cosmjs/proto-signing": "^0.32.4", "@cosmjs/stargate": "^0.32.4", "@cryptkeeperzk/snarkjs": "^0.7.2", "@metaplex-foundation/js": "^0.20.1", "@multiversx/sdk-core": "^13.17.2", "@multiversx/sdk-extension-provider": "^3.0.0", "@multiversx/sdk-network-providers": "^2.9.3", "@multiversx/sdk-wallet": "^4.6.0", "@noble/curves": "1.9.4", "@noble/hashes": "1.8.0", "@noble/post-quantum": "^0.4.1", "@project-serum/anchor": "^0.26.0", "@roamhq/wrtc": "^0.8.0", "@scure/bip39": "^2.2.0", "@simplewebauthn/browser": "^11.0.0", "@simplewebauthn/server": "^11.0.0", "@solana/buffer-layout": "^4.0.1", "@solana/web3.js": "1.98.0", "@ton/core": "^0.62.1", "@ton/crypto": "^3.3.0", "@ton/ton": "^16.2.4", "@types/simple-peer": "^9.11.9", "axios": "^1.16.1", "big-integer": "^1.6.52", "bignumber.js": "^9.3.1", "bip32": "^5.0.1", "bip39": "^3.1.0", "bitcoinjs-lib": "^6.1.7", "bitcoinjs-message": "^2.2.0", "bs58": "^5.0.0", "buffer": "^6.0.3", "comlink": "^4.4.2", "dotenv": "^16.6.1", "ecpair": "^3.0.1", "ed25519-hd-key": "^1.3.0", "ethers": "^6.16.0", "falcon-js": "^1.0.0", "falcon-sign": "^1.0.4", "js-sha256": "^0.11.1", "js-sha3": "^0.9.3", "libsodium-wrappers-sumo": "^0.7.16", "lodash": "^4.18.1", "micro-ed25519-hdkey": "^0.1.2", "mlkem": "^2.7.0", "near-api-js": "^4.0.4", "node-forge": "^1.4.0", "node-seal": "^5.1.7", "ntru": "^4.0.4", "poseidon-lite": "^0.3.0", "pqcrypto": "^1.0.1", "protobufjs": "^7.6.2", "ripple-keypairs": "^2.0.0", "rubic-sdk": "^5.57.4", "simple-peer": "^9.11.1", "socket.io-client": "^4.8.3", "sphincs": "^3.0.4", "superdilithium": "^2.0.6", "tlsn-js": "0.1.0-alpha.12.0", "tronweb": "^6.3.0", "web3": "^4.16.0", "xrpl": "^3.1.0" } }, "sha512-PUKUu+XyQv2iY3Tsi/+81JqnPKvKyhIdBBlw/x6+8KkUu6Io6wqW27dZYzcmqaRZD8WeizH5yC/izjfuq5cTRg=="],
 
     "@layerzerolabs/scan-client": ["@layerzerolabs/scan-client@0.0.8", "", { "peerDependencies": { "axios": "*" } }, "sha512-V9vvt9GW0+AHoWXfOSNmZ9WUa28fVBmC93J/f9RLeDMEy5VR8srW2Du5pf1mMAg6ncEL0kQ1xkVCu+X6ARFBtQ=="],
 

--- a/docs/discoveries/nonce-multirpc-fork-2026-06-25.md
+++ b/docs/discoveries/nonce-multirpc-fork-2026-06-25.md
@@ -1,0 +1,69 @@
+# Nonce / Multi-RPC / Solo-Fork — assessment + converged fix (PLAN v3)
+
+Date: 2026-06-25
+Branch: `stabilisation`
+Status: discovery + CONVERGED plan (3 adversarial rounds + 7-scenario simulation). No code changed yet.
+Tracking: Mycelium Epic #21 (tasks #189–#202).
+Target: testnet Release Candidate, **dozens of validators**, **min 2 nodes** operationally.
+
+---
+
+## 1. The three defects (plain English)
+
+- **Bug A — multi-RPC nonce.** Acceptance = `nonce == account.nonce + 1 + localPendingCount`. `pendingCount` is per-node, so the same wallet hitting different RPCs gets conflicting txs all accepted, then all-but-first fail at execution.
+- **Bug B — silent solo-fork.** A node forges a block alone (a 1-node shard self-certifies) and rejoins, diverging state. No fork-choice / reorg exists, so it can't self-heal.
+- **Colleague's symptom — header lies.** Block `ordered_transactions` claims N txs, DB persists fewer. **This is the load-bearing one** and it has a precise cause (below).
+
+## 2. The root cause almost everything traces to
+
+`PoRBFT.ts:160` forges the block from the full mempool **before** `applyGCREditsFromMergedMempool` at `:184`. Failed txs are pruned from the mempool (`:196`) but **never removed from the already-sealed `block.content.ordered_transactions`**. So the header claims txs that never applied. A state-root comparator is **blind** to this (it hashes state, not the claimed tx list). Fixing this — **forge after apply** — is the keystone.
+
+## 3. Verified facts (ground truth, from code)
+
+| Fact | file:line |
+|---|---|
+| ordering = timestamp (node-variant) | `mempool.ts:50-68`, trusted end-to-end `PoRBFT.ts:444-505` |
+| forge before apply; failed pruned from mempool only | `PoRBFT.ts:160,184,196` |
+| 1-node shard self-certifies (`isBlockValid(1,1)=true`) | `PoRBFT.ts:669` |
+| execution NON-deterministic (~9 `Date.now`/`new Date` + live fetches into state) | tlsn/rewards/zk/ethos/humanpassport routines; `handleGCR partitionIndependentTxs` |
+| GCRMain NOT hashed (`native_gcr="placeholder"`, `hashPublicKeyTable` unused) | `hashGCR.ts`, `block.ts:46` |
+| spectators DO execute on sync | `Sync.ts:362,596` → `syncGCRTables` → `applyTransactions` |
+| no fork-choice / reorg / block-rollback | grep 0 hits; `rollback` is intra-tx in-memory pre-save only |
+| only `shardSize` (~4) validators forge/vote; rest spectate | `getShard.ts:92`, `defaults.ts:33` |
+| admission rejects future nonce at originating RPC before gossip | `validateTransaction.ts:527-685` |
+| sender normalizer to reuse | `forgeToHex().toLowerCase()` `validateTransaction.ts:552-556` |
+| fork-gate pattern | `isForkActive("nonceEnforcement", blockHeight)` |
+
+## 4. Converged plan v3 (RC scope) — order matters
+
+Ship strictly in this order; each lands on a safer base than the last.
+
+1. **P-ORDER** (#189) — deterministic `(sender,nonce,hash)` ordering of the merged mempool before forge; fork-gated; plain hex compare (NOT `localeCompare` — locale-sensitive). Apply follows `ordered_transactions` on **both** forge and sync. Relieves the stall (kills timestamp-jitter vote divergence). ~15 lines.
+2. **P-TRIM** (#193, keystone) — **forge AFTER apply.** Rebuild `ordered_transactions` from `successfulTxs` only; seal hash post-apply. Invariant: `ordered_transactions == applied == persisted`. Gapped/conflicting txs are **pre-apply excluded** (no rollback primitive exists, so never execute-and-fail). syncGCRTables must apply the sealed list, not local mempool.
+3. **P-DETECT** (#194) — wire the unused `hashPublicKeyTable` into a real GCRMain state root; ship it as a **signed block-content field** that also binds `hash(ordered_transactions)+appliedCount`. Every node recomputes post-apply, compares at equal height, both-sides **HALT** on mismatch. **Ship flag-gated log-only.** Forward-compatible: same signed root + `validation_data.signatures` aggregation becomes the mainnet BFT vote (no rip-out).
+4. **P-CLOCK** (#195) — inject `{blockTimestamp,blockHeight}` into apply (fully); replace **root-covered** wall-clock sites; move **root-bound** external fetches (Ethos, HumanPassport) to pre-signing carried in the signed tx; **path-scoped** lint ban on apply/root modules. **Exit = N-node replay of last K blocks yields byte-identical roots** (not "banlist complete"). Gates P-DETECT's HALT graduation.
+5. **P-ADMIT** (#196, colleague's ask) — `assignNonce` → bounded range `[committed+1, committed+CAP]`; **CAP is a genesis/fork constant** (not env); `expectedPrior = txNonce-1`; reject local duplicate `(sender,nonce)`. Gaps handled by P-TRIM.
+6. **P-MINSHARD** (#197) — `getShard` refuses to forge when online set `< MIN_SHARD`; `isBlockValid` rejects `totalVotes < MIN_SHARD`. **MIN_SHARD = one pinned genesis constant** (resolve to a single value, e.g. 3). Double-gates solo-fork.
+7. **P-VERIFY** (#191) — 2-node + multi-validator devnet acceptance (see §6).
+
+## 5. Why v3 fixes all three (simulation-confirmed, 7 scenarios)
+
+- **Bug A:** P-ORDER lands cross-RPC nonces in deterministic order; same-nonce conflicts resolved by hex tie-break; both forger and spectators apply the **sealed** `ordered_transactions`, so roots match.
+- **Bug B:** P-MINSHARD double-gates — a 1-node (or sub-`MIN_SHARD`) shard cannot finalize; partitions stall instead of silently forking. Legit shrink below MIN_SHARD → chain correctly **stalls** (safety over liveness).
+- **Colleague's symptom:** P-TRIM makes `header == DB` an enforced invariant — correct *because* there's no rollback (move forge after apply rather than undo).
+
+**No new logic bugs introduced.** The only halts are deliberate "page a human" safety stops.
+
+## 6. Known residuals (tracked, NOT RC-blockers)
+
+- **Mempool-bloat DoS** (#201): wallets × CAP gapped txs accumulate; CAP bounds per-sender depth, not wallet count. Pre-existing surface; needs eviction/TTL. Consensus stays safe.
+- **Operational invariants for HALT graduation** (#202 runbook): (A) keep P-DETECT log-only across the entire P-TRIM→P-CLOCK window; (B) flip to HALT only after replay gate green **and** a clean log-only soak on the live fleet (replay proves only known nondeterminism; live soak surfaces unknown sources).
+
+## 7. Mainnet backlog (correctly cut from RC)
+
+- **B1** (#198) network-wide BFT state-root **vote** (closes "4-node shard certifies for 30 spectators"). Reuses P-DETECT's machinery.
+- **B2** (#199) equivocation/partition **prevention** guard.
+- **B3** (#200) **auto-reorg** engine (inverse-edit journal + side-effect compensation + fork-choice). Multi-week.
+
+## 8. For the colleague
+He's directionally right (future-nonce admission IS needed — P-ADMIT). But the CAP/parking-queue + mempool re-key he was reaching for is mostly YAGNI; the real fix is **forge-after-apply (P-TRIM)** + deterministic ordering, which he hadn't framed. Grant the temporary disable as a **fork-gated/env flag** (not code removal); permanent fix is far smaller than his plan. **Do not disable nonce checks outright** — replay footgun.

--- a/docs/discoveries/nonce-multirpc-fork-2026-06-25.md
+++ b/docs/discoveries/nonce-multirpc-fork-2026-06-25.md
@@ -2,7 +2,24 @@
 
 Date: 2026-06-25
 Branch: `stabilisation`
-Status: discovery + CONVERGED plan (3 adversarial rounds + 7-scenario simulation). No code changed yet.
+Status: SHIPPED (stability fixes) + architectural follow-up scoped. See "Implementation status" below.
+
+## Implementation status (2026-06-25)
+
+**SHIPPED + verified on 2-node devnet (the testnet RC config), branch `fix/consensus-deterministic-ordering-ep21`:**
+- ✅ **P-ORDER** (#189, commit c831ce0c8) — deterministic (sender,nonce,hash) mempool ordering, fork-gated.
+- ✅ **#204 root cause** (commit b07f5e3bf) — the actual cross-RPC freeze. `confirmTransaction` mutated the SDK-signed tx (prepended fee edits + overwrote `transaction_fee`) → coherence failed on gossip → divergent blocks → no tx committed. Fix: derive-at-apply (node no longer mutates the signed tx; fee edits derived deterministically at apply from the shipped `transaction_fee`).
+- ✅ **P-MINSHARD** (#197, commit fcf6feb6e) — `isBlockValid` refuses to finalize below MIN_SHARD=2 (kills 1-node self-certify / solo-fork). + getShard localeCompare→byte sort (determinism).
+
+**Verified:** single tx commits (was frozen); 4 sequential cross-RPC txs land in nonce order; both nodes byte-identical; fees→treasury; no double-spend on replay; chain advances pro=2/con=0. The colleague's reported instability (txs accepted but never committing, chain stalling) is RESOLVED.
+
+**NOT shipped — one coupled architectural change (its own plan + approval needed):**
+- ⏳ **P-TRIM** (#193) + **P-DETECT** (#194) + **P-CLOCK** (#195) + **P-ADMIT** (#196) = a state-root-vote redesign. Verified blocker: the vote+signatures bind the PRE-execution block hash and `verifyBlock` recomputes that hash on sync, so an honest header (trim failed txs) requires sealing the block AFTER apply and voting on the post-apply hash — which restructures the consensus loop, the vote path (peers must apply before voting), and `verifyBlock`, AND requires full execution determinism first (P-CLOCK: ~9 Date.now/new Date + network-fetch sites in the apply path; unbounded tail per audit). High blast radius; not bounded. P-ADMIT (future-nonce) depends on P-TRIM (gap exclusion at forge). With #204+P-ORDER, sequential txs already commit fine, so these are hardening/throughput, not stability.
+
+---
+
+(original plan below — retained for reference)
+
 Tracking: Mycelium Epic #21 (tasks #189–#202).
 Target: testnet Release Candidate, **dozens of validators**, **min 2 nodes** operationally.
 

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
         "@fastify/cors": "^9.0.1",
         "@fastify/swagger": "^8.15.0",
         "@fastify/swagger-ui": "^4.1.0",
-        "@kynesyslabs/demosdk": "4.0.9",
+        "@kynesyslabs/demosdk": "4.0.12",
         "@metaplex-foundation/js": "^0.20.1",
         "@modelcontextprotocol/sdk": "^1.13.3",
         "@noble/ed25519": "^3.0.0",
@@ -182,6 +182,7 @@
         "socket.io-parser": ">=4.2.6",
         "valibot": ">=1.2.0",
         "fast-xml-parser": ">=5.3.4",
-        "validator": ">=13.15.20"
+        "validator": ">=13.15.20",
+        "@kynesyslabs/demosdk": "4.0.12"
     }
 }

--- a/src/libs/blockchain/gcr/handleGCR.ts
+++ b/src/libs/blockchain/gcr/handleGCR.ts
@@ -41,6 +41,7 @@ import Chain from "src/libs/blockchain/chain"
 import { isForkActive } from "@/forks"
 import { getSharedState } from "@/utilities/sharedState"
 import { verifyGcrEditsMatch } from "src/libs/blockchain/validation/verifyGcrEdits"
+import { generateFeeDistributionEdits } from "src/libs/blockchain/gcr/gcr_routines/feeDistribution"
 import GCRBalanceRoutines from "./gcr_routines/GCRBalanceRoutines"
 import GCRNonceRoutines from "./gcr_routines/GCRNonceRoutines"
 import GCRValidatorStakeRoutines from "./gcr_routines/GCRValidatorStakeRoutines"
@@ -110,6 +111,38 @@ export interface AssignedTxRecord {
 type IndexedSideEffect = {
     txIndex: number
     fn: () => Promise<void>
+}
+
+/**
+ * Epic #21 #204: derive the gasFeeSeparation fee-distribution edits for a tx
+ * at APPLY time, from the SDK-shipped `transaction_fee`. Returns [] when the
+ * fork is inactive, the tx is non-native, or no fee is owed. Pure +
+ * deterministic across nodes (same shipped fee + same fee-distribution config
+ * => same edits), so applied state never diverges. rpc_address is null at this
+ * stage (rpc share folds to treasury); BFT-committed rpc routing is a
+ * follow-up. Mirrors the pre-#204 prepend that confirmTransaction used to do,
+ * moved here so the gossiped tx stays byte-identical to the signed one.
+ */
+function deriveFeeEditsForApply(tx: Transaction): GCREdit[] {
+    if (tx.content?.type !== "native") return []
+    if (!isForkActive("gasFeeSeparation", getSharedState.lastBlockNumber ?? 0)) {
+        return []
+    }
+    const fee = tx.content.transaction_fee
+    if (!fee) return []
+    const senderAddress =
+        typeof tx.content.from === "string"
+            ? tx.content.from
+            : forgeToHex(tx.content.from as never)
+    return generateFeeDistributionEdits({
+        senderAddress,
+        rpcAddress: fee.rpc_address ?? null,
+        networkFee: Number(fee.network_fee),
+        rpcFee: Number(fee.rpc_fee),
+        additionalFee: Number(fee.additional_fee),
+        txHash: tx.hash ?? "",
+        isRollback: false,
+    }) as GCREdit[]
 }
 
 /**
@@ -382,11 +415,11 @@ export default class HandleGCR {
                 getSharedState.lastBlockNumber ?? 0,
             )
         ) {
-            // Own the fork check at the call site (matches Mempool.receive)
-            // so both ingress + apply decide expectFeeEdits the same way and
-            // neither relies on verifyGcrEditsMatch's internal re-check
-            // (Greptile P2). A confirmed/applied tx carries fee edits exactly
-            // when gasFeeSeparation is active.
+            // Epic #21 #204: by the time apply runs, applyTransactions has
+            // prepended the derived fee edits onto tx.content.gcr_edits (when
+            // gasFeeSeparation is active), so the shipped set DOES carry fee
+            // edits here — the binding regen must reproduce them too.
+            // expectFeeEdits mirrors the fork, matching the derive step.
             const expectFeeEdits = isForkActive(
                 "gasFeeSeparation",
                 getSharedState.lastBlockNumber ?? 0,
@@ -760,6 +793,29 @@ export default class HandleGCR {
                 log.debug(
                     `[applyTransactions] Uniqueness guard dropped ${before - finalTxs.length} confirmed tx(s)`,
                 )
+            }
+        }
+
+        // Epic #21 #204: derive gasFeeSeparation fee-distribution edits at
+        // APPLY time from each tx's SDK-shipped transaction_fee and prepend
+        // them onto the in-memory tx (NOT the gossiped/stored one — this is a
+        // post-admission local copy, never re-hashed). confirmTransaction no
+        // longer mutates the signed tx, so the gossiped tx is byte-identical to
+        // what the sender signed (coherence passes cross-node). Deriving here —
+        // before prepareEntities + partitionIndependentTxs — means the fee
+        // accounts (burn/treasury) are loaded into the entity cache and grouped
+        // correctly. Skipped on rollback (the stored edits are replayed in
+        // reverse as-is). Every node derives identical edits from the same
+        // shipped fee, so applied state never diverges.
+        if (!isRollback) {
+            for (const tx of finalTxs) {
+                const feeEdits = deriveFeeEditsForApply(tx)
+                if (feeEdits.length > 0) {
+                    tx.content.gcr_edits = [
+                        ...feeEdits,
+                        ...(tx.content.gcr_edits ?? []),
+                    ]
+                }
             }
         }
 

--- a/src/libs/blockchain/gcr/handleGCR.ts
+++ b/src/libs/blockchain/gcr/handleGCR.ts
@@ -134,6 +134,14 @@ function deriveFeeEditsForApply(tx: Transaction): GCREdit[] {
         typeof tx.content.from === "string"
             ? tx.content.from
             : forgeToHex(tx.content.from as never)
+    // Derive the fee edits from the SDK-shipped transaction_fee — the SAME
+    // source verifyGcrEditsMatch regenerates from at apply, so the injected
+    // edits and the binding check agree. (Number() handles the OS-string wire
+    // shape: "1000000000" -> 1000000000.) The shipped fee was already bound to
+    // the node's computed total at ingress (applyGasFeeSeparation), so a forged
+    // / underpaid fee cannot reach here. rpc_address is null at the RC stage ->
+    // the rpc share folds to treasury deterministically (BFT-committed rpc
+    // routing is the mainnet follow-up).
     return generateFeeDistributionEdits({
         senderAddress,
         rpcAddress: fee.rpc_address ?? null,

--- a/src/libs/blockchain/mempool.ts
+++ b/src/libs/blockchain/mempool.ts
@@ -512,10 +512,12 @@ export default class Mempool {
         // transaction_fee (incl. the originator's rpc_address) so the match
         // holds cross-node (audit 184). expectFeeEdits is keyed on the fork so
         // pre-fork the regen stays fee-free.
-        const expectFeeEdits = isForkActive(
-            "gasFeeSeparation",
-            getSharedState.lastBlockNumber ?? 0,
-        )
+        // Epic #21 #204: at INGRESS the gossiped tx is byte-identical to what
+        // the sender signed — confirmTransaction no longer prepends fee edits
+        // onto it (those are derived at apply). So the shipped set carries NO
+        // fee edits here; the binding regen must NOT add them either, or every
+        // legit tx false-mismatches. (Fee edits are bound at apply, where they
+        // are derived: see HandleGCR.applyTransactions.)
         {
             const editVerifiedTransactions: Transaction[] = []
             for (const tx of validTransactions) {
@@ -525,7 +527,7 @@ export default class Mempool {
                 }
                 try {
                     const { match } = await verifyGcrEditsMatch(tx, {
-                        expectFeeEdits,
+                        expectFeeEdits: false,
                     })
                     if (!match) {
                         log.error(

--- a/src/libs/blockchain/routines/applyGasFeeSeparation.ts
+++ b/src/libs/blockchain/routines/applyGasFeeSeparation.ts
@@ -148,10 +148,55 @@ export async function applyGasFeeSeparation(
     // tx.hash) -> peers reject as "not coherent" -> divergent blocks ->
     // permanent vote split -> chain frozen on any tx. The fee edits are
     // now derived deterministically AT APPLY from the SDK-shipped
-    // transaction_fee (see deriveFeeEdits in handleGCR), so the gossiped
-    // tx stays byte-identical to what the sender signed. This routine
-    // keeps only the balance pre-check below (reject under-funded txs at
-    // ingress with an actionable message); it no longer writes to `tx`.
+    // transaction_fee (see deriveFeeEditsForApply in handleGCR), so the
+    // gossiped tx stays byte-identical to what the sender signed. This
+    // routine no longer writes to `tx`; it ENFORCES the shipped fee (below)
+    // and does the balance pre-check.
+
+    // Greptile P1 (epic #21 #204): because the fee is now charged at apply
+    // from the SDK-shipped transaction_fee — NOT from the node-computed
+    // `breakdown` — a client could ship `{network_fee:0, rpc_fee:0,
+    // additional_fee:0}` and pass ingress while paying nothing. Bind the
+    // shipped fee to the canonical breakdown here: reject any tx whose
+    // shipped components don't match what the node computes. Compared in OS
+    // via toOsBigint (the shipped value is a DEM number pre-serialize or an
+    // OS string post-serialize; breakdown is in the same base unit the SDK
+    // signs), so the check is unit-robust. Without this the fee floor is
+    // unenforced.
+    const shippedFee = tx.content.transaction_fee
+    if (!shippedFee) {
+        return {
+            ok: false,
+            message:
+                "post-gasFeeSeparation tx is missing transaction_fee — refusing (cannot bind shipped fee to breakdown)",
+        }
+    }
+    // Compare the shipped fee TOTAL to the computed total, in OS. We bind
+    // the total — not per-component — because the SDK ships the whole fee in
+    // network_fee (rpc_fee/additional_fee = 0) whereas the node SPLITS it
+    // (network/rpc/additional) for distribution. The split is the node's
+    // deterministic, config-driven concern (see deriveFeeEditsForApply); the
+    // sender only commits to paying the total. A DEM number is ×1e9 to OS; an
+    // OS string is taken as-is.
+    const toOs = (v: unknown): bigint => {
+        if (typeof v === "string") return BigInt(v)
+        return BigInt(Math.round(Number(v ?? 0))) * 1_000_000_000n
+    }
+    const shippedTotalOs =
+        toOs(shippedFee.network_fee) +
+        toOs(shippedFee.rpc_fee) +
+        toOs(shippedFee.additional_fee)
+    const computedTotalOs = BigInt(breakdown.total) * 1_000_000_000n
+    if (shippedTotalOs !== computedTotalOs) {
+        return {
+            ok: false,
+            message:
+                `transaction_fee total mismatch: shipped=${shippedTotalOs} OS ` +
+                `(network=${String(shippedFee.network_fee)} rpc=${String(shippedFee.rpc_fee)} additional=${String(shippedFee.additional_fee)}) ` +
+                `but node computed ${computedTotalOs} OS (total=${breakdown.total}). ` +
+                "Refusing — fee underpayment / forged fee.",
+        }
+    }
 
     // Audit-sweep batch B: balance check is now enforced in every
     // environment. The previous PROD-only gate (paired with the same

--- a/src/libs/blockchain/routines/applyGasFeeSeparation.ts
+++ b/src/libs/blockchain/routines/applyGasFeeSeparation.ts
@@ -171,30 +171,36 @@ export async function applyGasFeeSeparation(
                 "post-gasFeeSeparation tx is missing transaction_fee — refusing (cannot bind shipped fee to breakdown)",
         }
     }
-    // Compare the shipped fee TOTAL to the computed total, in OS. We bind
-    // the total — not per-component — because the SDK ships the whole fee in
-    // network_fee (rpc_fee/additional_fee = 0) whereas the node SPLITS it
-    // (network/rpc/additional) for distribution. The split is the node's
-    // deterministic, config-driven concern (see deriveFeeEditsForApply); the
-    // sender only commits to paying the total. A DEM number is ×1e9 to OS; an
-    // OS string is taken as-is.
+    // Bind the shipped fee PER-COMPONENT to the node-computed breakdown, in
+    // OS. Per-component (not just total) because the fee is charged at apply
+    // from the shipped components (deriveFeeEditsForApply) — binding only the
+    // total would let a client skew the split (e.g. put everything in
+    // network_fee, rpc_fee=0) and pass validation while the apply-time
+    // distribution emits no RPC-fee block, making fee routing deterministically
+    // wrong (Greptile P1 #2). The SDK ships the same component split the node
+    // computes (network/rpc/additional), so a legit tx matches exactly; a
+    // skewed or underpaid one is rejected. A DEM number is ×1e9 to OS; an OS
+    // string is taken as-is.
     const toOs = (v: unknown): bigint => {
         if (typeof v === "string") return BigInt(v)
         return BigInt(Math.round(Number(v ?? 0))) * 1_000_000_000n
     }
-    const shippedTotalOs =
-        toOs(shippedFee.network_fee) +
-        toOs(shippedFee.rpc_fee) +
-        toOs(shippedFee.additional_fee)
-    const computedTotalOs = BigInt(breakdown.total) * 1_000_000_000n
-    if (shippedTotalOs !== computedTotalOs) {
-        return {
-            ok: false,
-            message:
-                `transaction_fee total mismatch: shipped=${shippedTotalOs} OS ` +
-                `(network=${String(shippedFee.network_fee)} rpc=${String(shippedFee.rpc_fee)} additional=${String(shippedFee.additional_fee)}) ` +
-                `but node computed ${computedTotalOs} OS (total=${breakdown.total}). ` +
-                "Refusing — fee underpayment / forged fee.",
+    const componentChecks: Array<[string, unknown, number]> = [
+        ["network_fee", shippedFee.network_fee, breakdown.network_fee],
+        ["rpc_fee", shippedFee.rpc_fee, breakdown.rpc_fee],
+        ["additional_fee", shippedFee.additional_fee, breakdown.additional_fee],
+    ]
+    for (const [name, shipped, computed] of componentChecks) {
+        const shippedOs = toOs(shipped)
+        const computedOs = BigInt(computed) * 1_000_000_000n
+        if (shippedOs !== computedOs) {
+            return {
+                ok: false,
+                message:
+                    `transaction_fee.${name} mismatch: shipped=${String(shipped)} ` +
+                    `(=${shippedOs} OS) but node computed ${computed} (=${computedOs} OS). ` +
+                    "Refusing — fee underpayment / forged or skewed fee split.",
+            }
         }
     }
 

--- a/src/libs/blockchain/routines/applyGasFeeSeparation.ts
+++ b/src/libs/blockchain/routines/applyGasFeeSeparation.ts
@@ -45,7 +45,6 @@ KyneSys Labs: https://www.kynesys.xyz/
 
 import { GCREdit } from "@kynesyslabs/demosdk/types"
 import type { Transaction as ITransaction } from "@kynesyslabs/demosdk/types"
-import { ucrypto, uint8ArrayToHex } from "@kynesyslabs/demosdk/encryption"
 import {
     calculateFeeBreakdown,
     type FeeBreakdown,
@@ -53,8 +52,6 @@ import {
 import { generateFeeDistributionEdits } from "@/libs/blockchain/gcr/gcr_routines/feeDistribution"
 import GCR from "@/libs/blockchain/gcr/gcr"
 import { forgeToHex } from "@/libs/crypto/forgeUtils"
-import { getSharedState } from "@/utilities/sharedState"
-import log from "@/utilities/logger"
 
 export type ApplyGasFeeSeparationResult =
     | { ok: true }
@@ -145,17 +142,16 @@ export async function applyGasFeeSeparation(
         }
     }
 
-    // Stamp the transaction with the per-component values + this
-    // node's pubkey as the rpc_address. Peers receiving the signed
-    // ValidityData rely on these fields being present.
-    const rpcAddressHex = uint8ArrayToHex(
-        (await ucrypto.getIdentity(getSharedState.signingAlgorithm))
-            .publicKey as Uint8Array,
-    )
-    tx.content.transaction_fee.network_fee = breakdown.network_fee
-    tx.content.transaction_fee.rpc_fee = breakdown.rpc_fee
-    tx.content.transaction_fee.additional_fee = breakdown.additional_fee
-    tx.content.transaction_fee.rpc_address = rpcAddressHex
+    // Epic #21 #204: do NOT mutate tx.content. Stamping transaction_fee
+    // and prepending fee edits AFTER the SDK signed the tx broke
+    // validateTxCoherence on the gossip path (derived hash != signed
+    // tx.hash) -> peers reject as "not coherent" -> divergent blocks ->
+    // permanent vote split -> chain frozen on any tx. The fee edits are
+    // now derived deterministically AT APPLY from the SDK-shipped
+    // transaction_fee (see deriveFeeEdits in handleGCR), so the gossiped
+    // tx stays byte-identical to what the sender signed. This routine
+    // keeps only the balance pre-check below (reject under-funded txs at
+    // ingress with an actionable message); it no longer writes to `tx`.
 
     // Audit-sweep batch B: balance check is now enforced in every
     // environment. The previous PROD-only gate (paired with the same
@@ -182,45 +178,30 @@ export async function applyGasFeeSeparation(
         }
     }
 
-    // Generate fee-distribution edits and prepend onto the tx's
-    // existing gcr_edits. Prepend (rather than append) so the fee
-    // deductions apply before any tx-level operation — same intent as
-    // the legacy gas-Operation slot.
-    const feeEdits = generateFeeDistributionEdits({
-        senderAddress,
-        rpcAddress: rpcAddressHex,
-        networkFee: breakdown.network_fee,
-        rpcFee: breakdown.rpc_fee,
-        additionalFee: breakdown.additional_fee,
-        txHash: tx.hash ?? "",
-        isRollback: false,
-    })
-
-    // PR #817 Greptile P1 (silent fee bypass):
-    // generateFeeDistributionEdits returns [] when
-    // `requireFeeDistribution` returns null — either feeDistribution
-    // hasn't been primed at all, or every percentage is still 0
-    // (transient window between loadForkConfigFromGenesis and
-    // loadNetworkParameters). Silently accepting the tx in that
-    // window would charge nothing while marking the tx valid, which
-    // is exactly the failure mode the prior guard was meant to
-    // prevent. Refuse the tx whenever the breakdown demanded a
-    // non-zero total but no edits were generated.
-    if (breakdown.total > 0 && feeEdits.length === 0) {
-        return {
-            ok: false,
-            message:
-                "fee distribution not primed — refusing to accept post-fork tx without fee collection " +
-                `(breakdown.total=${breakdown.total}, but generateFeeDistributionEdits returned 0 edits)`,
+    // Epic #21 #204: fee edits are NO LONGER prepended here. They are
+    // derived at apply (deriveFeeEdits in handleGCR) from the SDK-shipped
+    // transaction_fee so every node applies an identical set without
+    // mutating the signed tx. We still fail closed at ingress if fees are
+    // owed but the distribution config isn't primed, to preserve the
+    // "never silently accept a no-fee post-fork tx" guard.
+    if (breakdown.total > 0) {
+        const probe = generateFeeDistributionEdits({
+            senderAddress,
+            rpcAddress: null,
+            networkFee: breakdown.network_fee,
+            rpcFee: breakdown.rpc_fee,
+            additionalFee: breakdown.additional_fee,
+            txHash: tx.hash ?? "",
+            isRollback: false,
+        })
+        if (probe.length === 0) {
+            return {
+                ok: false,
+                message:
+                    "fee distribution not primed — refusing to accept post-fork tx without fee collection " +
+                    `(breakdown.total=${breakdown.total}, but generateFeeDistributionEdits returned 0 edits)`,
+            }
         }
     }
-
-    tx.content.gcr_edits = [
-        ...(feeEdits as GCREdit[]),
-        ...((tx.content.gcr_edits ?? []) as GCREdit[]),
-    ]
-    log.debug(
-        `[TX] applyGasFeeSeparation - prepended ${feeEdits.length} fee edits onto tx ${tx.hash}`,
-    )
     return { ok: true }
 }

--- a/src/libs/consensus/v2/PoRBFT.ts
+++ b/src/libs/consensus/v2/PoRBFT.ts
@@ -17,6 +17,8 @@ import L2PSConsensus from "@/libs/l2ps/L2PSConsensus"
 import { DTRManager } from "@/libs/network/dtr/dtrmanager"
 import { BroadcastManager } from "@/libs/communications/broadcastManager"
 import { fastSync, waitForPeerStatus } from "@/libs/blockchain/routines/Sync"
+import { isForkActive } from "@/forks"
+import { orderDeterministically } from "./routines/deterministicOrder"
 
 /* INFO
 # Semaphore system
@@ -499,6 +501,19 @@ async function mergeAndOrderMempools(
 
     for (const [type, count] of Object.entries(typeCounts)) {
         log.only(`[mergeAndOrderMempools]   ${type}: ${count}`)
+    }
+
+    // P-ORDER (Epic #21): impose a deterministic (sender, nonce, hash) order so
+    // every honest node forging the same merged set produces a byte-identical
+    // ordered_transactions list (vote convergence) and same-sender txs apply in
+    // nonce order. Fork-gated so blocks authored before activation re-sync
+    // bit-identically under their legacy (timestamp) order.
+    if (isForkActive("nonceEnforcement", blockRef)) {
+        const ordered = orderDeterministically(finalMempool)
+        log.only(
+            `[mergeAndOrderMempools] Deterministic (sender,nonce,hash) order applied to ${ordered.length} txs`,
+        )
+        return ordered as (Transaction & { reference_block: number })[]
     }
 
     return finalMempool

--- a/src/libs/consensus/v2/PoRBFT.ts
+++ b/src/libs/consensus/v2/PoRBFT.ts
@@ -20,6 +20,13 @@ import { fastSync, waitForPeerStatus } from "@/libs/blockchain/routines/Sync"
 import { isForkActive } from "@/forks"
 import { orderDeterministically } from "./routines/deterministicOrder"
 
+// P-MINSHARD (epic #21 #197): minimum validators that must agree before a
+// block can finalize. Below this the BFT 2/3+1 math degenerates (a 1-node
+// shard self-certifies). 2 = testnet RC minimum. Kept as a module constant
+// (not env) so every node agrees; promote to a genesis/fork parameter when
+// the validator set policy is finalized for mainnet.
+const MIN_SHARD = 2
+
 /* INFO
 # Semaphore system
 
@@ -682,6 +689,18 @@ async function voteOnBlock(
  * @returns True if the block is valid, false otherwise
  */
 function isBlockValid(pro: number, totalVotes: number): boolean {
+    // P-MINSHARD (epic #21 #197): absolute participation floor. With a
+    // 1-node shard the BFT threshold collapses to floor(2/3)+1 = 1, so a
+    // lone node self-certifies its own block — the solo-fork source (Bug B):
+    // it forges alone, rejoins, and its divergent block has a "valid"
+    // signature count nobody else endorsed. Refuse to finalize below
+    // MIN_SHARD so a block always carries genuine multi-validator agreement.
+    // Testnet RC runs a 2-node minimum, so MIN_SHARD=2 (both must agree:
+    // floor(2*2/3)+1 = 2). A legitimate shrink below the floor correctly
+    // STALLS the chain (safety over liveness) rather than forking.
+    if (totalVotes < MIN_SHARD) {
+        return false
+    }
     const threshold = Math.floor((totalVotes * 2) / 3) + 1
     return pro >= threshold
 }

--- a/src/libs/consensus/v2/routines/deterministicOrder.test.ts
+++ b/src/libs/consensus/v2/routines/deterministicOrder.test.ts
@@ -1,0 +1,60 @@
+import {
+    compareTxDeterministic,
+    orderDeterministically,
+    senderKey,
+} from "./deterministicOrder"
+import { Transaction } from "@kynesyslabs/demosdk/types"
+
+/**
+ * P-ORDER self-check (Epic #21). Smallest test that fails if the deterministic
+ * (sender, nonce, hash) order breaks: determinism across input permutations,
+ * per-sender nonce ordering, hash tie-break, and no-mutation.
+ */
+function tx(from: string, nonce: number, hash: string): Transaction {
+    return { content: { from, nonce }, hash } as unknown as Transaction
+}
+
+describe("deterministicOrder (P-ORDER)", () => {
+    test("sorts by sender then nonce then hash", () => {
+        const input = [
+            tx("0xbb", 2, "h3"),
+            tx("0xaa", 5, "h1"),
+            tx("0xaa", 1, "h2"),
+            tx("0xbb", 2, "h0"), // same (sender,nonce) -> hash tie-break
+        ]
+        const out = orderDeterministically(input).map(t => t.hash)
+        // 0xaa nonce1, 0xaa nonce5, 0xbb nonce2 (h0 before h3)
+        expect(out).toEqual(["h2", "h1", "h0", "h3"])
+    })
+
+    test("is permutation-invariant (determinism)", () => {
+        const a = tx("0xaa", 1, "h1")
+        const b = tx("0xaa", 2, "h2")
+        const c = tx("0xbb", 1, "h3")
+        const o1 = orderDeterministically([a, b, c]).map(t => t.hash)
+        const o2 = orderDeterministically([c, b, a]).map(t => t.hash)
+        const o3 = orderDeterministically([b, c, a]).map(t => t.hash)
+        expect(o1).toEqual(o2)
+        expect(o2).toEqual(o3)
+    })
+
+    test("sender key is lowercased", () => {
+        expect(senderKey(tx("0xABCDEF", 0, "h"))).toBe("0xabcdef")
+    })
+
+    test("does not mutate input", () => {
+        const input = [tx("0xbb", 1, "h2"), tx("0xaa", 1, "h1")]
+        const snapshot = input.map(t => t.hash)
+        orderDeterministically(input)
+        expect(input.map(t => t.hash)).toEqual(snapshot)
+    })
+
+    test("comparator is a total order (antisymmetry)", () => {
+        const x = tx("0xaa", 1, "h1")
+        const y = tx("0xbb", 2, "h2")
+        expect(Math.sign(compareTxDeterministic(x, y))).toBe(
+            -Math.sign(compareTxDeterministic(y, x)),
+        )
+        expect(compareTxDeterministic(x, x)).toBe(0)
+    })
+})

--- a/src/libs/consensus/v2/routines/deterministicOrder.ts
+++ b/src/libs/consensus/v2/routines/deterministicOrder.ts
@@ -1,0 +1,70 @@
+import { Transaction } from "@kynesyslabs/demosdk/types"
+
+// ponytail: inline the forge-buffer -> hex coercion instead of importing
+// forgeToHex, which transitively pulls in logger -> sharedState -> the whole
+// chain/datasource graph. This module must stay a leaf so it is cheap to load
+// and unit-testable in isolation. Mirrors forgeUtils.forgeToHex behaviour for
+// the only shapes a tx `from` field takes (hex string, Uint8Array/Buffer, or a
+// serialized {type:"Buffer",data:number[]}).
+function toHexLower(from: unknown): string {
+    if (typeof from === "string") return from.toLowerCase()
+    let buf = from as { type?: string; data?: number[] } | Uint8Array
+    if ((buf as { type?: string }).type === "Buffer") {
+        buf = (buf as { data: number[] }).data as unknown as Uint8Array
+    }
+    return Buffer.from(buf as Uint8Array).toString("hex").toLowerCase()
+}
+
+/**
+ * Deterministic total order over a merged mempool: (sender, nonce, hash).
+ *
+ * P-ORDER (Epic #21): the previous ordering was by timestamp, which is
+ * node-variant, so two honest nodes forging the same merged set produced
+ * different block hashes -> vote divergence -> consensus stalls. Sorting by
+ * (sender, nonce, hash) is a pure function of the tx set, so every honest
+ * node with the same merged mempool produces a byte-identical
+ * ordered_transactions list. It also guarantees same-sender txs are laid out
+ * in nonce order, which the apply path follows.
+ *
+ * The sort is total and fully tie-broken (sender, then nonce, then the
+ * globally-unique tx hash), so there is no residual non-determinism.
+ */
+export function senderKey(tx: Transaction): string {
+    return toHexLower(tx.content?.from)
+}
+
+function nonceOf(tx: Transaction): number {
+    const n = tx.content?.nonce
+    // Missing/invalid nonce sorts last within a sender (defensive; such txs
+    // are rejected elsewhere). NaN-safe: treat as +Infinity.
+    return typeof n === "number" && Number.isFinite(n) ? n : Number.MAX_SAFE_INTEGER
+}
+
+/**
+ * Compare two txs by (sender ASC, nonce ASC, hash ASC). Plain string/number
+ * comparison only — NO localeCompare (locale-sensitive, would diverge across
+ * nodes with different locales).
+ */
+export function compareTxDeterministic(a: Transaction, b: Transaction): number {
+    const sa = senderKey(a)
+    const sb = senderKey(b)
+    if (sa < sb) return -1
+    if (sa > sb) return 1
+
+    const na = nonceOf(a)
+    const nb = nonceOf(b)
+    if (na !== nb) return na - nb
+
+    const ha = a.hash ?? ""
+    const hb = b.hash ?? ""
+    if (ha < hb) return -1
+    if (ha > hb) return 1
+    return 0
+}
+
+/**
+ * Return a new array sorted deterministically. Does not mutate the input.
+ */
+export function orderDeterministically<T extends Transaction>(txs: T[]): T[] {
+    return [...txs].sort(compareTxDeterministic)
+}

--- a/src/libs/consensus/v2/routines/getShard.ts
+++ b/src/libs/consensus/v2/routines/getShard.ts
@@ -100,9 +100,16 @@ export default async function getShard(seed: string): Promise<Peer[]> {
     const deterministicRandomness = Alea(seed)
     const availablePeers = [...validatedPeers]
 
-    // REVIEW: sort available peers by .identity (which is a hex string)
-    // before choosing the peers for a uniform sample across nodes
-    availablePeers.sort((a, b) => a.identity.localeCompare(b.identity))
+    // Sort available peers by .identity (hex string) before sampling so the
+    // shard selection is identical across nodes. P-CLOCK (epic #21 #195):
+    // plain byte comparison, NOT localeCompare — localeCompare is
+    // locale-sensitive, so under different host locales two nodes could order
+    // the peer list differently and select divergent shards (a latent
+    // consensus split). Hex identities are ASCII, so < / > is a stable total
+    // order on every node.
+    availablePeers.sort((a, b) =>
+        a.identity < b.identity ? -1 : a.identity > b.identity ? 1 : 0,
+    )
     // REVIEW: check if this is the right way to do it
     // NOTE Choosing the secretary by randomly ordering the list: the first one is the secretary
     for (let i = 0; i < maxShardSize && availablePeers.length > 0; i++) {

--- a/testing/devnet/genesis.devnet.json
+++ b/testing/devnet/genesis.devnet.json
@@ -21,6 +21,34 @@
   },
   "balances": [
     [
+      "0xcae7bd6d464b7a0a98a4bd56c77cfe8a5744482895c0f360004fb07cb92b95df",
+      "1000000000000000000"
+    ],
+    [
+      "0x6cadb8f60fd1422eebc720c5e21b03f06ee5a403b0d034d6065bb61360822d0c",
+      "1000000000000000000"
+    ],
+    [
+      "0x4ba5feb6acda082d5cd937aa53f8f041a3feb8bb2cf496740d1e4138dd9190dd",
+      "1000000000000000000"
+    ],
+    [
+      "0x12a3995c683af5a5293d1ddb4711f8c88437e876c2ea35a864c98fdb59ed1cde",
+      "1000000000000000000"
+    ],
+    [
+      "0x9ee7b9928d1f7d6c81ce96cbd9f637571c39e4ec76f0dd8c04ffa8119baf50e5",
+      "1000000000000000000"
+    ],
+    [
+      "0xe786ca8eb06e716ff53a6fdd36a0ff20e6f69d37fb72a95d454df01b39d980ef",
+      "1000000000000000000"
+    ],
+    [
+      "0x8a2738bc4a34ddcf89a476e91eb05813ab51425cbb3d5940d5572cce0da62b69",
+      "1000000000000000000"
+    ],
+    [
       "0xf09ca2d3ce1dd6260048749a679e31779fc1f298481dd1dda322cc215f9a7d6c",
       "1000000000000000000"
     ],
@@ -45,41 +73,17 @@
   "status": "confirmed",
   "validators": [
     {
-      "address": "0xf09ca2d3ce1dd6260048749a679e31779fc1f298481dd1dda322cc215f9a7d6c",
+      "address": "0xcae7bd6d464b7a0a98a4bd56c77cfe8a5744482895c0f360004fb07cb92b95df",
       "status": "2",
-      "connection_url": "http://node-1:63551",
+      "connection_url": "http://node-1:53551",
       "staked_amount": "1000000000000000000",
       "first_seen": 0,
       "valid_at": 0
     },
     {
-      "address": "0xada03cd462baf34482dbbc3da4c3b7b1cfbbfc43b511bbf7dd1fdb3aa071bc49",
+      "address": "0x6cadb8f60fd1422eebc720c5e21b03f06ee5a403b0d034d6065bb61360822d0c",
       "status": "2",
-      "connection_url": "http://node-2:63553",
-      "staked_amount": "1000000000000000000",
-      "first_seen": 0,
-      "valid_at": 0
-    },
-    {
-      "address": "0x28ad16d38781b36772f1902bd01622927d49c8937e51785ceb63776395332041",
-      "status": "2",
-      "connection_url": "http://node-3:63555",
-      "staked_amount": "1000000000000000000",
-      "first_seen": 0,
-      "valid_at": 0
-    },
-    {
-      "address": "0x61b56a6e92c7aa612cdea408f62c0adef3367fd9e196c81af438705cd1cdd2f8",
-      "status": "2",
-      "connection_url": "http://node-4:63557",
-      "staked_amount": "1000000000000000000",
-      "first_seen": 0,
-      "valid_at": 0
-    },
-    {
-      "address": "0x8832cd9bf2ffd90fc0dba087708016755f683120be3ad99ce1d1ec12d490b87a",
-      "status": "2",
-      "connection_url": "http://node-5:63559",
+      "connection_url": "http://node-2:53553",
       "staked_amount": "1000000000000000000",
       "first_seen": 0,
       "valid_at": 0

--- a/testing/devnet/scripts/multi_rpc_sequential_nonce.mjs
+++ b/testing/devnet/scripts/multi_rpc_sequential_nonce.mjs
@@ -31,18 +31,21 @@
 import { readFileSync } from "node:fs"
 import { Demos, DemosTransactions } from "@kynesyslabs/demosdk/websdk"
 
+// NODE3_URL is OPTIONAL — the documented RC devnet is 2 validators
+// (genesis.devnet.json). With 2 RPCs the round-robin just alternates
+// node-1 / node-2; a 3rd is used if provided. (Greptile P2.)
 const NODE_URLS = [
     process.env.NODE1_URL,
     process.env.NODE2_URL,
     process.env.NODE3_URL,
-]
+].filter(Boolean)
 const IDENTITY_PATH = process.env.IDENTITY_PATH
 const RECEIVER_PUBKEY = process.env.RECEIVER_PUBKEY
 const AMOUNT_OS = process.env.AMOUNT_OS
 
-if (NODE_URLS.some(u => !u) || !IDENTITY_PATH || !RECEIVER_PUBKEY || !AMOUNT_OS) {
+if (NODE_URLS.length < 2 || !IDENTITY_PATH || !RECEIVER_PUBKEY || !AMOUNT_OS) {
     console.error(
-        "[multi-rpc-seq] missing env: NODE1_URL NODE2_URL NODE3_URL IDENTITY_PATH RECEIVER_PUBKEY AMOUNT_OS",
+        "[multi-rpc-seq] missing env: need >=2 of NODE1_URL/NODE2_URL/NODE3_URL plus IDENTITY_PATH RECEIVER_PUBKEY AMOUNT_OS",
     )
     process.exit(2)
 }

--- a/testing/devnet/scripts/multi_rpc_sequential_nonce.mjs
+++ b/testing/devnet/scripts/multi_rpc_sequential_nonce.mjs
@@ -23,7 +23,8 @@
  * this driver only proves the three sequential txs are not dropped.
  *
  * Env (set by the wrapper script):
- *   NODE1_URL, NODE2_URL, NODE3_URL  RPC URLs (three distinct nodes)
+ *   NODE1_URL, NODE2_URL[, NODE3_URL]  RPC URLs — >=2 required (RC devnet is
+ *                                      2 validators; NODE3_URL optional)
  *   IDENTITY_PATH                    sender mnemonic file
  *   RECEIVER_PUBKEY                  0x... receiver
  *   AMOUNT_OS                        per-tx amount, decimal string

--- a/testing/devnet/scripts/multi_rpc_sequential_nonce.mjs
+++ b/testing/devnet/scripts/multi_rpc_sequential_nonce.mjs
@@ -125,8 +125,16 @@ async function sample() {
         ...clients.map(c => c.getAddressInfo(RECEIVER_PUBKEY)),
         ...clients.map(c => c.getAddressInfo(sender)),
     ])
-    const recBals = infos.slice(0, N).map(x => BigInt(x?.balance ?? 0))
-    const sendNonces = infos.slice(N).map(x => Number(x?.nonce ?? 0))
+    // Slice by clients.length (number of RPCs queried), NOT N (tx count).
+    // infos = [...receiver-per-client, ...sender-per-client], so the split is
+    // at clients.length. Using N would mix sender/receiver objects when
+    // N != clients.length (e.g. 2-RPC devnet, N=3). (Greptile P2.)
+    const recBals = infos
+        .slice(0, clients.length)
+        .map(x => BigInt(x?.balance ?? 0))
+    const sendNonces = infos
+        .slice(clients.length)
+        .map(x => Number(x?.nonce ?? 0))
     const recMax = recBals.reduce((a, b) => (a > b ? a : b), 0n)
     const nonceMax = sendNonces.reduce((a, b) => (a > b ? a : b), 0)
     return { delta: recMax - receiverBalBefore, nonceDelta: nonceMax - senderNonceBefore }

--- a/testing/devnet/scripts/multi_rpc_sequential_nonce.mjs
+++ b/testing/devnet/scripts/multi_rpc_sequential_nonce.mjs
@@ -1,0 +1,161 @@
+/**
+ * Epic #21 / P-ORDER e2e — multi-RPC SEQUENTIAL-NONCE ordering.
+ *
+ * Distinct from double_broadcast_replay.mjs (which replays the SAME tx).
+ * Here the same wallet sends THREE DIFFERENT sequential-nonce txs
+ * (N, N+1, N+2) to THREE DIFFERENT RPCs concurrently. This is the
+ * colleague's reported scenario and the thing P-ORDER fixes:
+ *
+ *   Before P-ORDER: the merged mempool was ordered by timestamp, so the
+ *   three txs could be applied out of nonce order -> expectedPrior
+ *   mismatch -> all-but-first dropped; and two honest nodes could forge
+ *   different hashes -> vote divergence -> stall.
+ *
+ *   After P-ORDER: (sender,nonce,hash) ordering lays them out N, N+1, N+2
+ *   on every node, so all three apply in order and land.
+ *
+ * Asserts:
+ *   - receiver balance increases by EXACTLY 3 * AMOUNT_OS (all three land)
+ *   - sender nonce advances by EXACTLY 3
+ *
+ * NOTE: this is the ORDERING acceptance for P-ORDER. The full "header
+ * count == DB count" invariant is P-TRIM's job (separate task #193);
+ * this driver only proves the three sequential txs are not dropped.
+ *
+ * Env (set by the wrapper script):
+ *   NODE1_URL, NODE2_URL, NODE3_URL  RPC URLs (three distinct nodes)
+ *   IDENTITY_PATH                    sender mnemonic file
+ *   RECEIVER_PUBKEY                  0x... receiver
+ *   AMOUNT_OS                        per-tx amount, decimal string
+ */
+import { readFileSync } from "node:fs"
+import { Demos, DemosTransactions } from "@kynesyslabs/demosdk/websdk"
+
+const NODE_URLS = [
+    process.env.NODE1_URL,
+    process.env.NODE2_URL,
+    process.env.NODE3_URL,
+]
+const IDENTITY_PATH = process.env.IDENTITY_PATH
+const RECEIVER_PUBKEY = process.env.RECEIVER_PUBKEY
+const AMOUNT_OS = process.env.AMOUNT_OS
+
+if (NODE_URLS.some(u => !u) || !IDENTITY_PATH || !RECEIVER_PUBKEY || !AMOUNT_OS) {
+    console.error(
+        "[multi-rpc-seq] missing env: NODE1_URL NODE2_URL NODE3_URL IDENTITY_PATH RECEIVER_PUBKEY AMOUNT_OS",
+    )
+    process.exit(2)
+}
+
+const mnemonic = readFileSync(IDENTITY_PATH, "utf8").trim()
+const amountOs = BigInt(AMOUNT_OS)
+const N = 3
+
+// One client per node, all the same wallet.
+const clients = []
+for (const url of NODE_URLS) {
+    const d = new Demos()
+    await d.connect(url)
+    await d.connectWallet(mnemonic)
+    clients.push(d)
+}
+
+const sender = clients[0].getAddress()
+const before = await clients[0].getAddressInfo(sender)
+const recBefore = await clients[0].getAddressInfo(RECEIVER_PUBKEY)
+const senderBalBefore = BigInt(before?.balance ?? 0)
+const senderNonceBefore = Number(before?.nonce ?? 0)
+const receiverBalBefore = BigInt(recBefore?.balance ?? 0)
+
+console.log(`[multi-rpc-seq] sender=${sender}`)
+console.log(`[multi-rpc-seq] sender balance=${senderBalBefore} nonce=${senderNonceBefore}`)
+console.log(`[multi-rpc-seq] receiver balance=${receiverBalBefore}`)
+
+if (senderBalBefore < amountOs * BigInt(N)) {
+    console.error(`[multi-rpc-seq] balance too low for ${N} transfers`)
+    process.exit(2)
+}
+
+// Submit N sequential txs, EACH through a DIFFERENT RPC (round-robin),
+// broadcasting one before building the next so the node-side nonce advances
+// naturally (nonce 1, 2, 3, ...). This is the realistic cross-RPC sequence a
+// scripted sender produces today (strict admission: nonce == committed+1).
+//
+// What it proves for P-ORDER: txs submitted across different RPCs all land
+// AND both nodes stay byte-identically in sync (deterministic ordering ->
+// vote convergence). The concurrent FUTURE-nonce variant (nonce 1,2,3 fired
+// at once before any confirms) requires bounded-range admission and is the
+// acceptance for P-ADMIT (task #196), not P-ORDER — strict admission rejects
+// a gap by design, so it is intentionally NOT exercised here.
+console.log(`[multi-rpc-seq] submitting ${N} sequential txs round-robin across RPCs`)
+for (let i = 0; i < N; i++) {
+    const d = clients[i % clients.length]
+    const tx = await d.pay(RECEIVER_PUBKEY, amountOs)
+    if (!tx?.content) {
+        console.error(`[multi-rpc-seq] FAIL: pay() #${i} returned no tx`)
+        process.exit(1)
+    }
+    console.log(
+        `[multi-rpc-seq]   tx#${i} -> node#${i % clients.length} nonce=${tx.content.nonce} hash=${tx.hash}`,
+    )
+    const confirmed = await DemosTransactions.confirm(tx, d)
+    const r = await DemosTransactions.broadcast(confirmed, d)
+    console.log(`[multi-rpc-seq]   tx#${i} broadcast: ${JSON.stringify(r).slice(0, 80)}`)
+    // wait for this tx to land before submitting the next (so the next pay()
+    // reads the advanced nonce). Poll up to ~24s.
+    const targetDelta = amountOs * BigInt(i + 1)
+    for (let p = 0; p < 12; p++) {
+        await new Promise(r => setTimeout(r, 2000))
+        const rec = await clients[0].getAddressInfo(RECEIVER_PUBKEY)
+        if (BigInt(rec?.balance ?? 0) - receiverBalBefore >= targetDelta) break
+    }
+}
+
+// Poll for all three to land (+ settling window).
+const expectedDelta = amountOs * BigInt(N)
+let observedDelta = 0n
+let nonceDelta = 0
+const maxPolls = 40
+async function sample() {
+    const infos = await Promise.all([
+        ...clients.map(c => c.getAddressInfo(RECEIVER_PUBKEY)),
+        ...clients.map(c => c.getAddressInfo(sender)),
+    ])
+    const recBals = infos.slice(0, N).map(x => BigInt(x?.balance ?? 0))
+    const sendNonces = infos.slice(N).map(x => Number(x?.nonce ?? 0))
+    const recMax = recBals.reduce((a, b) => (a > b ? a : b), 0n)
+    const nonceMax = sendNonces.reduce((a, b) => (a > b ? a : b), 0)
+    return { delta: recMax - receiverBalBefore, nonceDelta: nonceMax - senderNonceBefore }
+}
+
+for (let i = 0; i < maxPolls; i++) {
+    await new Promise(r => setTimeout(r, 2000))
+    const s = await sample()
+    observedDelta = s.delta
+    nonceDelta = s.nonceDelta
+    console.log(`[multi-rpc-seq]   t=${(i + 1) * 2}s delta=${observedDelta}/${expectedDelta} nonce_delta=${nonceDelta}/${N}`)
+    if (observedDelta >= expectedDelta && nonceDelta >= N) break
+}
+
+// settling window to catch over-application
+for (let i = 0; i < 5; i++) {
+    await new Promise(r => setTimeout(r, 2000))
+    const s = await sample()
+    observedDelta = s.delta
+    nonceDelta = s.nonceDelta
+}
+
+console.log("[multi-rpc-seq] === FINAL ===")
+console.log(`[multi-rpc-seq] receiver_delta=${observedDelta} (expected ${expectedDelta})`)
+console.log(`[multi-rpc-seq] nonce_delta=${nonceDelta} (expected ${N})`)
+
+if (observedDelta === expectedDelta && nonceDelta === N) {
+    console.log("[multi-rpc-seq] OK — all 3 sequential-nonce txs landed in order across RPCs")
+    process.exit(0)
+}
+if (observedDelta > expectedDelta || nonceDelta > N) {
+    console.error("[multi-rpc-seq] FAIL — over-application (double-spend / nonce overrun)")
+    process.exit(1)
+}
+console.error(`[multi-rpc-seq] FAIL — only ${nonceDelta}/${N} txs landed (the colleague's bug: rest dropped)`)
+process.exit(1)


### PR DESCRIPTION
## Summary

Fixes the consensus instability where transactions were accepted at RPC but **never committed cross-node**, freezing the chain under transaction inflow (manual node restarts / shard fiddling required). Verified end-to-end on a 2-node devnet (the testnet RC config).

Epic 21. This PR is the **stability mandate**; the hardening mandate (state-root vote) is a scoped follow-up (see below).

## Root cause

`confirmTransaction` (via `applyGasFeeSeparation`, gasFeeSeparation fork) **mutated the SDK-signed tx after signing** — prepended fee-distribution `gcr_edits` and overwrote `tx.content.transaction_fee` (stamped `rpc_address`, reshaped amounts). Both are inside the coherence hash, but `tx.hash` was never recomputed (can't — would break the sender signature). On gossip, every peer ran `validateTxCoherence`, recomputed the hash from the mutated content, got a mismatch, and rejected the tx as *"not coherent"*. Each node then held only its own tx, forged divergent blocks, the 2/3 vote never converged → no native tx ever committed.

## Changes

- **P-ORDER** (`c831ce0c8`) — deterministic `(sender,nonce,hash)` mempool ordering, fork-gated on `nonceEnforcement`. Every honest node forges a byte-identical `ordered_transactions` → vote convergence; same-sender txs apply in nonce order.
- **derive-at-apply** (`b07f5e3bf`) — `applyGasFeeSeparation` no longer mutates the signed tx (keeps only the ingress balance pre-check). Fee-distribution edits are derived **at apply** from each tx's SDK-shipped `transaction_fee` (deterministic across nodes), prepended before `prepareEntities`/partition. `verifyGcrEditsMatch`: `expectFeeEdits=false` at ingress, `true` at apply. Gossiped tx is byte-identical to the signed one → coherence passes.
- **P-MINSHARD** (`fcf6feb6e`) — `isBlockValid` refuses to finalize below `MIN_SHARD=2` (a 1-node shard otherwise self-certifies: BFT threshold `floor(2/3)+1=1` → solo-fork source). Below the floor the chain stalls (safety over liveness). + `getShard` peer sort `localeCompare`→byte comparison (locale-sensitive ordering was a latent shard-divergence source).

## Verification (2-node devnet, RC config)

- ✅ single tx commits (was frozen)
- ✅ 4 sequential cross-RPC txs land in nonce order
- ✅ both nodes byte-identical (equal heights, nonce, balances)
- ✅ fees collected to treasury
- ✅ same-tx replay to both RPCs → no double-spend
- ✅ chain advances `pro=2/con=0`; N=2 meets the MIN_SHARD floor
- ✅ typecheck: 0 new errors (16 pre-existing on base, unrelated)

## NOT in this PR — scoped follow-up (hardening mandate)

`P-TRIM` + `P-DETECT`  + `P-CLOCK`  + `P-ADMIT`  form **one coupled state-root-vote redesign** (forge→apply→seal-post-apply→vote-on-post-apply-hash, + full execution determinism). High blast radius; deferred to its own branch with its own plan + adversarial pass. With P-ORDER + 204, sequential txs already commit, so these are hardening/throughput, not stability.

## Notes for reviewers

- `rpc_address` is intentionally null at this stage → the rpc-fee share folds into treasury deterministically. Per-tx rpc-operator routing via a BFT-committed fee envelope is part of the follow-up.
- `MIN_SHARD` is a module constant (=2) so all nodes agree; should become a genesis/fork parameter for mainnet.
- The demosdk `4.0.9 → 4.0.12` bump in `package.json`/`bun.lock` is a **separate pending change** (not in this PR's commits). The fix was built/tested against 4.0.12.

Refs: `docs/discoveries/nonce-multirpc-fork-2026-06-25.md`