### PR TITLE
fix(lint): correct CLI quote violations

### DIFF
--- a/scripts/derive-pubkey.ts
+++ b/scripts/derive-pubkey.ts
@@ -10,7 +10,7 @@ import { ucrypto, Hashing, uint8ArrayToHex } from "@kynesyslabs/demosdk/encrypti
 
 const mnemonicFile = process.argv[2]
 if (!mnemonicFile || !fs.existsSync(mnemonicFile)) {
-    console.error(`usage: bun derive-pubkey.ts <mnemonic-file>`)
+    console.error("usage: bun derive-pubkey.ts <mnemonic-file>")
     process.exit(1)
 }
 

--- a/scripts/gen-test-identity.ts
+++ b/scripts/gen-test-identity.ts
@@ -40,7 +40,7 @@ if (fs.existsSync(MNEMONIC_FILE) && !FORCE) {
     console.log(
         `[gen-test-identity] identity already exists at ${OUT_DIR}; pubkey=${existing}`,
     )
-    console.log(`[gen-test-identity] pass --force to regenerate`)
+    console.log("[gen-test-identity] pass --force to regenerate")
     process.exit(0)
 }
 


### PR DESCRIPTION
## Summary
- Fix the two existing quote-rule errors in standalone CLI scripts.
- Preserve intentional CLI console output and avoid changing lint rules.

## Validation
- Targeted ESLint: 0 errors; 6 existing intentional `no-console` warnings.
- `bun run type-check`: passed.
- `git diff --check`: passed.

## Scope
This is a bounded lint-baseline slice for #989. It does not touch consensus code or PR #986.
