### PR TITLE
fix(consensus): restrict collected signatures to shard members

### DIFF
--- a/src/libs/consensus/v2/routines/broadcastBlockHash.ts
+++ b/src/libs/consensus/v2/routines/broadcastBlockHash.ts
@@ -6,6 +6,7 @@ import log from "src/utilities/logger"
 import { hexToUint8Array } from "@kynesyslabs/demosdk/encryption"
 import TxValidatorPool from "@/libs/blockchain/validation/txValidatorPool"
 import Mempool from "@/libs/blockchain/mempool"
+import { filterSignaturesByShardMembership } from "./signerMembership"
 
 /**
  * Per-peer vote outcome. The `signaturesToMerge` map carries every
@@ -35,8 +36,11 @@ async function verifyIncomingSignatures(
     incoming: Record<string, string>,
     candidateBlockHash: string,
     peerId: string,
+    shard: Peer[],
 ): Promise<Record<string, string>> {
-    const entries = Object.entries(incoming)
+    const entries = Object.entries(
+        filterSignaturesByShardMembership(incoming, shard),
+    )
     const checks = await Promise.all(
         entries.map(async ([identity, signature]) => {
             try {
@@ -96,6 +100,7 @@ async function proposeAndCollect(
     peer: Peer,
     block: Block,
     proposeParams: [string, Block["validation_data"], string],
+    shard: Peer[],
 ): Promise<PeerVoteOutcome> {
     const peerId = peer.identity
     let response: RPCResponse
@@ -269,6 +274,7 @@ async function proposeAndCollect(
         incomingSignatures,
         block.hash,
         peerId,
+        shard,
     )
 
     // PR #888 Greptile P1 (continued): a peer's signature on our
@@ -369,7 +375,7 @@ export async function broadcastBlockHash(
     ]
 
     const outcomes = await Promise.all(
-        shard.map(peer => proposeAndCollect(peer, block, proposeParams)),
+        shard.map(peer => proposeAndCollect(peer, block, proposeParams, shard)),
     )
 
     let pro = 0

--- a/src/libs/consensus/v2/routines/manageProposeBlockHash.ts
+++ b/src/libs/consensus/v2/routines/manageProposeBlockHash.ts
@@ -13,6 +13,7 @@ import { isNetworkAhead } from "./networkAheadVeto"
 import TxValidatorPool from "@/libs/blockchain/validation/txValidatorPool"
 import Chain from "@/libs/blockchain/chain"
 import { checkTimestampAgainstParent } from "@/libs/blockchain/validation/verifyBlock"
+import { filterSignaturesByShardMembership } from "./signerMembership"
 
 export default async function manageProposeBlockHash(
     blockHash: string,
@@ -92,9 +93,11 @@ export default async function manageProposeBlockHash(
         response.response = getSharedState.publicKeyHex
 
         // INFO: Copy the incoming signatures to our candidate block
-        for (const [identity, signature] of Object.entries(
+        const shardSignatures = filterSignaturesByShardMembership(
             validationData["signatures"],
-        )) {
+            shard,
+        )
+        for (const [identity, signature] of Object.entries(shardSignatures)) {
             let isValid = false
 
             try {

--- a/src/libs/consensus/v2/routines/signerMembership.integration.test.ts
+++ b/src/libs/consensus/v2/routines/signerMembership.integration.test.ts
@@ -1,0 +1,141 @@
+import { beforeAll, describe, expect, it, mock } from "bun:test"
+
+const MEMBER = "aa".repeat(32)
+const OTHER_MEMBER = "bb".repeat(32)
+const OUTSIDER = "cc".repeat(32)
+const SIGNATURE = "11".repeat(64)
+
+const state = {
+    publicKeyHex: MEMBER,
+    signingAlgorithm: "ed25519",
+    candidateBlock: undefined as any,
+}
+
+mock.module("src/utilities/sharedState", () => ({
+    getSharedState: state,
+    __esModule: true,
+}))
+mock.module("src/utilities/logger", () => ({
+    default: {
+        debug: () => {},
+        info: () => {},
+        warning: () => {},
+        error: () => {},
+        custom: () => {},
+    },
+    __esModule: true,
+}))
+mock.module("src/libs/blockchain/validation/txValidatorPool", () => ({
+    default: {
+        getInstance: () => ({ verify: async () => true }),
+    },
+    __esModule: true,
+}))
+mock.module("@kynesyslabs/demosdk/encryption", () => ({
+    hexToUint8Array: (value: string) => new Uint8Array(value.length / 2),
+    __esModule: true,
+}))
+mock.module("src/libs/blockchain/mempool", () => ({
+    default: { getTransactionsByHashes: async () => [] },
+    __esModule: true,
+}))
+mock.module("src/libs/network/server_rpc", () => ({
+    emptyResponse: { result: 0, response: "", extra: {} },
+    __esModule: true,
+}))
+mock.module("src/libs/peer/PeerManager", () => ({
+    default: { getInstance: () => ({ getPeer: () => undefined }) },
+    __esModule: true,
+}))
+mock.module("src/libs/consensus/v2/routines/getCommonValidatorSeed", () => ({
+    default: async () => ({ commonValidatorSeed: "seed" }),
+    __esModule: true,
+}))
+mock.module("src/libs/consensus/v2/routines/getShard", () => ({
+    default: async () => [
+        { identity: MEMBER, connection: { string: MEMBER } },
+        { identity: OTHER_MEMBER, connection: { string: OTHER_MEMBER } },
+    ],
+    __esModule: true,
+}))
+mock.module("src/libs/consensus/v2/routines/ensureCandidateBlockFormed", () => ({
+    default: async () => true,
+    __esModule: true,
+}))
+mock.module("src/libs/consensus/v2/routines/networkAheadVeto", () => ({
+    isNetworkAhead: async () => false,
+    __esModule: true,
+}))
+mock.module("src/libs/blockchain/chain", () => ({
+    default: { getBlockByNumber: async () => null },
+    __esModule: true,
+}))
+mock.module("src/libs/blockchain/validation/verifyBlock", () => ({
+    checkTimestampAgainstParent: () => ({ valid: true }),
+    __esModule: true,
+}))
+
+const peer = (identity: string) => ({ identity, connection: { string: identity } })
+
+beforeAll(() => {
+    state.candidateBlock = {
+        hash: "candidate-hash",
+        number: 10,
+        content: { timestamp: 10, ordered_transactions: [] },
+        validation_data: { signatures: {} },
+    }
+})
+
+describe("consensus signature collection", () => {
+    it("broadcastBlockHash merges only signatures from current shard members", async () => {
+        const { broadcastBlockHash } = await import("./broadcastBlockHash")
+        const block = structuredClone(state.candidateBlock)
+        const peers = [
+            {
+                ...peer(MEMBER),
+                longCall: async () => ({
+                    result: 200,
+                    response: MEMBER,
+                    extra: {
+                        signatures: {
+                            [MEMBER]: SIGNATURE,
+                            [OUTSIDER]: SIGNATURE,
+                        },
+                    },
+                }),
+            },
+        ] as any
+
+        const [pro, con] = await broadcastBlockHash(block, peers)
+
+        expect([pro, con]).toEqual([1, 0])
+        expect(block.validation_data.signatures).toEqual({
+            [MEMBER]: SIGNATURE,
+        })
+        expect(block.validation_data.signatures[OUTSIDER]).toBeUndefined()
+    })
+
+    it("manageProposeBlockHash does not merge non-shard signatures", async () => {
+        const { default: manageProposeBlockHash } = await import(
+            "./manageProposeBlockHash"
+        )
+        const response = await manageProposeBlockHash(
+            "candidate-hash",
+            {
+                signatures: {
+                    [MEMBER]: SIGNATURE,
+                    [OUTSIDER]: SIGNATURE,
+                },
+            },
+            MEMBER,
+        )
+
+        expect(response.result).toBe(200)
+        expect(state.candidateBlock.validation_data.signatures).toEqual({
+            [MEMBER]: SIGNATURE,
+        })
+        expect(
+            state.candidateBlock.validation_data.signatures[OUTSIDER],
+        ).toBeUndefined()
+    })
+})

--- a/src/libs/consensus/v2/routines/signerMembership.test.ts
+++ b/src/libs/consensus/v2/routines/signerMembership.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "bun:test"
+import { filterSignaturesByShardMembership } from "./signerMembership"
+
+const member = (identity: string) => ({ identity })
+
+describe("filterSignaturesByShardMembership", () => {
+    it("drops valid-looking signatures from identities outside the shard", () => {
+        const signatures = {
+            "AA": "signature-a",
+            "BB": "signature-b",
+        }
+
+        expect(
+            filterSignaturesByShardMembership(signatures, [member("aa")]),
+        ).toEqual({ "AA": "signature-a" })
+    })
+
+    it("preserves signatures from current shard members", () => {
+        const signatures = { aa: "signature-a", bb: "signature-b" }
+
+        expect(
+            filterSignaturesByShardMembership(signatures, [
+                member("AA"),
+                member("bb"),
+            ]),
+        ).toEqual(signatures)
+    })
+
+    it("does not mutate the incoming signature map", () => {
+        const signatures = { aa: "signature-a", cc: "signature-c" }
+
+        filterSignaturesByShardMembership(signatures, [member("aa")])
+
+        expect(signatures).toEqual({ aa: "signature-a", cc: "signature-c" })
+    })
+})

--- a/src/libs/consensus/v2/routines/signerMembership.ts
+++ b/src/libs/consensus/v2/routines/signerMembership.ts
@@ -1,0 +1,21 @@
+import { Peer } from "src/libs/peer"
+
+/**
+ * Keep only signatures whose identity belongs to the current committee.
+ * The original key spelling is preserved for signature verification/storage;
+ * membership comparison is case-insensitive because public-key hex is
+ * represented inconsistently by some transports.
+ */
+export function filterSignaturesByShardMembership(
+    signatures: Record<string, string>,
+    shard: Pick<Peer, "identity">[],
+): Record<string, string> {
+    const memberIdentities = new Set(
+        shard.map(member => member.identity.toLowerCase()),
+    )
+    return Object.fromEntries(
+        Object.entries(signatures).filter(([identity]) =>
+            memberIdentities.has(identity.toLowerCase()),
+        ),
+    )
+}


