### PR TITLE
feat(rpc): add getAddressPendingNonce (mempool-aware next nonce)

### DIFF
--- a/src/libs/network/handlers/identityHandlers.ts
+++ b/src/libs/network/handlers/identityHandlers.ts
@@ -11,6 +11,7 @@ import type { DiscordMessage } from "../../identity/tools/discord"
 import log from "src/utilities/logger"
 import type { NodeCallHandler } from "./types"
 import GCR from "@/libs/blockchain/gcr/gcr"
+import Mempool from "@/libs/blockchain/mempool"
 
 export const identityHandlers: Record<string, NodeCallHandler> = {
     getAddressInfo: async (data, response) => {
@@ -39,6 +40,35 @@ export const identityHandlers: Record<string, NodeCallHandler> = {
             return response
         }
         response.response = await GCR.getAccountNonce(data.address)
+        return response
+    },
+
+    // Mempool-aware next nonce: the value a client should place directly in
+    // `tx.content.nonce`. `getAddressNonce` returns only the confirmed nonce,
+    // which lags inclusion — so rapid/batch sends from one address all read
+    // the same value and collide (assignNonce hard-rejects the duplicates).
+    // This returns exactly what assignNonce expects:
+    //     account.nonce + 1 + pendingMempoolCount
+    // (see validateTransaction.assignNonce). Address is lowercased to match
+    // the canonicalisation there. Pure read — no account provisioning.
+    getAddressPendingNonce: async (data, response) => {
+        if (!data.address) {
+            response.result = 400
+            response.response = "No address specified"
+            return response
+        }
+        try {
+            const address = String(data.address).toLowerCase()
+            const confirmedNonce = await GCR.getAccountNonce(address)
+            const pendingCount = await Mempool.countPendingByAddress(address)
+            response.response = confirmedNonce + 1 + pendingCount
+        } catch (error) {
+            response.result = 400
+            response.response = "error"
+            response.extra = {
+                message: error instanceof Error ? error.message : String(error),
+            }
+        }
         return response
     },
 


### PR DESCRIPTION
## Why

`getAddressNonce` returns only the **confirmed** account nonce (`gcr_main.nonce`), which lags inclusion. So when a client sends several txs from one address in quick succession, every `getAddressNonce()+1` reads the same value → they all claim the same nonce → `assignNonce` hard-rejects the duplicates. This is the batch-send failure the DACS Directory team hit, and there is currently **no** client-facing way to learn the next usable nonce.

The node already computes the correct value internally in `assignNonce`:

```
expected = account.nonce + 1 + pendingMempoolCount   // validateTransaction.ts
```

…but never exposes it. This PR exposes exactly that value.

## What

A new read-only RPC handler `getAddressPendingNonce` in `identityHandlers`:

```ts
const address = String(data.address).toLowerCase()
const confirmedNonce = await GCR.getAccountNonce(address)      // pure findOne, no provisioning
const pendingCount   = await Mempool.countPendingByAddress(address)
response.response    = confirmedNonce + 1 + pendingCount        // == assignNonce's `expected`
```

A client places this straight into `tx.content.nonce` (semantics of eth `getTransactionCount('pending')`) and can sequence a batch without collisions.

## Why it's safe

- **Read-only.** No writes, no consensus surface, **no fork gate** — it only surfaces a number the node already derives.
- **No side-effects.** Uses `GCR.getAccountNonce` (a pure `findOne`, returns 0 for unknown) — unlike `getAddressInfo`/`ensureGCRForUser` it does **not** provision a phantom account on a read.
- **Exact match to enforcement.** Same formula and same lowercase canonicalisation as `assignNonce`, so the returned value is precisely what the node will accept. Reuses the existing `Mempool.countPendingByAddress` (same query, same `referenceBlockRoom` window).
- **Auto-registered** via the `...identityHandlers` spread in `handlerRegistry`.

## Compatibility

Pairs with the SDK auto-nonce manager (kynesyslabs/sdks#108), which calls this RPC and **falls back to `getAddressNonce()+1` on nodes that don't have this handler** — so the two can ship independently.

## Follow-up (optional)

Binary/omniprotocol opcode parity (mirroring `gcr_getAddressNonce` `0x4b`) — not required for the SDK's HTTP `nodeCall` path; can be added later.

## Test notes

Type-clean (`tsc --noEmit` reports nothing on the changed file). Runtime behaviour is a pure composition of two already-tested primitives; a live-node integration check is best done on the testnet deploy.