### PR TITLE
docs(tlsnotary): explicit notary-port proxy block + $is_args$args gotcha

### DIFF
--- a/docs/runbooks/tlsn-reverse-proxy.md
+++ b/docs/runbooks/tlsn-reverse-proxy.md
@@ -16,10 +16,12 @@ This is required on **every** node that serves TLSN to a browser. The node image
 port range are repo-managed; the reverse proxy is the only piece an operator may
 need to touch by hand.
 
-## ⚠️ The one non-obvious gotcha
+## ⚠️ Two non-obvious gotchas
 
-**`wstcp` 0.2.1 checks the `Connection` header case-sensitively** — it requires
-`Connection: Upgrade` (capital U). The common nginx snippet uses
+Both produce the **same** browser symptom — `CloseEvent 1006` — so check both.
+
+**1. `Connection: Upgrade` must be capital-U.** `wstcp` 0.2.1 checks the
+`Connection` header case-sensitively. The common nginx snippet uses
 `proxy_set_header Connection "upgrade";` (lowercase), which `wstcp` rejects:
 
 ```
@@ -28,6 +30,19 @@ Invalid WebSocket handshake request: assertion failed: `values.any(|v| v.trim() 
 
 → the handshake never completes, every `/tlsn/<port>/` 502s, and the browser sees
 `CloseEvent 1006`. Use **capital `Upgrade`**.
+
+**2. The query string must be forwarded (`$is_args$args`).** The notary reads its
+`sessionId` from the URL query (`/tlsn/<notary-port>/notarize?sessionId=…`). An
+nginx `proxy_pass` that rebuilds the path as `…/$2;` **without** `$is_args$args`
+drops the query on the WebSocket upgrade. The notary then answers:
+
+```
+Failed to deserialize query string: missing field `sessionId`
+```
+
+→ the upgrade fails and the browser sees `CloseEvent 1006`. The tell that it's
+*this* one (not the casing bug): `/tlsn/<notary-port>/info` still returns `200`
+while `notarize` fails. **This bit prod once — keep `$is_args$args`.**
 
 ## Caddy (repo-managed — automatic)
 
@@ -42,10 +57,17 @@ Add this `location` inside the node's `listen 443 ssl; server_name <domain>;`
 block, then `sudo nginx -t && sudo systemctl reload nginx`:
 
 ```nginx
-# Dynamic wstcp TLSNotary proxies: /tlsn/<port>/ -> 127.0.0.1:<port>
-# The 5[567]\d{3} class restricts to the 55000-57999 allocation window so this
-# can't be used to reach arbitrary node ports (RPC 53550, MCP 3001, ...).
-location ~ ^/tlsn/(5[567]\d{3})/?(.*)$ {
+# /tlsn/<port>/ -> 127.0.0.1:<port> — ONE block for the notary AND the wstcp
+# proxies. The explicit port class is a security control: a bare `(\d+)`
+# catch-all would let /tlsn/<port>/ reach any loopback port (RPC 53550,
+# MCP 3001, ...). Keep it tight.
+#   7047 / 7147  = the TLSNotary notary (TLSNOTARY_PORT; 7047 main/testnet,
+#                  7147 devnet). Add your value here if you changed it.
+#   5[567]\d{3}  = the 55000-57999 wstcp allocation window.
+location ~ ^/tlsn/(7047|7147|5[567]\d{3})/?(.*)$ {
+    # $is_args$args is REQUIRED — the notary reads sessionId from the query
+    # (…/notarize?sessionId=…). Drop it and every notarize upgrade dies with
+    # `CloseEvent 1006` (gotcha #2 above).
     proxy_pass http://127.0.0.1:$1/$2$is_args$args;
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;
@@ -55,8 +77,11 @@ location ~ ^/tlsn/(5[567]\d{3})/?(.*)$ {
 }
 ```
 
-If the notary port is outside `55000-57999` (e.g. `7047`/`7147`), give it its own
-`location = /tlsn/<notary-port>/ { ... }` block, or widen the class accordingly.
+The notary port is already covered by the class above. If your `TLSNOTARY_PORT`
+is non-default, add it to the alternation
+(`^/tlsn/(<your-port>|7047|7147|5[567]\d{3})/…`). **Do not** replace this with a
+bare `^/tlsn/(\d+)/` catch-all: it reaches every loopback port *and* is the shape
+that tends to lose `$is_args$args` — both failure modes have hit prod.
 
 Prerequisites (both already handled by deploying this branch):
 
@@ -79,6 +104,20 @@ curl -s -o /dev/null -w '%{http_code}\n' -k \
 
 `101` → routing + upgrade are correct. `502` → the location is missing, the port
 isn't published/reachable, or `Connection` is lowercase.
+
+Notary query-string check (catches gotcha #2) — send an upgrade with a bogus
+`sessionId` and read what the notary says:
+
+```bash
+curl -sk -H "Connection: Upgrade" -H "Upgrade: websocket" \
+  -H "Sec-WebSocket-Version: 13" -H "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==" \
+  "https://<node-domain>/tlsn/<notary-port>/notarize?sessionId=x"
+```
+
+- `Session id x does not exist` → the query reached the notary; **good**.
+- `missing field sessionId` → the proxy is dropping the query, you're missing
+  `$is_args$args`. (`/tlsn/<notary-port>/info` returning `200` alongside this
+  confirms the route is otherwise fine.)
 
 ## Note: HTTPS RPC
 


### PR DESCRIPTION
## Why

A node2 redeploy dropped the TLSN notary WebSocket with `CloseEvent 1006` (attest broken in the browser). Root cause traced live on the box:

- The route was fine — `/tlsn/7047/info` returned `200`.
- But on the **WebSocket upgrade**, the `?sessionId=` query was dropped, so the notary answered `Failed to deserialize query string: missing field sessionId` → 1006.
- The live nginx block serving node2 was a hand-added catch-all `^/tlsn/(\d+)/` with `proxy_pass http://127.0.0.1:$1/$2;` — **no `$is_args$args`**.

Why the config got there: this runbook gave the correct wstcp-range block but only **vague guidance** for the notary port (7047, outside `55000-57999`) — *"give it its own block, or widen the class accordingly."* So the notary block was hand-rolled and lost `$is_args$args`. The bare `(\d+)` catch-all is also a security hole (reaches any loopback port — RPC 53550, MCP 3001, …), which the `5[567]\d{3}` restriction existed to prevent.

## What changed (docs only)

- **One explicit port class** `^/tlsn/(7047|7147|5[567]\d{3})/…` covering the notary *and* wstcp ports — so there's a copy-paste-correct block and no separate notary block to get wrong.
- **`$is_args$args` documented as a required, prod-breaking gotcha (#2)**, next to the existing `Connection` casing one — both give the identical `CloseEvent 1006`, so the runbook now says to check both.
- **Explicit warning against the bare `(\d+)` catch-all** (port reach + the query-drop shape).
- **A notary query-string verification curl** that distinguishes "query reached the notary" (`Session id x does not exist`) from "query dropped" (`missing field sessionId`).

## Immediate action (separate from this doc)

DevOps applied the one-line fix on node2 live (add `$is_args$args` to the offending block). This PR hardens the runbook so the next redeploy can't reintroduce it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified TLSN reverse-proxy setup guidance for WebSocket connections.
  * Added troubleshooting notes for common `1006` disconnects related to header formatting and query-string forwarding.
  * Reworked nginx routing recommendations to use a more specific path pattern and support non-default notary ports.
  * Added a verification step to confirm query parameters are passed through correctly during WebSocket upgrade requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->