### PR DESCRIPTION
## Summary

- Restrict relayed consensus signatures to identities in the current shard.
- Apply the membership gate in both outbound aggregation and inbound proposal handling.
- Preserve case-insensitive public-key identity matching while retaining the original key spelling.
- Add focused regression tests for non-member rejection, member acceptance, and input immutability.

## Security rationale

The Petri review identified a quorum-inflation risk: a cryptographically valid signature from an identity outside the current shard could be stored and later counted. This draft addresses that specific signer-membership gap. It does not claim to resolve vote freshness, block-height/round binding, shard derivation, block acceptance, or transport authentication; those require separate review work.

## Verification

- `bun test src/libs/consensus/v2/routines/signerMembership.test.ts` — 3 passed.
- Targeted related suite — new tests and existing pinning tests passed; an existing `getShard.test.ts` failed before reaching assertions because Bun does not provide the repository test's `jest.requireMock` API.
- `bunx eslint@8.57.1 ...` — passed.
- `bun run type-check-ts` — blocked by unrelated pre-existing repository errors (TLSNotary config, transaction types, GCR APIs, and other baseline diagnostics).
- No live nodes, credentials, generated databases, or upstream PR #692 were modified.

## Review status

This remains a draft pending independent consensus review, maintainer review, CI validation, and integration coverage through both changed code paths. No approval is claimed from the preliminary automated review attempts.

## Checklist

- [ ] Confirm current shard membership source is the authoritative signer set.
- [x] Add integration coverage through both `broadcastBlockHash` and `manageProposeBlockHash`.
- [ ] Independent consensus review.
- [ ] CI passes on GitHub.
- [ ] Maintainer approval.
