### PR TITLE
fix(web2): stop stamping an empty Authorization on every proxied request

### DIFF
--- a/src/features/web2/proxy/Proxy.test.ts
+++ b/src/features/web2/proxy/Proxy.test.ts
@@ -1,0 +1,77 @@
+// Importing Proxy pulls the node runtime in (SharedState -> chain -> logger ->
+// PeerManager). Both config objects are passed explicitly below, so none of it
+// is actually exercised — stub the modules so the suite stays a unit test.
+jest.mock("@/utilities/sharedState", () => ({
+    __esModule: true,
+    default: { getInstance: () => ({ PROD: false }) },
+}))
+jest.mock("@/utilities/logger", () => ({
+    __esModule: true,
+    default: { error: jest.fn(), info: jest.fn(), warn: jest.fn(), debug: jest.fn() },
+}))
+jest.mock("src/libs/crypto/hashing", () => ({
+    __esModule: true,
+    default: { sha256: (v: string) => v },
+}))
+
+import { Proxy } from "./Proxy"
+
+/**
+ * Build a Proxy with both config objects supplied so construction never reaches
+ * SharedState — these tests are about header shaping, not runtime environment.
+ */
+function makeProxy(requireAuthForAll: boolean) {
+    return new Proxy(
+        "test-session-id",
+        "localhost",
+        { requireAuthForAll, exceptions: [] },
+        { verifyCertificates: false },
+    )
+}
+
+/** `createHeaders` is private; TS visibility is compile-time only. */
+function headersFor(
+    proxy: Proxy,
+    targetAuthorization: string,
+): Record<string, string> {
+    return (proxy as any).createHeaders(
+        "GET",
+        {},
+        targetAuthorization,
+    ) as Record<string, string>
+}
+
+describe("Proxy outbound Authorization header", () => {
+    it("is omitted when the caller supplied no token, even in production", () => {
+        // The regression: `requireAuthForAll` is true on production, and the
+        // outbound header used to be keyed on it. Every proxied request then
+        // carried `Bearer undefined`, which GitHub rejects (401 on
+        // api.github.com, 404 on raw.githubusercontent.com) while permissive
+        // targets like httpbin ignore it — hence "DAHR works but GitHub 401s".
+        const headers = headersFor(makeProxy(true), "")
+
+        expect(headers).not.toHaveProperty("Authorization")
+        expect(Object.values(headers).join(" ")).not.toContain("undefined")
+    })
+
+    it("forwards the token the caller did supply", () => {
+        const headers = headersFor(makeProxy(true), "ghp_realtoken")
+
+        expect(headers["Authorization"]).toBe("Bearer ghp_realtoken")
+    })
+
+    it("forwards a supplied token off production too, rather than dropping it", () => {
+        // Keying the header on the inbound-access flag also meant a token
+        // passed in development was silently discarded.
+        const headers = headersFor(makeProxy(false), "ghp_realtoken")
+
+        expect(headers["Authorization"]).toBe("Bearer ghp_realtoken")
+    })
+
+    it("still stamps the session id that gates inbound proxy access", () => {
+        // The inbound control must be untouched by the outbound change.
+        expect(headersFor(makeProxy(true), "")["x-dahr-session-id"]).toBe(
+            "test-session-id",
+        )
+    })
+})

--- a/src/features/web2/proxy/Proxy.ts
+++ b/src/features/web2/proxy/Proxy.ts
@@ -78,7 +78,6 @@ export class Proxy {
                 targetMethod,
                 targetHeaders,
                 targetAuthorization,
-                targetUrl,
             )
 
             const req = http.request({
@@ -429,7 +428,6 @@ export class Proxy {
         targetMethod: Web2Method,
         targetHeaders: IWeb2Request["raw"]["headers"],
         targetAuthorization: string,
-        targetUrl: string,
     ): IWeb2Request["raw"]["headers"] {
         // Base headers - only essential ones
         const headers: IWeb2Request["raw"]["headers"] = {
@@ -461,8 +459,14 @@ export class Proxy {
             headers["Accept-Encoding"] = "identity"
         }
 
-        // Add Authorization if required
-        if (this.requiresAuthorization(targetUrl, targetMethod)) {
+        // Only forward an Authorization the caller actually supplied.
+        // `requireAuthForAll` governs INBOUND access to this proxy (the
+        // x-dahr-session-id check in isAuthorizedRequest) and says nothing
+        // about what the target site should receive. Keying the outbound
+        // header on it stamps `Bearer undefined` onto every proxied request,
+        // which any site that validates the header rejects — GitHub answers
+        // 401 on api.github.com and 404 on raw.githubusercontent.com.
+        if (targetAuthorization) {
             headers["Authorization"] = `Bearer ${targetAuthorization}`
         }
 
@@ -510,20 +514,5 @@ export class Proxy {
         }
         entries.sort((a, b) => (a.key < b.key ? -1 : a.key > b.key ? 1 : 0))
         return entries.map(e => `${e.key}:${e.value}`).join("\n")
-    }
-
-    private requiresAuthorization(url: string, method: Web2Method): boolean {
-        if (this._authConfig.requireAuthForAll) {
-            for (const exception of this._authConfig.exceptions) {
-                if (
-                    exception.urlPattern.test(url) &&
-                    exception.methods.includes(method)
-                ) {
-                    return false
-                }
-            }
-            return true
-        }
-        return false
     }
 }


### PR DESCRIPTION
Fixes #959.

## Root cause

Not a stale token, as the report guessed — the proxy sends an Authorization header nobody asked for.

The outbound `Authorization` header was keyed on `requireAuthForAll`. That flag actually governs **inbound** access to the DAHR proxy — the `x-dahr-session-id` check in `isAuthorizedRequest` — and says nothing about what the target site should receive. It defaults to `SharedState.PROD`, so on the public testnet every proxied request went out carrying `Bearer undefined`, whether or not the caller supplied a token (`exceptions` is empty by default, so nothing was exempt).

That explains both reported symptoms and why DAHR looked healthy:

- `https://httpbin.org/get` → **200**, because permissive targets ignore a bogus Authorization header
- `api.github.com` → **401 "Bad credentials"**, because GitHub validates it
- `raw.githubusercontent.com` → **404**, GitHub's answer to invalid auth on raw content

It also meant a token passed off production was silently dropped, since the flag is false there.

## Fix

Forward the header only when the caller actually supplied a token. The inbound session-id control is untouched — `isAuthorizedRequest` still gates access to the proxy exactly as before. The outbound gate `requiresAuthorization` had no other caller and is removed, along with the now-unused `targetUrl` parameter.

## Tests

New `Proxy.test.ts` (there was no proxy coverage at all). Verified non-vacuous: restoring the unconditional injection makes the first case fail.

- no token + production flag → no Authorization header, and nothing containing `undefined`
- token supplied → `Bearer <token>`
- token supplied off production → still forwarded, not dropped
- the inbound `x-dahr-session-id` header is still stamped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Authorization headers are now forwarded only when explicitly provided by the caller.
  * Requests without a supplied token no longer receive an unintended authorization header.
  * Session identification headers continue to be included correctly.

* **Tests**
  * Added coverage for authorization behavior across production and non-production proxy configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->