### PR TITLE
fix(consensus): return own mempool on empty-incoming pull

### DIFF
--- a/src/libs/blockchain/mempool.ts
+++ b/src/libs/blockchain/mempool.ts
@@ -399,9 +399,18 @@ export default class Mempool {
 
     public static async receive(incoming: Transaction[], returnDiff = true) {
         if (incoming.length === 0) {
+            // An idle peer (empty mempool) still pulls ours via the "mempool"
+            // exchange (handleMempool → receive(theirTxs).mempool). Return our
+            // own pool — not [] — otherwise the puller never learns our txs,
+            // the proposer's candidate block diverges from the shard's tx-set
+            // (broadcastBlockHash missingFromThem>0), and a tx submitted to a
+            // single node is never included. Mirrors the unseenTransactions===0
+            // path below.
+            const blockNumber = SecretaryManager.lastBlockRef
+            const finalPool = await this.getMempool(blockNumber)
             return {
                 success: true,
-                mempool: [],
+                mempool: finalPool.filter(tx => tx.blockNumber <= blockNumber),
             }
         }
 


### PR DESCRIPTION
## What
Fixes a consensus-liveness bug: a tx submitted to a single node in a multi-validator network is never included.

## Root cause
`Mempool.receive([])` early-returned `{ mempool: [] }`. The peer "mempool" exchange is push-pull (`handleMempool` → `receive(theirTxs).mempool`): an idle validator (empty mempool) pulls a peer by sending `[]`, so the proposer replied `[]` instead of its own pool. Peers never learned the proposer's txs → the candidate block's tx-set diverged (`broadcastBlockHash missingFromThem>0`) → block rejected → tx never included.

## Fix
On empty incoming, return our own pool (mirrors the `unseenTransactions===0` path).

## Verified
Local 4-node devnet: before, peers logged "Received 0 transactions from <proposer>"; after, "Received N". Single-validator sidesteps the bug.

## Follow-up (separate scope, NOT in this PR)
Exposed a second layer: peers then reject propagated txs as "Transaction is not coherent" — the submit path hashes via the node `@/forks` serializer while the worker validates via the SDK `demosdk` denomination serializer; they diverge post-osDenomination. Serializer-parity fix is its own (likely cross-repo) scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)