### PR TITLE
fix(l2ps-messaging): canonicalize peer identity — address #978 review

### DIFF
--- a/src/features/l2ps-messaging/L2PSMessagingServer.ts
+++ b/src/features/l2ps-messaging/L2PSMessagingServer.ts
@@ -32,6 +32,17 @@ interface WSData {
     l2psUid: string | null
 }
 
+/**
+ * Canonical peer identity: strip an optional 0x/0X prefix and lowercase, so the
+ * same ed25519 key resolves to one identity regardless of how a client formats it.
+ * Used for every identity/lookup — NOT for the signed proof, which the client
+ * produced over its own representation of the key.
+ */
+export function canonicalizeKey(key: string): string {
+    const stripped = key.startsWith("0x") || key.startsWith("0X") ? key.slice(2) : key
+    return stripped.toLowerCase()
+}
+
 export class L2PSMessagingServer {
     private peers = new Map<string, ConnectedPeer>()
     // Bun.Server / Bun.serve dropped the WSData generic; the cast on
@@ -129,9 +140,12 @@ export class L2PSMessagingServer {
             return
         }
 
-        // Accept an optional 0x prefix; the SDK address/signature are 0x-prefixed.
-        const publicKeyHex = publicKey.startsWith("0x") ? publicKey.slice(2) : publicKey
-        if (publicKeyHex.length < MIN_PUBLIC_KEY_LENGTH || !/^[0-9a-fA-F]+$/.test(publicKeyHex)) {
+        // Canonicalise the key (strip 0x/0X, lowercase) so `0xABCD`, `0Xabcd` and
+        // `abcd` all resolve to one peer identity — otherwise the same key
+        // registers as two peers. The raw `publicKey` is kept only for the proof
+        // message below, which the client signed over its own representation.
+        const canonicalKey = canonicalizeKey(publicKey)
+        if (canonicalKey.length < MIN_PUBLIC_KEY_LENGTH || !/^[0-9a-f]+$/.test(canonicalKey)) {
             this.sendError(ws, "INVALID_MESSAGE", "Invalid publicKey format (expected hex)", msg.requestId)
             return
         }
@@ -161,17 +175,17 @@ export class L2PSMessagingServer {
             return
         }
 
-        // Remove old connection if re-registering
-        const existing = this.peers.get(publicKey)
+        // Remove old connection if re-registering (canonical identity)
+        const existing = this.peers.get(canonicalKey)
         if (existing) {
             try { (existing.ws as ServerWebSocket<WSData>).close() } catch {}
         }
 
-        // Register peer
-        ws.data.publicKey = publicKey
+        // Register peer under the canonical identity
+        ws.data.publicKey = canonicalKey
         ws.data.l2psUid = l2psUid
-        this.peers.set(publicKey, {
-            publicKey,
+        this.peers.set(canonicalKey, {
+            publicKey: canonicalKey,
             l2psUid,
             ws,
             connectedAt: Date.now(),
@@ -179,13 +193,13 @@ export class L2PSMessagingServer {
 
         // Get online peers in the same L2PS network
         const onlinePeers = Array.from(this.peers.values())
-            .filter(p => p.l2psUid === l2psUid && p.publicKey !== publicKey)
+            .filter(p => p.l2psUid === l2psUid && p.publicKey !== canonicalKey)
             .map(p => p.publicKey)
 
         // Send registration confirmation
         this.send(ws, {
             type: "registered",
-            payload: { success: true, publicKey, l2psUid, onlinePeers },
+            payload: { success: true, publicKey: canonicalKey, l2psUid, onlinePeers },
             timestamp: Date.now(),
             requestId: msg.requestId,
         })
@@ -196,16 +210,16 @@ export class L2PSMessagingServer {
             if (peer) {
                 this.send(peer.ws as ServerWebSocket<WSData>, {
                     type: "peer_joined",
-                    payload: { publicKey },
+                    payload: { publicKey: canonicalKey },
                     timestamp: Date.now(),
                 })
             }
         }
 
         // Deliver queued messages
-        await this.deliverQueuedMessages(ws, publicKey, l2psUid)
+        await this.deliverQueuedMessages(ws, canonicalKey, l2psUid)
 
-        log.info(`[L2PS-IM] Peer registered: ${publicKey.slice(0, 12)}... on ${l2psUid}`)
+        log.info(`[L2PS-IM] Peer registered: ${canonicalKey.slice(0, 12)}... on ${l2psUid}`)
     }
 
     // ─── Send Message ────────────────────────────────────────────
@@ -222,6 +236,7 @@ export class L2PSMessagingServer {
             this.sendError(ws, "INVALID_MESSAGE", "Missing to, encrypted, or messageHash", msg.requestId)
             return
         }
+        const toKey = canonicalizeKey(to) // canonical recipient identity for routing
 
         if (!encrypted.ciphertext || !encrypted.nonce) {
             this.sendError(ws, "INVALID_MESSAGE", "Encrypted payload must have ciphertext and nonce", msg.requestId)
@@ -233,19 +248,19 @@ export class L2PSMessagingServer {
             return
         }
 
-        if (to === senderKey) {
+        if (toKey === senderKey) {
             this.sendError(ws, "INVALID_MESSAGE", "Cannot send message to yourself", msg.requestId)
             return
         }
 
         const l2psUid = ws.data.l2psUid!
         const messageId = crypto.randomUUID()
-        const recipientPeer = this.peers.get(to)
+        const recipientPeer = this.peers.get(toKey)
         const recipientOnline = !!recipientPeer && recipientPeer.l2psUid === l2psUid
 
         // Process through service (DB + L2PS mempool) before delivering
         const result = await this.service.processMessage(
-            senderKey, to, l2psUid, messageId, messageHash, encrypted, recipientOnline,
+            senderKey, toKey, l2psUid, messageId, messageHash, encrypted, recipientOnline,
         )
 
         if (!result.success) {
@@ -363,8 +378,8 @@ export class L2PSMessagingServer {
             return
         }
 
-        // Only return peers in the same L2PS network
-        const peer = this.peers.get(targetId)
+        // Only return peers in the same L2PS network (canonical lookup)
+        const peer = this.peers.get(canonicalizeKey(targetId))
         const sameNetwork = peer && peer.l2psUid === ws.data.l2psUid
         this.send(ws, {
             type: "public_key_response",

--- a/src/features/l2ps-messaging/L2PSMessagingServer.ts
+++ b/src/features/l2ps-messaging/L2PSMessagingServer.ts
@@ -172,7 +172,13 @@ export class L2PSMessagingServer {
         // Remove old connection if re-registering (canonical identity)
         const existing = this.peers.get(canonicalKey)
         if (existing) {
-            try { (existing.ws as ServerWebSocket<WSData>).close() } catch {}
+            // Closing an already-dead socket can throw; we're replacing this
+            // connection regardless, so a close failure here is irrelevant.
+            try {
+                (existing.ws as ServerWebSocket<WSData>).close()
+            } catch {
+                /* replaced regardless — ignore */
+            }
         }
 
         // Register peer under the canonical identity

--- a/src/features/l2ps-messaging/L2PSMessagingServer.ts
+++ b/src/features/l2ps-messaging/L2PSMessagingServer.ts
@@ -11,6 +11,7 @@ import { getSharedState } from "@/utilities/sharedState"
 import log from "@/utilities/logger"
 import ParallelNetworks from "@/libs/l2ps/parallelNetworks"
 import { L2PSMessagingService } from "./L2PSMessagingService"
+import { canonicalizeKey } from "./keys"
 import type {
     ConnectedPeer,
     ProtocolFrame,
@@ -32,16 +33,9 @@ interface WSData {
     l2psUid: string | null
 }
 
-/**
- * Canonical peer identity: strip an optional 0x/0X prefix and lowercase, so the
- * same ed25519 key resolves to one identity regardless of how a client formats it.
- * Used for every identity/lookup — NOT for the signed proof, which the client
- * produced over its own representation of the key.
- */
-export function canonicalizeKey(key: string): string {
-    const stripped = key.startsWith("0x") || key.startsWith("0X") ? key.slice(2) : key
-    return stripped.toLowerCase()
-}
+// Re-exported from ./keys so external callers (and tests) keep importing it
+// from the server module; the service imports it from ./keys directly.
+export { canonicalizeKey }
 
 export class L2PSMessagingServer {
     private peers = new Map<string, ConnectedPeer>()
@@ -216,8 +210,10 @@ export class L2PSMessagingServer {
             }
         }
 
-        // Deliver queued messages
-        await this.deliverQueuedMessages(ws, canonicalKey, l2psUid)
+        // Deliver queued messages. Pass the raw registration key too so rows
+        // queued by an earlier build under a non-canonical recipient key are
+        // still recovered on reconnect.
+        await this.deliverQueuedMessages(ws, canonicalKey, l2psUid, publicKey)
 
         log.info(`[L2PS-IM] Peer registered: ${canonicalKey.slice(0, 12)}... on ${l2psUid}`)
     }
@@ -333,8 +329,12 @@ export class L2PSMessagingServer {
             return
         }
 
+        // Query by the canonical peer identity. Messages are persisted under
+        // canonical keys, so the raw peerKey (kept above for the client's proof)
+        // would match nothing. myKey is already canonical (set at register).
+        const canonicalPeer = canonicalizeKey(peerKey)
         const l2psUid = ws.data.l2psUid!
-        const result = await this.service.getHistory(myKey, peerKey, l2psUid, before, limit ?? 50)
+        const result = await this.service.getHistory(myKey, canonicalPeer, l2psUid, before, limit ?? 50)
 
         this.send(ws, {
             type: "history_response",
@@ -427,8 +427,9 @@ export class L2PSMessagingServer {
         ws: ServerWebSocket<WSData>,
         toKey: string,
         l2psUid: string,
+        rawKey?: string,
     ): Promise<void> {
-        const queued = await this.service.getQueuedMessages(toKey, l2psUid)
+        const queued = await this.service.getQueuedMessages(toKey, l2psUid, rawKey)
         if (queued.length === 0) return
 
         const deliveredIds: string[] = []

--- a/src/features/l2ps-messaging/L2PSMessagingServer.ts
+++ b/src/features/l2ps-messaging/L2PSMessagingServer.ts
@@ -210,10 +210,9 @@ export class L2PSMessagingServer {
             }
         }
 
-        // Deliver queued messages. Pass the raw registration key too so rows
-        // queued by an earlier build under a non-canonical recipient key are
-        // still recovered on reconnect.
-        await this.deliverQueuedMessages(ws, canonicalKey, l2psUid, publicKey)
+        // Deliver queued messages. Rows are stored canonically (persist boundary
+        // + migration), so the canonical identity finds every queued message.
+        await this.deliverQueuedMessages(ws, canonicalKey, l2psUid)
 
         log.info(`[L2PS-IM] Peer registered: ${canonicalKey.slice(0, 12)}... on ${l2psUid}`)
     }
@@ -329,12 +328,10 @@ export class L2PSMessagingServer {
             return
         }
 
-        // Query by the canonical peer identity. Messages are persisted under
-        // canonical keys, so the raw peerKey (kept above for the client's proof)
-        // would match nothing. myKey is already canonical (set at register).
-        const canonicalPeer = canonicalizeKey(peerKey)
+        // getHistory canonicalises both keys for the lookup; peerKey stays raw
+        // here because the proof above was signed over the client's own form.
         const l2psUid = ws.data.l2psUid!
-        const result = await this.service.getHistory(myKey, canonicalPeer, l2psUid, before, limit ?? 50)
+        const result = await this.service.getHistory(myKey, peerKey, l2psUid, before, limit ?? 50)
 
         this.send(ws, {
             type: "history_response",
@@ -427,9 +424,8 @@ export class L2PSMessagingServer {
         ws: ServerWebSocket<WSData>,
         toKey: string,
         l2psUid: string,
-        rawKey?: string,
     ): Promise<void> {
-        const queued = await this.service.getQueuedMessages(toKey, l2psUid, rawKey)
+        const queued = await this.service.getQueuedMessages(toKey, l2psUid)
         if (queued.length === 0) return
 
         const deliveredIds: string[] = []

--- a/src/features/l2ps-messaging/L2PSMessagingService.ts
+++ b/src/features/l2ps-messaging/L2PSMessagingService.ts
@@ -6,7 +6,6 @@
  * Also manages offline message storage and delivery.
  */
 
-import { In } from "typeorm"
 import { dataSource } from "@/model/datasource"
 import log from "@/utilities/logger"
 import Transaction from "@/libs/blockchain/transaction"
@@ -120,8 +119,11 @@ export class L2PSMessagingService {
     ): Promise<string | null> {
         const msg = new L2PSMessage()
         msg.id = opts.messageId
-        msg.fromKey = opts.fromKey
-        msg.toKey = opts.toKey
+        // Canonicalise at the persistence boundary: every row lands under one
+        // identity regardless of how the caller formatted the key, so canonical
+        // reads (getQueuedMessages / getHistory) always match.
+        msg.fromKey = canonicalizeKey(opts.fromKey)
+        msg.toKey = canonicalizeKey(opts.toKey)
         msg.l2psUid = opts.l2psUid
         msg.messageHash = opts.messageHash
         msg.encrypted = opts.encrypted
@@ -275,15 +277,12 @@ export class L2PSMessagingService {
     /**
      * Get queued messages for a peer (offline delivery).
      */
-    async getQueuedMessages(toKey: string, l2psUid: string, rawKey?: string): Promise<StoredMessage[]> {
+    async getQueuedMessages(toKey: string, l2psUid: string): Promise<StoredMessage[]> {
         const repo = dataSource.getRepository(L2PSMessage)
-        // New rows are keyed by the canonical identity. Rows queued by an earlier
-        // build under the client's raw key are recovered by also matching the raw
-        // registration form when it differs from the canonical one.
-        const canonical = canonicalizeKey(toKey)
-        const keys = rawKey && rawKey !== canonical ? [canonical, rawKey] : [canonical]
+        // Rows are stored canonically (persist boundary + one-shot migration),
+        // so a single canonical lookup covers every key variant.
         const messages = await repo.find({
-            where: { toKey: In(keys), l2psUid, status: "queued" },
+            where: { toKey: canonicalizeKey(toKey), l2psUid, status: "queued" },
             order: { timestamp: "ASC" },
         })
         return messages.map(m => ({
@@ -343,11 +342,15 @@ export class L2PSMessagingService {
         limit = 50,
     ): Promise<{ messages: StoredMessage[]; hasMore: boolean }> {
         const repo = dataSource.getRepository(L2PSMessage)
+        // Rows are stored canonically, so both sides of the pair must be
+        // canonicalised for the lookup to match.
+        const a = canonicalizeKey(peerA)
+        const b = canonicalizeKey(peerB)
         const qb = repo.createQueryBuilder("m")
             .where("m.l2ps_uid = :l2psUid", { l2psUid })
             .andWhere(
                 "((m.from_key = :a AND m.to_key = :b) OR (m.from_key = :b AND m.to_key = :a))",
-                { a: peerA, b: peerB },
+                { a, b },
             )
             .orderBy("m.timestamp", "DESC")
             .take(limit + 1)

--- a/src/features/l2ps-messaging/L2PSMessagingService.ts
+++ b/src/features/l2ps-messaging/L2PSMessagingService.ts
@@ -6,6 +6,7 @@
  * Also manages offline message storage and delivery.
  */
 
+import { In } from "typeorm"
 import { dataSource } from "@/model/datasource"
 import log from "@/utilities/logger"
 import Transaction from "@/libs/blockchain/transaction"
@@ -13,6 +14,7 @@ import ParallelNetworks from "@/libs/l2ps/parallelNetworks"
 import L2PSMempool from "@/libs/blockchain/l2ps_mempool"
 import L2PSTransactionExecutor from "@/libs/l2ps/L2PSTransactionExecutor"
 import { L2PSMessage } from "./entities/L2PSMessage"
+import { canonicalizeKey } from "./keys"
 import type { SerializedEncryptedMessage, StoredMessage } from "./types"
 
 const MAX_OFFLINE_MESSAGES_PER_SENDER = 200
@@ -273,10 +275,15 @@ export class L2PSMessagingService {
     /**
      * Get queued messages for a peer (offline delivery).
      */
-    async getQueuedMessages(toKey: string, l2psUid: string): Promise<StoredMessage[]> {
+    async getQueuedMessages(toKey: string, l2psUid: string, rawKey?: string): Promise<StoredMessage[]> {
         const repo = dataSource.getRepository(L2PSMessage)
+        // New rows are keyed by the canonical identity. Rows queued by an earlier
+        // build under the client's raw key are recovered by also matching the raw
+        // registration form when it differs from the canonical one.
+        const canonical = canonicalizeKey(toKey)
+        const keys = rawKey && rawKey !== canonical ? [canonical, rawKey] : [canonical]
         const messages = await repo.find({
-            where: { toKey, l2psUid, status: "queued" },
+            where: { toKey: In(keys), l2psUid, status: "queued" },
             order: { timestamp: "ASC" },
         })
         return messages.map(m => ({

--- a/src/features/l2ps-messaging/keys.ts
+++ b/src/features/l2ps-messaging/keys.ts
@@ -1,0 +1,16 @@
+/**
+ * Canonical peer identity for L2PS messaging.
+ *
+ * External SDKs send the same public key in several equivalent forms — with a
+ * `0x`/`0X` prefix or in mixed case. They all denote one peer, so every
+ * identity, routing key, and DB lookup normalises through here. Kept in its
+ * own module so the server (in-memory peer map) and the service (persistence
+ * boundary) can share it without importing each other.
+ *
+ * NOT for the signed proof: the client signs over its own representation of
+ * the key, so proof verification must use the raw form.
+ */
+export function canonicalizeKey(key: string): string {
+    const stripped = key.startsWith("0x") || key.startsWith("0X") ? key.slice(2) : key
+    return stripped.toLowerCase()
+}

--- a/src/features/l2ps-messaging/tests/L2PSMessagingServer.test.ts
+++ b/src/features/l2ps-messaging/tests/L2PSMessagingServer.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, mock, spyOn } from "bun:test"
-import { L2PSMessagingServer } from "../L2PSMessagingServer"
+import { L2PSMessagingServer, canonicalizeKey } from "../L2PSMessagingServer"
 import { L2PSMessagingService } from "../L2PSMessagingService"
 
 // ─── Test Helpers ────────────────────────────────────────────────
@@ -306,5 +306,30 @@ describe("Offline Message Rate Limiting", () => {
         counts.delete("sender1")
         expect(counts.has("sender1")).toBe(false)
         expect(counts.get("sender2")).toBe(100)
+    })
+})
+
+describe("Key canonicalisation (external client compatibility, DEM-778)", () => {
+    const KEY = "ab".repeat(32) // 64 lowercase hex chars
+
+    it("treats 0x-prefixed, 0X-prefixed and bare keys as one identity", () => {
+        const bare = canonicalizeKey(KEY)
+        expect(canonicalizeKey("0x" + KEY)).toBe(bare)
+        expect(canonicalizeKey("0X" + KEY)).toBe(bare)
+        expect(bare).toBe(KEY)
+    })
+
+    it("lowercases so casing never splits a peer", () => {
+        expect(canonicalizeKey("0xABCDEF")).toBe("abcdef")
+        expect(canonicalizeKey("ABCDEF")).toBe("abcdef")
+    })
+
+    it("only strips a leading prefix, not an interior 0x", () => {
+        expect(canonicalizeKey("a0xb")).toBe("a0xb")
+    })
+
+    it("is idempotent", () => {
+        const once = canonicalizeKey("0X" + KEY)
+        expect(canonicalizeKey(once)).toBe(once)
     })
 })

--- a/src/migrations/1782680000000-CanonicalizeL2PSMessageKeys.ts
+++ b/src/migrations/1782680000000-CanonicalizeL2PSMessageKeys.ts
@@ -1,0 +1,54 @@
+/* LICENSE
+
+© 2026 by KyneSys Labs, licensed under CC BY-NC-ND 4.0
+
+Full license text: https://creativecommons.org/licenses/by-nc-nd/4.0/legalcode
+Human readable license: https://creativecommons.org/licenses/by-nc-nd/4.0/
+
+KyneSys Labs: https://www.kynesys.xyz/
+
+*/
+
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+/**
+ * Canonicalise stored L2PS-message peer keys.
+ *
+ * External SDKs send the same ed25519 public key in several equivalent
+ * forms — with a `0x`/`0X` prefix or in mixed case. An earlier build
+ * persisted `from_key`/`to_key` verbatim, so a message queued for an
+ * offline peer could be stored under a non-canonical variant. Reads now
+ * look rows up by the single canonical identity (leading `0x`/`0X`
+ * stripped, lowercased), so any legacy row under a different variant
+ * would be stranded forever.
+ *
+ * This one-shot pass rewrites every non-canonical row to its canonical
+ * form, matching `canonicalizeKey()` exactly: `lower(regexp_replace(k,
+ * '^0[xX]', ''))` strips a single leading prefix (anchored, non-global)
+ * then lowercases. After it runs, canonical-only lookups are complete.
+ *
+ * Idempotent — re-running touches nothing (the WHERE guard excludes
+ * already-canonical rows).
+ */
+export class CanonicalizeL2PSMessageKeys1782680000000
+    implements MigrationInterface
+{
+    name = "CanonicalizeL2PSMessageKeys1782680000000"
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            UPDATE "l2ps_messages"
+            SET "to_key"   = lower(regexp_replace("to_key",   '^0[xX]', '')),
+                "from_key" = lower(regexp_replace("from_key", '^0[xX]', ''))
+            WHERE "to_key"   <> lower(regexp_replace("to_key",   '^0[xX]', ''))
+               OR "from_key" <> lower(regexp_replace("from_key", '^0[xX]', ''))
+        `)
+    }
+
+    public async down(): Promise<void> {
+        // Irreversible: canonicalisation discards the original prefix and
+        // casing, so the pre-migration representation cannot be restored.
+        // A no-op down keeps the migration runner consistent without
+        // pretending to recover lost information.
+    }
+}


### PR DESCRIPTION
Follow-up to #978, addressing the review there.

**CodeRabbit (Major) — duplicate identities.** In #978 the `0x` strip was validation-only; the *raw* key was still used as the peer identity (peers map, `ws.data.publicKey`, broadcasts). So `0x<key>` and `<key>` registered as **two separate peers** for one cryptographic key, and re-registration didn't close the other socket. Fixed by canonicalising the identity everywhere.

**Greptile (P2) — uppercase 0X.** `hexToUint8Array` already accepts `0x`/`0X`, but the register validation only stripped lowercase `0x`. The canonical form now strips both.

**Changes**
- New pure `export function canonicalizeKey(key)` — strip a leading `0x`/`0X`, lowercase.
- Used for **every identity/lookup**: register (peer record, `ws.data`, online-peer list, `registered`/`peer_joined` payloads, queued-message delivery), `send` recipient (`to`), and `request_public_key` (`targetId`).
- The **signed proof keeps the client's raw key** (they signed `register:{their-key}:{ts}`), so verification is unaffected.

**Tests:** 4 canonicalization cases added (0x/0X/bare → one identity; lowercasing; interior-0x untouched; idempotent). **76 pass.**

**Honest note:** `requestId` echo (from #978) is threaded through all direct responses; verifiable in the diff. Full request/response-level coverage needs driving the real server — the existing `integration.test.ts` re-implements a fake server, so a real-server harness is a separate improvement worth a ticket.

Base: `stabilisation`. Refs DEM-778.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved messaging reliability by treating public keys consistently, regardless of letter casing or a leading `0x`/`0X` prefix.
  - Peer registration, message delivery, recipient lookup, and conversation history now work consistently across key formats.
  - Improved error handling for failed history proof verification while preserving detailed diagnostic logging.

- **Data Migration**
  - Existing message records are updated to use the standardized key format.

- **Tests**
  - Added coverage for key normalization, including casing, prefixes, and repeated normalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->