### PR TITLE
fix(ci): repair workflow trigger configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,6 @@
 name: CI
 
 on:
-on:
   pull_request:
     branches: [main, testnet, stabilisation]
   push:


### PR DESCRIPTION
## Summary
- Remove the duplicate workflow trigger key from `.github/workflows/ci.yml`.
- Restore GitHub Actions job creation for the repository CI workflow.

## Validation
- YAML parses locally.
- `git diff --check` passes.
- GitHub Actions jobs now execute instead of failing before job creation.
- Type Check: passed.
- SonarCloud and SonarCloud Code Analysis: passed.
- Lint: failed on the pre-existing repository baseline with 222 errors and 757 warnings across existing scripts/tests/load generators.

## Scope
This is intentionally limited to workflow syntax. It does not alter consensus code, lint rules, or PR #986. The existing lint baseline should be handled as separate, bounded cleanup work.
